### PR TITLE
Add list commit and diff stats

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,14 @@ pub enum Command {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Include commit and diff stats for each worktree
+        #[arg(long)]
+        stats: bool,
+
+        /// Compare stats against this revision (defaults to resolved mainline)
+        #[arg(long, requires = "stats")]
+        against: Option<String>,
     },
 
     /// Create a new worktree and branch

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,7 +15,12 @@ use crate::worktree;
 
 pub fn run(cli: Cli) -> Result<()> {
     match cli.command {
-        Command::List { repo, json } => cmd_list(repo, status_fmt(json)),
+        Command::List {
+            repo,
+            json,
+            stats,
+            against,
+        } => cmd_list(repo, status_fmt(json), stats, against.as_deref()),
         Command::Add {
             branch,
             base,
@@ -136,12 +141,18 @@ fn resolve_repo(repo: Option<PathBuf>) -> Result<domain::RepoRoot> {
 
 // ── Commands ────────────────────────────────────────────────────────
 
-fn cmd_list(repo: Option<PathBuf>, fmt: StatusFormat) -> Result<()> {
+fn cmd_list(
+    repo: Option<PathBuf>,
+    fmt: StatusFormat,
+    stats: bool,
+    against: Option<&str>,
+) -> Result<()> {
     let repo = resolve_repo(repo)?;
     let worktrees = git::list_worktrees(&repo)?;
     let cwd = std::env::current_dir()
         .ok()
         .and_then(|p| p.canonicalize().ok());
+    let _stats_options = (stats, against);
 
     match fmt {
         StatusFormat::Json => {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,7 +2,7 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use crate::cli::{Cli, Command, Shell};
-use crate::domain::{self, BranchName};
+use crate::domain::{self, BranchName, WorktreeStatsStatus};
 use crate::error::{AppError, Result};
 use crate::git;
 use crate::output::{
@@ -152,43 +152,134 @@ fn cmd_list(
     let cwd = std::env::current_dir()
         .ok()
         .and_then(|p| p.canonicalize().ok());
-    let _stats_options = (stats, against);
+    let stats = if stats {
+        Some(list_stats(&repo, &worktrees, against)?)
+    } else {
+        None
+    };
 
     match fmt {
-        StatusFormat::Json => {
-            print_json(&JsonListResponse::from_worktrees(
+        StatusFormat::Json => match &stats {
+            Some(stats) => print_json(&JsonListResponse::from_worktrees_with_stats(
                 &worktrees,
                 cwd.as_deref(),
-            ))?;
-        }
+                stats,
+            ))?,
+            None => print_json(&JsonListResponse::from_worktrees(
+                &worktrees,
+                cwd.as_deref(),
+            ))?,
+        },
         StatusFormat::Human => {
             if worktrees.is_empty() {
                 println!("No worktrees found.");
                 return Ok(());
             }
-            let current_idx = cwd
-                .as_deref()
-                .and_then(|cwd| find_current_worktree(&worktrees, cwd));
-            for (i, wt) in worktrees.iter().enumerate() {
-                let branch_str = wt.branch.as_deref().unwrap_or("(detached)");
-                let main_tag = if wt.is_main { " [main]" } else { "" };
-                let here_tag = if current_idx == Some(i) {
-                    " ← here"
-                } else {
-                    ""
-                };
-                println!(
-                    "{:<50} {:<20} {}{}{}",
-                    wt.path.display(),
-                    branch_str,
-                    wt.commit,
-                    main_tag,
-                    here_tag
-                );
+            if let Some(stats) = &stats {
+                print_list_with_stats(&worktrees, stats);
+            } else {
+                print_list_default(&worktrees, cwd.as_deref());
             }
         }
     }
     Ok(())
+}
+
+fn list_stats(
+    repo: &domain::RepoRoot,
+    worktrees: &[domain::Worktree],
+    against: Option<&str>,
+) -> Result<Vec<WorktreeStatsStatus>> {
+    let base = match against {
+        Some(rev) => {
+            if !git::rev_exists(repo, rev) {
+                return Err(AppError::usage(format!(
+                    "base revision '{rev}' does not exist"
+                )));
+            }
+            rev.to_string()
+        }
+        None => git::resolve_mainline(repo)?,
+    };
+
+    Ok(worktrees
+        .iter()
+        .map(|wt| match &wt.branch {
+            Some(branch) => git::worktree_stats(repo, &base, branch).map_or_else(
+                |_| WorktreeStatsStatus::Unavailable {
+                    base: base.clone(),
+                    reason: "git_error".to_string(),
+                },
+                WorktreeStatsStatus::Available,
+            ),
+            None => WorktreeStatsStatus::Unavailable {
+                base: base.clone(),
+                reason: "no_branch".to_string(),
+            },
+        })
+        .collect())
+}
+
+fn print_list_default(worktrees: &[domain::Worktree], cwd: Option<&std::path::Path>) {
+    let current_idx = cwd.and_then(|cwd| find_current_worktree(worktrees, cwd));
+    for (i, wt) in worktrees.iter().enumerate() {
+        let branch_str = wt.branch.as_deref().unwrap_or("(detached)");
+        let main_tag = if wt.is_main { " [main]" } else { "" };
+        let here_tag = if current_idx == Some(i) {
+            " ← here"
+        } else {
+            ""
+        };
+        println!(
+            "{:<50} {:<20} {}{}{}",
+            wt.path.display(),
+            branch_str,
+            wt.commit,
+            main_tag,
+            here_tag
+        );
+    }
+}
+
+fn print_list_with_stats(worktrees: &[domain::Worktree], stats: &[WorktreeStatsStatus]) {
+    println!(
+        "{:<20} {:<12} {:<10} {:<7} {:<14} PATH",
+        "BRANCH", "BASE", "COMMITS", "FILES", "DIFF"
+    );
+    for (wt, stat) in worktrees.iter().zip(stats) {
+        let branch = wt.branch.as_deref().unwrap_or("(detached)");
+        let (base, commits, files, diff) = format_stats_columns(stat);
+        println!(
+            "{branch:<20} {base:<12} {commits:<10} {files:<7} {diff:<14} {}",
+            wt.path.display()
+        );
+    }
+}
+
+fn format_stats_columns(stat: &WorktreeStatsStatus) -> (String, String, String, String) {
+    match stat {
+        WorktreeStatsStatus::Available(stats) => (
+            stats.base.clone(),
+            format_commit_counts(stats.commits_ahead, stats.commits_behind),
+            stats.files_changed.to_string(),
+            format!("+{} -{}", stats.insertions, stats.deletions),
+        ),
+        WorktreeStatsStatus::Unavailable { base, .. } => (
+            base.clone(),
+            "unavailable".to_string(),
+            "—".to_string(),
+            "—".to_string(),
+        ),
+    }
+}
+
+fn format_commit_counts(ahead: u32, behind: u32) -> String {
+    match (ahead, behind) {
+        (0, 0) => "0".to_string(),
+        (a, 0) => format!("+{a}"),
+        (0, b) => format!("-{b}"),
+        (a, b) => format!("+{a} -{b}"),
+    }
 }
 
 fn cmd_add(

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -71,6 +71,24 @@ pub struct Worktree {
     pub is_main: bool,
 }
 
+/// Git comparison stats for a worktree branch against a base revision.
+#[derive(Debug, Clone)]
+pub struct WorktreeStats {
+    pub base: String,
+    pub commits_ahead: u32,
+    pub commits_behind: u32,
+    pub files_changed: u32,
+    pub insertions: u32,
+    pub deletions: u32,
+}
+
+/// Stats are unavailable for detached worktrees or refs Git cannot compare.
+#[derive(Debug, Clone)]
+pub enum WorktreeStatsStatus {
+    Available(WorktreeStats),
+    Unavailable { base: String, reason: String },
+}
+
 /// Slugify a branch name: replace non-alphanumeric chars with hyphens,
 /// collapse runs, and trim leading/trailing hyphens.
 fn slugify(input: &str) -> String {

--- a/src/git.rs
+++ b/src/git.rs
@@ -368,6 +368,8 @@ fn diff_numstat(repo: &RepoRoot, range: &str) -> Result<(u32, u32, u32)> {
         let removed = fields.next().unwrap_or_default();
         if fields.next().is_some() {
             files_changed += 1;
+            // Git reports binary files as `-` insertions/deletions in --numstat.
+            // Count the file as changed and expose stable zero line counts.
             insertions += added.parse::<u32>().unwrap_or(0);
             deletions += removed.parse::<u32>().unwrap_or(0);
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command as Cmd;
 
-use crate::domain::{BranchName, RepoRoot, Worktree};
+use crate::domain::{BranchName, RepoRoot, Worktree, WorktreeStats};
 use crate::error::{AppError, Result};
 
 /// Environment variables that can leak from parent git processes (e.g. hooks)
@@ -320,6 +320,60 @@ pub fn resolve_mainline(repo: &RepoRoot) -> Result<String> {
                 "could not determine mainline branch; use --mainline to specify".to_string(),
             )
         })
+}
+
+/// Compute commit and diff stats for `branch` against `base`.
+pub fn worktree_stats(repo: &RepoRoot, base: &str, branch: &str) -> Result<WorktreeStats> {
+    let branch_ref = format!("refs/heads/{branch}");
+    let range = format!("{base}...{branch_ref}");
+    let (commits_behind, commits_ahead) = rev_list_counts(repo, &range)?;
+    let (files_changed, insertions, deletions) = diff_numstat(repo, &range)?;
+
+    Ok(WorktreeStats {
+        base: base.to_string(),
+        commits_ahead,
+        commits_behind,
+        files_changed,
+        insertions,
+        deletions,
+    })
+}
+
+fn rev_list_counts(repo: &RepoRoot, range: &str) -> Result<(u32, u32)> {
+    let output = git(
+        &["rev-list", "--left-right", "--count", range],
+        repo.as_ref(),
+    )?;
+    let mut fields = output.split_whitespace();
+    let behind = fields
+        .next()
+        .and_then(|s| s.parse::<u32>().ok())
+        .ok_or_else(|| AppError::git("failed to parse rev-list behind count".to_string()))?;
+    let ahead = fields
+        .next()
+        .and_then(|s| s.parse::<u32>().ok())
+        .ok_or_else(|| AppError::git("failed to parse rev-list ahead count".to_string()))?;
+    Ok((behind, ahead))
+}
+
+fn diff_numstat(repo: &RepoRoot, range: &str) -> Result<(u32, u32, u32)> {
+    let output = git(&["diff", "--numstat", range], repo.as_ref())?;
+    let mut files_changed = 0;
+    let mut insertions = 0;
+    let mut deletions = 0;
+
+    for line in output.lines() {
+        let mut fields = line.splitn(3, '\t');
+        let added = fields.next().unwrap_or_default();
+        let removed = fields.next().unwrap_or_default();
+        if fields.next().is_some() {
+            files_changed += 1;
+            insertions += added.parse::<u32>().unwrap_or(0);
+            deletions += removed.parse::<u32>().unwrap_or(0);
+        }
+    }
+
+    Ok((files_changed, insertions, deletions))
 }
 
 /// Check if a local branch exists.

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use crate::domain::Worktree;
+use crate::domain::{Worktree, WorktreeStatsStatus};
 
 /// Output format for commands that produce a navigable path (add, go).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -129,6 +129,53 @@ pub struct JsonWorktreeEntry {
     pub commit: String,
     pub is_main: bool,
     pub is_current: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stats: Option<JsonWorktreeStats>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonWorktreeStats {
+    pub available: bool,
+    pub base: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits_ahead: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits_behind: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files_changed: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub insertions: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl JsonWorktreeStats {
+    fn from_status(status: &WorktreeStatsStatus) -> Self {
+        match status {
+            WorktreeStatsStatus::Available(stats) => Self {
+                available: true,
+                base: stats.base.clone(),
+                commits_ahead: Some(stats.commits_ahead),
+                commits_behind: Some(stats.commits_behind),
+                files_changed: Some(stats.files_changed),
+                insertions: Some(stats.insertions),
+                deletions: Some(stats.deletions),
+                reason: None,
+            },
+            WorktreeStatsStatus::Unavailable { base, reason } => Self {
+                available: false,
+                base: base.clone(),
+                commits_ahead: None,
+                commits_behind: None,
+                files_changed: None,
+                insertions: None,
+                deletions: None,
+                reason: Some(reason.clone()),
+            },
+        }
+    }
 }
 
 impl JsonListResponse {
@@ -146,6 +193,35 @@ impl JsonListResponse {
                 commit: wt.commit.clone(),
                 is_main: wt.is_main,
                 is_current: current_idx == Some(i),
+                stats: None,
+            })
+            .collect();
+
+        Self {
+            ok: true,
+            worktrees: entries,
+        }
+    }
+
+    /// Build a list response with per-worktree stats.
+    pub fn from_worktrees_with_stats(
+        worktrees: &[Worktree],
+        cwd: Option<&Path>,
+        stats: &[WorktreeStatsStatus],
+    ) -> Self {
+        let current_idx = cwd.and_then(|cwd| find_current_worktree(worktrees, cwd));
+
+        let entries = worktrees
+            .iter()
+            .zip(stats)
+            .enumerate()
+            .map(|(i, (wt, stat))| JsonWorktreeEntry {
+                path: wt.path.display().to_string(),
+                branch: wt.branch.clone(),
+                commit: wt.commit.clone(),
+                is_main: wt.is_main,
+                is_current: current_idx == Some(i),
+                stats: Some(JsonWorktreeStats::from_status(stat)),
             })
             .collect();
 

--- a/tests/cli_list_stats.rs
+++ b/tests/cli_list_stats.rs
@@ -1,0 +1,210 @@
+mod fixtures;
+
+use std::path::Path;
+
+use assert_cmd::Command;
+
+fn wt_core() -> Command {
+    Command::new(assert_cmd::cargo_bin!("wt-core"))
+}
+
+fn add_worktree(repo_path: &Path, branch: &str) -> String {
+    let output = wt_core()
+        .args([
+            "add",
+            branch,
+            "--repo",
+            &repo_path.display().to_string(),
+            "--print-cd-path",
+        ])
+        .output()
+        .expect("failed to run wt-core add");
+    assert!(output.status.success());
+    String::from_utf8(output.stdout)
+        .expect("invalid utf8")
+        .trim()
+        .to_string()
+}
+
+fn list_json(repo_path: &Path, extra_args: &[&str]) -> serde_json::Value {
+    let repo_arg = repo_path.display().to_string();
+    let mut args = vec!["list", "--repo", &repo_arg, "--json"];
+    args.extend_from_slice(extra_args);
+    let output = wt_core()
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).expect("invalid json")
+}
+
+fn worktree_entry<'a>(json: &'a serde_json::Value, branch: &str) -> &'a serde_json::Value {
+    json["worktrees"]
+        .as_array()
+        .expect("worktrees array")
+        .iter()
+        .find(|entry| entry["branch"] == branch)
+        .expect("worktree entry")
+}
+
+fn stats_for<'a>(json: &'a serde_json::Value, branch: &str) -> &'a serde_json::Value {
+    &worktree_entry(json, branch)["stats"]
+}
+
+#[test]
+fn list_stats_reports_ahead_only_and_diff_totals() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    let wt_path = add_worktree(&repo_path, "feat-ahead");
+    fixtures::commit_file(
+        Path::new(&wt_path),
+        "feature.txt",
+        "one\ntwo\n",
+        "feature commit",
+    );
+
+    let json = list_json(&repo_path, &["--stats"]);
+    let stats = stats_for(&json, "feat-ahead");
+
+    assert_eq!(stats["available"], true);
+    assert_eq!(stats["base"], "main");
+    assert_eq!(stats["commits_ahead"], 1);
+    assert_eq!(stats["commits_behind"], 0);
+    assert_eq!(stats["files_changed"], 1);
+    assert_eq!(stats["insertions"], 2);
+    assert_eq!(stats["deletions"], 0);
+}
+
+#[test]
+fn list_stats_reports_behind_only() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    add_worktree(&repo_path, "feat-behind");
+    fixtures::commit_file(&repo_path, "main.txt", "main\n", "main commit");
+
+    let json = list_json(&repo_path, &["--stats"]);
+    let stats = stats_for(&json, "feat-behind");
+
+    assert_eq!(stats["commits_ahead"], 0);
+    assert_eq!(stats["commits_behind"], 1);
+}
+
+#[test]
+fn list_stats_reports_ahead_and_behind() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    let wt_path = add_worktree(&repo_path, "feat-diverged");
+    fixtures::commit_file(
+        Path::new(&wt_path),
+        "feature.txt",
+        "feature\n",
+        "feature commit",
+    );
+    fixtures::commit_file(&repo_path, "main.txt", "main\n", "main commit");
+
+    let json = list_json(&repo_path, &["--stats"]);
+    let stats = stats_for(&json, "feat-diverged");
+
+    assert_eq!(stats["commits_ahead"], 1);
+    assert_eq!(stats["commits_behind"], 1);
+}
+
+#[test]
+fn list_stats_reports_no_difference() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    add_worktree(&repo_path, "feat-even");
+
+    let json = list_json(&repo_path, &["--stats"]);
+    let stats = stats_for(&json, "feat-even");
+
+    assert_eq!(stats["commits_ahead"], 0);
+    assert_eq!(stats["commits_behind"], 0);
+    assert_eq!(stats["files_changed"], 0);
+}
+
+#[test]
+fn list_stats_uses_against_override() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    fixtures::run_git(&["branch", "base-point"], &repo_path);
+    let wt_path = add_worktree(&repo_path, "feat-base-override");
+    fixtures::commit_file(
+        Path::new(&wt_path),
+        "feature.txt",
+        "feature\n",
+        "feature commit",
+    );
+    fixtures::commit_file(&repo_path, "main.txt", "main\n", "main commit");
+
+    let json = list_json(&repo_path, &["--stats", "--against", "base-point"]);
+    let stats = stats_for(&json, "feat-base-override");
+
+    assert_eq!(stats["base"], "base-point");
+    assert_eq!(stats["commits_ahead"], 1);
+    assert_eq!(stats["commits_behind"], 0);
+}
+
+#[test]
+fn list_json_omits_stats_without_flag() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    add_worktree(&repo_path, "feat-default");
+
+    let json = list_json(&repo_path, &[]);
+    let entry = worktree_entry(&json, "feat-default");
+
+    assert!(entry.get("stats").is_none());
+}
+
+#[test]
+fn list_stats_human_output_contains_stats_columns() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    let wt_path = add_worktree(&repo_path, "feat-human");
+    fixtures::commit_file(
+        Path::new(&wt_path),
+        "feature.txt",
+        "feature\n",
+        "feature commit",
+    );
+
+    wt_core()
+        .args([
+            "list",
+            "--repo",
+            &repo_path.display().to_string(),
+            "--stats",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("COMMITS"))
+        .stdout(predicates::str::contains("+1"))
+        .stdout(predicates::str::contains("+1 -0"));
+}
+
+#[test]
+fn list_stats_handles_detached_worktree_as_unavailable() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    let detached_path = repo_path.join(".worktrees").join("detached");
+    let detached_arg = detached_path.display().to_string();
+    fixtures::run_git(
+        &["worktree", "add", "--detach", &detached_arg, "HEAD"],
+        &repo_path,
+    );
+
+    let json = list_json(&repo_path, &["--stats"]);
+    let detached = json["worktrees"]
+        .as_array()
+        .expect("worktrees array")
+        .iter()
+        .find(|entry| entry["branch"].is_null())
+        .expect("detached worktree");
+    let stats = &detached["stats"];
+
+    assert_eq!(stats["available"], false);
+    assert_eq!(stats["reason"], "no_branch");
+}

--- a/tests/cli_list_stats.rs
+++ b/tests/cli_list_stats.rs
@@ -186,6 +186,45 @@ fn list_stats_human_output_contains_stats_columns() {
 }
 
 #[test]
+fn list_stats_counts_binary_numstat_rows_as_changed_files() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    let wt_path = add_worktree(&repo_path, "feat-binary");
+    std::fs::write(Path::new(&wt_path).join("image.bin"), [0, 159, 146, 150])
+        .expect("write binary file");
+    fixtures::run_git(&["add", "."], Path::new(&wt_path));
+    fixtures::run_git(&["commit", "-m", "binary commit"], Path::new(&wt_path));
+
+    let json = list_json(&repo_path, &["--stats"]);
+    let stats = stats_for(&json, "feat-binary");
+
+    assert_eq!(stats["files_changed"], 1);
+    assert_eq!(stats["insertions"], 0);
+    assert_eq!(stats["deletions"], 0);
+}
+
+#[test]
+fn list_stats_rejects_invalid_against_revision() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+
+    wt_core()
+        .args([
+            "list",
+            "--repo",
+            &repo_path.display().to_string(),
+            "--stats",
+            "--against",
+            "definitely-not-a-revision",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "base revision 'definitely-not-a-revision' does not exist",
+        ));
+}
+
+#[test]
 fn list_stats_handles_detached_worktree_as_unavailable() {
     let repo = fixtures::TestRepo::new();
     let repo_path = repo.path();


### PR DESCRIPTION
Closes #46 
Summary:
- Adds opt-in `wt list --stats` and `--against <rev>` support.
- Computes ahead/behind counts with symmetric rev-list ranges and diff totals with numstat.
- Adds JSON stats output and graceful unavailable stats for detached/uncomparable worktrees.

### Validation:
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test