### PR TITLE
Support non-interactive wt go with line-oriented JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ Example: branch `feature/auth` → `.worktrees/feature-auth--a1b2c3d4/`
 | Flag              | Behavior                                     |
 |-------------------|----------------------------------------------|
 | *(default)*       | Human-readable text                          |
-| `--json`          | Structured JSON envelope on stdout           |
+| `--json`          | Single-line JSON envelope on stdout          |
 | `--print-cd-path` | Bare absolute path on stdout (for wrappers)  |
 | `--print-paths`   | Multi-line key values on stdout (for wrappers) |
+
+`--json` emits one compact JSON object per line so machine consumers can parse stdout line-by-line.
 
 JSON envelope example (`add`, `go`, `remove`):
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -289,11 +289,11 @@ pub struct JsonSetupResponse {
     pub gitignore_updated: bool,
 }
 
-/// Serialize a value as pretty-printed JSON to stdout.
+/// Serialize a value as a compact single-line JSON object to stdout.
 pub fn print_json(value: &impl Serialize) -> crate::error::Result<()> {
     println!(
         "{}",
-        serde_json::to_string_pretty(value)
+        serde_json::to_string(value)
             .map_err(|e| crate::error::AppError::invariant(format!("json error: {e}")))?
     );
     Ok(())

--- a/tests/cli_go.rs
+++ b/tests/cli_go.rs
@@ -105,6 +105,43 @@ fn go_json_returns_structured_response() {
 }
 
 #[test]
+fn go_json_emits_single_line_for_machine_parsing() {
+    let repo = fixtures::TestRepo::new();
+
+    wt_core()
+        .args([
+            "add",
+            "go-json-line",
+            "--repo",
+            &repo.path().display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    let output = wt_core()
+        .args([
+            "go",
+            "go-json-line",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("invalid utf8");
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "expected single-line json output");
+
+    let json: serde_json::Value = serde_json::from_str(lines[0]).expect("invalid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["branch"], "go-json-line");
+}
+
+#[test]
 fn go_fails_for_nonexistent_branch() {
     let repo = fixtures::TestRepo::new();
 
@@ -147,6 +184,30 @@ fn go_no_branch_non_tty_errors() {
 #[test]
 fn go_no_branch_json_errors() {
     let repo = fixtures::TestRepo::new();
+
+    wt_core()
+        .args(["go", "--json", "--repo", &repo.path().display().to_string()])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "branch argument is required with --json",
+        ));
+}
+
+#[test]
+fn go_no_branch_json_requires_explicit_branch_even_with_one_worktree() {
+    let repo = fixtures::TestRepo::new();
+
+    wt_core()
+        .args([
+            "add",
+            "json-sole",
+            "--repo",
+            &repo.path().display().to_string(),
+        ])
+        .assert()
+        .success();
 
     wt_core()
         .args(["go", "--json", "--repo", &repo.path().display().to_string()])


### PR DESCRIPTION
## Summary
- emit compact single-line JSON for `--json` output so machine consumers can parse stdout line-by-line
- add regression coverage for `wt go --json` single-line output and explicit-branch enforcement
- document line-oriented JSON behavior in README

Closes #32.

## Testing
- cargo test --test cli_go
- cargo test