### PR TITLE
Add diff command for selected worktree branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ wt go [<branch>] [-i]                  Switch to an existing worktree
 wt list                                List all worktrees
 wt remove [<branch>] [--force]         Remove a worktree and its local branch
 wt merge [<branch>] [--push]           Merge a branch into mainline and clean up
+wt diff [<branch>] [--dry-run]         Open difftool for a branch vs mainline
 wt prune [--execute] [--force]         Remove worktrees integrated into mainline
 wt doctor                              Diagnose worktree/repo health
 ```
@@ -112,6 +113,19 @@ wt merge                    # merge current worktree's branch
 wt merge feature/auth       # explicit branch
 wt merge --push             # push mainline to origin after merge
 wt merge --no-cleanup       # keep worktree and branch after merge
+```
+
+### `wt diff`
+
+Opens Git's configured difftool in directory-diff mode for a worktree branch
+against the auto-detected mainline. When called without a branch in a TTY, a
+fuzzy picker containing non-main worktrees is shown.
+
+```
+wt diff feature/auth                 # git difftool --dir-diff main...feature/auth
+wt diff --against develop feature/auth
+wt diff --tool vimdiff feature/auth
+wt diff --dry-run feature/auth       # print the resolved git command
 ```
 
 ### `wt prune`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,6 +130,28 @@ pub enum Command {
         print_paths: bool,
     },
 
+    /// Open a difftool for a worktree branch against mainline
+    Diff {
+        /// Branch name of the worktree to diff
+        branch: Option<String>,
+
+        /// Compare against this revision (defaults to resolved mainline)
+        #[arg(long)]
+        against: Option<String>,
+
+        /// Git difftool name to use
+        #[arg(long)]
+        tool: Option<String>,
+
+        /// Print the resolved command without launching difftool
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Repository path (defaults to current directory)
+        #[arg(long)]
+        repo: Option<PathBuf>,
+    },
+
     /// Remove worktrees whose branches are fully integrated into mainline
     Prune {
         /// Actually remove integrated worktrees (default is dry-run)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -72,6 +72,19 @@ pub fn run(cli: Cli) -> Result<()> {
             repo,
             merge_fmt(json, print_paths),
         ),
+        Command::Diff {
+            branch,
+            against,
+            tool,
+            dry_run,
+            repo,
+        } => cmd_diff(
+            branch.as_deref().map(BranchName::new),
+            against.as_deref(),
+            tool.as_deref(),
+            dry_run,
+            repo,
+        ),
         Command::Prune {
             execute,
             force,
@@ -711,6 +724,61 @@ fn capitalize(s: &str) -> String {
         Some(c) => c.to_uppercase().to_string() + chars.as_str(),
         None => String::new(),
     }
+}
+
+fn cmd_diff(
+    branch: Option<BranchName>,
+    against: Option<&str>,
+    tool: Option<&str>,
+    dry_run: bool,
+    repo: Option<PathBuf>,
+) -> Result<()> {
+    let repo = resolve_repo(repo)?;
+    let resolved_branch = match branch {
+        Some(branch) => branch,
+        None => resolve_diff_branch(&repo)?,
+    };
+
+    let result = worktree::diff(&repo, &resolved_branch, against, tool, dry_run)?;
+
+    if dry_run {
+        println!("{}", result.command.join(" "));
+    } else {
+        println!(
+            "Opened diff for '{}' against {}",
+            result.branch, result.base
+        );
+    }
+
+    Ok(())
+}
+
+fn resolve_diff_branch(repo: &domain::RepoRoot) -> Result<BranchName> {
+    let worktrees = git::list_worktrees(repo)?;
+    let candidates: Vec<_> = worktrees.iter().filter(|wt| !wt.is_main).collect();
+
+    if candidates.is_empty() {
+        return Err(AppError::usage(
+            "no worktrees to diff (create one with `wt add`)".to_string(),
+        ));
+    }
+
+    if !std::io::stdin().is_terminal() {
+        return Err(AppError::usage(
+            "no branch specified; interactive mode requires a terminal".to_string(),
+        ));
+    }
+
+    let preselect = std::env::current_dir().ok().and_then(|cwd| {
+        candidates
+            .iter()
+            .enumerate()
+            .filter(|(_, wt)| cwd.starts_with(&wt.path))
+            .max_by_key(|(_, wt)| wt.path.as_os_str().len())
+            .map(|(idx, _)| idx)
+    });
+
+    pick_action_worktree(&candidates, preselect, "diff")
 }
 
 fn cmd_merge(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -733,6 +733,10 @@ fn cmd_diff(
     dry_run: bool,
     repo: Option<PathBuf>,
 ) -> Result<()> {
+    if matches!(tool, Some(name) if name.trim().is_empty()) {
+        return Err(AppError::usage("--tool must not be empty".to_string()));
+    }
+
     let repo = resolve_repo(repo)?;
     let resolved_branch = match branch {
         Some(branch) => branch,

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command as Cmd;
+use std::process::Stdio;
 
 use crate::domain::{BranchName, RepoRoot, Worktree, WorktreeStats};
 use crate::error::{AppError, Result};
@@ -431,6 +432,39 @@ pub fn merge_no_ff(repo: &RepoRoot, branch: &str) -> Result<()> {
 /// we silently ignore.
 pub fn merge_abort(repo: &RepoRoot) {
     let _ = git(&["merge", "--abort"], repo.as_ref());
+}
+
+/// Run Git's configured difftool for a branch comparison.
+pub fn difftool(repo: &RepoRoot, tool: Option<&str>, range: &str) -> Result<()> {
+    let mut cmd = Cmd::new("git");
+    cmd.arg("-C")
+        .arg(repo.as_ref())
+        .arg("difftool")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    if let Some(tool) = tool {
+        cmd.arg("--tool").arg(tool);
+    }
+
+    cmd.arg("--dir-diff").arg(range);
+
+    for var in GIT_ENV_OVERRIDES {
+        cmd.env_remove(var);
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| AppError::git(format!("failed to run git difftool: {e}")))?;
+
+    if !status.success() {
+        return Err(AppError::git(format!(
+            "git difftool failed with status {status}"
+        )));
+    }
+
+    Ok(())
 }
 
 /// Push a branch to `origin`.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -54,6 +54,13 @@ pub struct GoResult {
     pub repo_root: PathBuf,
 }
 
+/// Result of a resolved `diff` operation.
+pub struct DiffResult {
+    pub branch: BranchName,
+    pub base: String,
+    pub command: Vec<String>,
+}
+
 /// Result of a successful `remove` operation.
 pub struct RemoveResult {
     pub removed_path: PathBuf,
@@ -76,6 +83,69 @@ pub enum DiagLevel {
     Ok,
     Warn,
     Error,
+}
+
+/// Resolve and optionally run a branch-vs-mainline difftool command.
+pub fn diff(
+    repo: &RepoRoot,
+    branch: &BranchName,
+    against: Option<&str>,
+    tool: Option<&str>,
+    dry_run: bool,
+) -> Result<DiffResult> {
+    let worktrees = git::list_worktrees(repo)?;
+    let has_worktree = worktrees
+        .iter()
+        .any(|wt| !wt.is_main && wt.branch.as_deref() == Some(branch.as_str()));
+
+    if !has_worktree {
+        return Err(AppError::usage(format!(
+            "branch '{}' has no associated worktree",
+            branch.as_str()
+        )));
+    }
+
+    let base = match against {
+        Some(rev) => {
+            if !git::rev_exists(repo, rev) {
+                return Err(AppError::usage(format!(
+                    "base revision '{rev}' does not exist"
+                )));
+            }
+            rev.to_string()
+        }
+        None => git::resolve_mainline(repo)?,
+    };
+    let range = format!("{}...{}", base, branch.as_str());
+    let command = difftool_command(repo, tool, &range);
+
+    if !dry_run {
+        git::difftool(repo, tool, &range)?;
+    }
+
+    Ok(DiffResult {
+        branch: branch.clone(),
+        base,
+        command,
+    })
+}
+
+fn difftool_command(repo: &RepoRoot, tool: Option<&str>, range: &str) -> Vec<String> {
+    let mut command = vec![
+        "git".to_string(),
+        "-C".to_string(),
+        repo.display().to_string(),
+        "difftool".to_string(),
+    ];
+
+    if let Some(tool) = tool {
+        command.push("--tool".to_string());
+        command.push(tool.to_string());
+    }
+
+    command.push("--dir-diff".to_string());
+    command.push(range.to_string());
+    command
 }
 
 /// Create a new worktree for the given branch.

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -1,0 +1,95 @@
+mod fixtures;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+use fixtures::commit_file;
+
+fn wt_core() -> Command {
+    Command::new(assert_cmd::cargo_bin!("wt-core"))
+}
+
+#[test]
+fn diff_dry_run_explicit_branch_uses_mainline_three_dot_range() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/diff", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    wt_core()
+        .args(["diff", "feature/diff", "--repo", &repo_str, "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "git -C {} difftool",
+            repo_str
+        )))
+        .stdout(predicate::str::contains("--dir-diff"))
+        .stdout(predicate::str::contains("main...feature/diff"));
+}
+
+#[test]
+fn diff_dry_run_respects_base_override_and_tool() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/tool", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    wt_core()
+        .args([
+            "diff",
+            "feature/tool",
+            "--repo",
+            &repo_str,
+            "--against",
+            "HEAD",
+            "--tool",
+            "vimdiff",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--tool vimdiff"))
+        .stdout(predicate::str::contains("HEAD...feature/tool"));
+}
+
+#[test]
+fn diff_errors_when_requested_branch_has_no_worktree() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    commit_file(&repo.path(), "local.txt", "local", "local branch base");
+    fixtures::run_git(&["branch", "feature/no-worktree"], &repo.path());
+
+    wt_core()
+        .args([
+            "diff",
+            "feature/no-worktree",
+            "--repo",
+            &repo_str,
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "branch 'feature/no-worktree' has no associated worktree",
+        ));
+}
+
+#[test]
+fn diff_without_branch_errors_when_no_non_main_worktrees() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["diff", "--repo", &repo_str, "--dry-run"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no worktrees to diff"));
+}

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -93,3 +93,28 @@ fn diff_without_branch_errors_when_no_non_main_worktrees() {
         .failure()
         .stderr(predicate::str::contains("no worktrees to diff"));
 }
+
+#[test]
+fn diff_rejects_empty_tool_name() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/empty-tool", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    wt_core()
+        .args([
+            "diff",
+            "feature/empty-tool",
+            "--repo",
+            &repo_str,
+            "--tool",
+            "   ",
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--tool must not be empty"));
+}


### PR DESCRIPTION
Closes #44\n\nSummary:\n- Adds `wt diff [branch]` with branch-vs-mainline difftool execution.\n- Supports `--against`, `--tool`, and `--dry-run` command printing.\n- Reuses non-main worktree selection patterns and adds targeted integration coverage.\n\nValidation:\n- cargo fmt\n- cargo clippy -- -D warnings\n- cargo test\n- ast-grep scan