### PR TITLE
Complete diff dirty worktree modes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,7 +130,7 @@ pub enum Command {
         print_paths: bool,
     },
 
-    /// Open a difftool for a worktree branch against mainline
+    /// Open a difftool for a worktree branch or dirty worktree changes
     Diff {
         /// Branch name of the worktree to diff
         branch: Option<String>,
@@ -139,6 +139,18 @@ pub enum Command {
         #[arg(long)]
         against: Option<String>,
 
+        /// Inspect all uncommitted changes in the selected worktree
+        #[arg(long)]
+        dirty: bool,
+
+        /// Inspect staged changes only in the selected worktree
+        #[arg(long)]
+        staged: bool,
+
+        /// Inspect unstaged changes only in the selected worktree
+        #[arg(long)]
+        unstaged: bool,
+
         /// Git difftool name to use
         #[arg(long)]
         tool: Option<String>,
@@ -146,6 +158,10 @@ pub enum Command {
         /// Print the resolved command without launching difftool
         #[arg(long)]
         dry_run: bool,
+
+        /// Print the resolved command without launching difftool
+        #[arg(long)]
+        print_command: bool,
 
         /// Repository path (defaults to current directory)
         #[arg(long)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -677,6 +677,19 @@ fn pick_action_worktree(
     preselect: Option<usize>,
     action: &str,
 ) -> Result<BranchName> {
+    let worktree = pick_action_worktree_entry(candidates, preselect, action)?;
+    let branch = worktree.branch.as_deref().ok_or_else(|| {
+        AppError::usage("selected worktree has no branch (detached HEAD)".to_string())
+    })?;
+    Ok(BranchName::new(branch))
+}
+
+#[cfg(feature = "interactive")]
+fn pick_action_worktree_entry(
+    candidates: &[&domain::Worktree],
+    preselect: Option<usize>,
+    action: &str,
+) -> Result<domain::Worktree> {
     use dialoguer::theme::ColorfulTheme;
     use dialoguer::FuzzySelect;
 
@@ -698,12 +711,7 @@ fn pick_action_worktree(
         .map_err(|e| AppError::usage(format!("picker failed: {e}")))?;
 
     match selection {
-        Some(idx) => {
-            let branch = candidates[idx].branch.as_deref().ok_or_else(|| {
-                AppError::usage("selected worktree has no branch (detached HEAD)".to_string())
-            })?;
-            Ok(BranchName::new(branch))
-        }
+        Some(idx) => Ok(candidates[idx].clone()),
         // Esc / Ctrl-C: dialoguer has already restored the terminal state
         // before returning None, so destructors are not a concern here.
         // Exit 130 (128 + SIGINT) is the Unix convention for user cancellation.
@@ -713,10 +721,23 @@ fn pick_action_worktree(
 
 #[cfg(not(feature = "interactive"))]
 fn pick_action_worktree(
+    candidates: &[&domain::Worktree],
+    preselect: Option<usize>,
+    action: &str,
+) -> Result<BranchName> {
+    let worktree = pick_action_worktree_entry(candidates, preselect, action)?;
+    let branch = worktree.branch.as_deref().ok_or_else(|| {
+        AppError::usage("selected worktree has no branch (detached HEAD)".to_string())
+    })?;
+    Ok(BranchName::new(branch))
+}
+
+#[cfg(not(feature = "interactive"))]
+fn pick_action_worktree_entry(
     _candidates: &[&domain::Worktree],
     _preselect: Option<usize>,
     _action: &str,
-) -> Result<BranchName> {
+) -> Result<domain::Worktree> {
     Err(AppError::usage(
         "interactive mode not available (compiled without 'interactive' feature)".to_string(),
     ))
@@ -780,23 +801,94 @@ fn cmd_diff(
     }
 
     let repo = resolve_repo(repo)?;
-    let resolved_branch = match branch {
-        Some(branch) => branch,
-        None => resolve_diff_branch(&repo)?,
-    };
 
-    let result = worktree::diff(&repo, &resolved_branch, against, tool, dry_run)?;
+    if mode == DiffMode::Branch {
+        let resolved_branch = match branch {
+            Some(branch) => branch,
+            None => resolve_diff_branch(&repo)?,
+        };
 
-    if dry_run {
-        println!("{}", result.command.join(" "));
-    } else {
-        println!(
-            "Opened diff for '{}' against {}",
-            result.branch, result.base
-        );
+        let result = worktree::diff(&repo, &resolved_branch, against, tool, dry_run)?;
+        print_branch_diff_result(&result, dry_run);
+        return Ok(());
     }
 
+    let selected_worktree = resolve_diff_worktree(&repo, branch)?;
+    let dirty_mode = match mode {
+        DiffMode::Dirty => worktree::DirtyDiffMode::Dirty,
+        DiffMode::Staged => worktree::DirtyDiffMode::Staged,
+        DiffMode::Unstaged => worktree::DirtyDiffMode::Unstaged,
+        DiffMode::Branch => unreachable!("branch diff handled above"),
+    };
+    let result = worktree::diff_dirty(&selected_worktree, dirty_mode, tool, dry_run)?;
+    print_dirty_diff_result(&result, dry_run);
+
     Ok(())
+}
+
+fn print_branch_diff_result(result: &worktree::DiffResult, dry_run: bool) {
+    if dry_run {
+        println!("{}", result.command.join(" "));
+        return;
+    }
+
+    println!(
+        "Opened diff for '{}' against {}",
+        result.branch, result.base
+    );
+}
+
+fn print_dirty_diff_result(result: &worktree::DirtyDiffResult, dry_run: bool) {
+    if dry_run {
+        println!("{}", result.command.join(" "));
+        return;
+    }
+
+    println!("Opened dirty diff for '{}'", result.label);
+}
+
+fn resolve_diff_worktree(
+    repo: &domain::RepoRoot,
+    branch: Option<BranchName>,
+) -> Result<domain::Worktree> {
+    let worktrees = git::list_worktrees(repo)?;
+
+    if let Some(branch) = branch {
+        return worktrees
+            .into_iter()
+            .find(|wt| !wt.is_main && wt.branch.as_deref() == Some(branch.as_str()))
+            .ok_or_else(|| {
+                AppError::usage(format!(
+                    "branch '{}' has no associated worktree",
+                    branch.as_str()
+                ))
+            });
+    }
+
+    let candidates: Vec<_> = worktrees.iter().filter(|wt| !wt.is_main).collect();
+
+    if candidates.is_empty() {
+        return Err(AppError::usage(
+            "no worktrees to diff (create one with `wt add`)".to_string(),
+        ));
+    }
+
+    if !std::io::stdin().is_terminal() {
+        return Err(AppError::usage(
+            "no branch specified; interactive mode requires a terminal".to_string(),
+        ));
+    }
+
+    let preselect = std::env::current_dir().ok().and_then(|cwd| {
+        candidates
+            .iter()
+            .enumerate()
+            .filter(|(_, wt)| cwd.starts_with(&wt.path))
+            .max_by_key(|(_, wt)| wt.path.as_os_str().len())
+            .map(|(idx, _)| idx)
+    });
+
+    pick_action_worktree_entry(&candidates, preselect, "diff")
 }
 
 fn resolve_diff_branch(repo: &domain::RepoRoot) -> Result<BranchName> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -75,14 +75,19 @@ pub fn run(cli: Cli) -> Result<()> {
         Command::Diff {
             branch,
             against,
+            dirty,
+            staged,
+            unstaged,
             tool,
             dry_run,
+            print_command,
             repo,
         } => cmd_diff(
             branch.as_deref().map(BranchName::new),
             against.as_deref(),
+            DiffMode::from_flags(dirty, staged, unstaged)?,
             tool.as_deref(),
-            dry_run,
+            dry_run || print_command,
             repo,
         ),
         Command::Prune {
@@ -726,15 +731,52 @@ fn capitalize(s: &str) -> String {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiffMode {
+    Branch,
+    Dirty,
+    Staged,
+    Unstaged,
+}
+
+impl DiffMode {
+    fn from_flags(dirty: bool, staged: bool, unstaged: bool) -> Result<Self> {
+        let selected = [dirty, staged, unstaged]
+            .into_iter()
+            .filter(|flag| *flag)
+            .count();
+
+        if selected > 1 {
+            return Err(AppError::usage(
+                "--dirty, --staged, and --unstaged are mutually exclusive".to_string(),
+            ));
+        }
+
+        Ok(match (dirty, staged, unstaged) {
+            (true, false, false) => Self::Dirty,
+            (false, true, false) => Self::Staged,
+            (false, false, true) => Self::Unstaged,
+            _ => Self::Branch,
+        })
+    }
+}
+
 fn cmd_diff(
     branch: Option<BranchName>,
     against: Option<&str>,
+    mode: DiffMode,
     tool: Option<&str>,
     dry_run: bool,
     repo: Option<PathBuf>,
 ) -> Result<()> {
     if matches!(tool, Some(name) if name.trim().is_empty()) {
         return Err(AppError::usage("--tool must not be empty".to_string()));
+    }
+
+    if mode != DiffMode::Branch && against.is_some() {
+        return Err(AppError::usage(
+            "--against can only be used with branch-vs-mainline diffs".to_string(),
+        ));
     }
 
     let repo = resolve_repo(repo)?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -436,9 +436,36 @@ pub fn merge_abort(repo: &RepoRoot) {
 
 /// Run Git's configured difftool for a branch comparison.
 pub fn difftool(repo: &RepoRoot, tool: Option<&str>, range: &str) -> Result<()> {
+    let mut cmd = base_difftool(repo.as_ref(), tool);
+    cmd.arg(range);
+    run_difftool(cmd)
+}
+
+/// Run Git's configured difftool for dirty changes in a linked worktree.
+pub fn difftool_dirty(
+    worktree_path: &Path,
+    mode: crate::worktree::DirtyDiffMode,
+    tool: Option<&str>,
+) -> Result<()> {
+    let mut cmd = base_difftool(worktree_path, tool);
+
+    match mode {
+        crate::worktree::DirtyDiffMode::Dirty => {
+            cmd.arg("HEAD");
+        }
+        crate::worktree::DirtyDiffMode::Staged => {
+            cmd.arg("--staged");
+        }
+        crate::worktree::DirtyDiffMode::Unstaged => {}
+    }
+
+    run_difftool(cmd)
+}
+
+fn base_difftool(path: &Path, tool: Option<&str>) -> Cmd {
     let mut cmd = Cmd::new("git");
     cmd.arg("-C")
-        .arg(repo.as_ref())
+        .arg(path)
         .arg("difftool")
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -448,8 +475,11 @@ pub fn difftool(repo: &RepoRoot, tool: Option<&str>, range: &str) -> Result<()> 
         cmd.arg("--tool").arg(tool);
     }
 
-    cmd.arg("--dir-diff").arg(range);
+    cmd.arg("--dir-diff");
+    cmd
+}
 
+fn run_difftool(mut cmd: Cmd) -> Result<()> {
     for var in GIT_ENV_OVERRIDES {
         cmd.env_remove(var);
     }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -54,10 +54,23 @@ pub struct GoResult {
     pub repo_root: PathBuf,
 }
 
-/// Result of a resolved `diff` operation.
+/// Result of a resolved branch-vs-mainline `diff` operation.
 pub struct DiffResult {
     pub branch: BranchName,
     pub base: String,
+    pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirtyDiffMode {
+    Dirty,
+    Staged,
+    Unstaged,
+}
+
+/// Result of a resolved dirty-worktree `diff` operation.
+pub struct DirtyDiffResult {
+    pub label: String,
     pub command: Vec<String>,
 }
 
@@ -130,11 +143,55 @@ pub fn diff(
     })
 }
 
+/// Resolve and optionally run a dirty-worktree difftool command.
+pub fn diff_dirty(
+    worktree: &Worktree,
+    mode: DirtyDiffMode,
+    tool: Option<&str>,
+    dry_run: bool,
+) -> Result<DirtyDiffResult> {
+    let command = dirty_difftool_command(&worktree.path, mode, tool);
+
+    if !dry_run {
+        git::difftool_dirty(&worktree.path, mode, tool)?;
+    }
+
+    Ok(DirtyDiffResult {
+        label: worktree
+            .branch
+            .clone()
+            .unwrap_or_else(|| format!("detached at {}", worktree.commit)),
+        command,
+    })
+}
+
 fn difftool_command(repo: &RepoRoot, tool: Option<&str>, range: &str) -> Vec<String> {
+    let mut command = base_difftool_command(repo.as_ref(), tool);
+    command.push(range.to_string());
+    command
+}
+
+fn dirty_difftool_command(
+    worktree_path: &std::path::Path,
+    mode: DirtyDiffMode,
+    tool: Option<&str>,
+) -> Vec<String> {
+    let mut command = base_difftool_command(worktree_path, tool);
+
+    match mode {
+        DirtyDiffMode::Dirty => command.push("HEAD".to_string()),
+        DirtyDiffMode::Staged => command.push("--staged".to_string()),
+        DirtyDiffMode::Unstaged => {}
+    }
+
+    command
+}
+
+fn base_difftool_command(path: &std::path::Path, tool: Option<&str>) -> Vec<String> {
     let mut command = vec![
         "git".to_string(),
         "-C".to_string(),
-        repo.display().to_string(),
+        path.display().to_string(),
         "difftool".to_string(),
     ];
 
@@ -144,7 +201,6 @@ fn difftool_command(repo: &RepoRoot, tool: Option<&str>, range: &str) -> Vec<Str
     }
 
     command.push("--dir-diff".to_string());
-    command.push(range.to_string());
     command
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -733,6 +733,26 @@ mod tests {
     }
 
     #[test]
+    fn diff_dirty_dry_run_supports_detached_worktree() {
+        let worktree = wt("/repo/.worktrees/detached--abc12345", None, false);
+        let result = diff_dirty(&worktree, DirtyDiffMode::Dirty, None, true)
+            .expect("dry-run dirty diff should resolve");
+
+        assert_eq!(result.label, "detached at deadbee");
+        assert_eq!(
+            result.command,
+            [
+                "git",
+                "-C",
+                "/repo/.worktrees/detached--abc12345",
+                "difftool",
+                "--dir-diff",
+                "HEAD"
+            ]
+        );
+    }
+
+    #[test]
     fn worktree_for_cwd_prefers_longest_prefix() {
         let worktrees = vec![
             wt("/repo", Some("main"), true),

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -118,3 +118,176 @@ fn diff_rejects_empty_tool_name() {
         .failure()
         .stderr(predicate::str::contains("--tool must not be empty"));
 }
+
+#[test]
+fn diff_dirty_dry_run_explicit_branch_uses_worktree_path() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/dirty", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let worktree = fixtures::find_worktree_dir(&repo.path(), "feature-dirty");
+
+    wt_core()
+        .args([
+            "diff",
+            "--dirty",
+            "feature/dirty",
+            "--repo",
+            &repo_str,
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "git -C {} difftool",
+            worktree.display()
+        )))
+        .stdout(predicate::str::contains("--dir-diff HEAD"));
+}
+
+#[test]
+fn diff_staged_and_unstaged_dry_run_construct_worktree_commands() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/index", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let worktree = fixtures::find_worktree_dir(&repo.path(), "feature-index");
+
+    wt_core()
+        .args([
+            "diff",
+            "--staged",
+            "feature/index",
+            "--repo",
+            &repo_str,
+            "--tool",
+            "vimdiff",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "git -C {} difftool --tool vimdiff --dir-diff --staged",
+            worktree.display()
+        )));
+
+    wt_core()
+        .args([
+            "diff",
+            "--unstaged",
+            "feature/index",
+            "--repo",
+            &repo_str,
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "git -C {} difftool --dir-diff",
+            worktree.display()
+        )))
+        .stdout(predicate::str::contains("--staged").not())
+        .stdout(predicate::str::contains(" HEAD").not());
+}
+
+#[test]
+fn diff_print_command_alias_prints_dirty_command() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/print", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    wt_core()
+        .args([
+            "diff",
+            "--dirty",
+            "feature/print",
+            "--repo",
+            &repo_str,
+            "--print-command",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("git -C"))
+        .stdout(predicate::str::contains("difftool"));
+}
+
+#[test]
+fn diff_dirty_errors_when_requested_branch_has_no_worktree() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    commit_file(&repo.path(), "local.txt", "local", "local branch base");
+    fixtures::run_git(&["branch", "feature/no-dirty-worktree"], &repo.path());
+
+    wt_core()
+        .args([
+            "diff",
+            "--dirty",
+            "feature/no-dirty-worktree",
+            "--repo",
+            &repo_str,
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "branch 'feature/no-dirty-worktree' has no associated worktree",
+        ));
+}
+
+#[test]
+fn diff_rejects_ambiguous_dirty_mode_flags() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args([
+            "diff",
+            "--dirty",
+            "--staged",
+            "feature/ambiguous",
+            "--repo",
+            &repo_str,
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--dirty, --staged, and --unstaged are mutually exclusive",
+        ));
+}
+
+#[test]
+fn diff_rejects_against_with_dirty_mode() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args([
+            "diff",
+            "--dirty",
+            "feature/against",
+            "--against",
+            "HEAD",
+            "--repo",
+            &repo_str,
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--against can only be used with branch-vs-mainline diffs",
+        ));
+}


### PR DESCRIPTION
Closes #45.\n\nSummary:\n- Adds explicit `wt diff --dirty`, `--staged`, and `--unstaged` modes.\n- Resolves dirty diffs to the selected linked worktree and runs `git -C <worktree-path> difftool`.\n- Adds `--print-command` as a dry-run alias and rejects ambiguous dirty-mode flag combinations.\n- Covers dirty, staged, unstaged, missing worktree, invalid flag, and detached dry-run behavior in tests.\n\nValidation:\n- `cargo fmt --check`\n- `cargo clippy -- -D warnings`\n- `cargo test`