### PR TITLE
Fix wt list stats table alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ clap = { version = "4", features = ["derive"] }
 dialoguer = { version = "0.12", optional = true, features = ["fuzzy-select"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+unicode-width = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -19,22 +19,14 @@ def --wrapped wt [
 
 # List all worktrees
 export def "wt list" [
-    --repo: path        # Repository path (defaults to cwd)
-    --json              # Output as JSON
-    --stats             # Include commit and diff stats for each worktree
-    --against: string   # Compare stats against this revision (requires --stats)
-    --color: string     # When to color stats output: auto, always, never
+    --repo: path  # Repository path (defaults to cwd)
+    --json        # Output as JSON
 ] {
-    mut args = ["list"]
-    if $stats { $args = ($args | append "--stats") }
-    if $against != null { $args = ($args | append ["--against" $against]) }
-    if $color != null { $args = ($args | append ["--color" $color]) }
-
-    let full_args = (build-args $args $repo $json false)
+    let args = (build-args ["list"] $repo $json false)
     if $json {
-        ^wt-core ...$full_args | from json
+        ^wt-core ...$args | from json
     } else {
-        ^wt-core ...$full_args
+        ^wt-core ...$args
     }
 }
 

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -19,14 +19,22 @@ def --wrapped wt [
 
 # List all worktrees
 export def "wt list" [
-    --repo: path  # Repository path (defaults to cwd)
-    --json        # Output as JSON
+    --repo: path        # Repository path (defaults to cwd)
+    --json              # Output as JSON
+    --stats             # Include commit and diff stats for each worktree
+    --against: string   # Compare stats against this revision (requires --stats)
+    --color: string     # When to color stats output: auto, always, never
 ] {
-    let args = (build-args ["list"] $repo $json false)
+    mut args = ["list"]
+    if $stats { $args = ($args | append "--stats") }
+    if $against != null { $args = ($args | append ["--against" $against]) }
+    if $color != null { $args = ($args | append ["--color" $color]) }
+
+    let full_args = (build-args $args $repo $json false)
     if $json {
-        ^wt-core ...$args | from json
+        ^wt-core ...$full_args | from json
     } else {
-        ^wt-core ...$args
+        ^wt-core ...$full_args
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -437,7 +437,7 @@ fn joined_cell(cells: &[RenderedCell]) -> RenderedCell {
 fn plain_cell(text: &str) -> RenderedCell {
     RenderedCell {
         rendered: text.to_string(),
-        visible_len: text.len(),
+        visible_len: text.chars().count(),
     }
 }
 
@@ -468,7 +468,7 @@ impl ColorPolicy {
         if self.enabled {
             RenderedCell {
                 rendered: format!("{}{}\x1b[0m", sign.ansi_code(), text),
-                visible_len: text.len(),
+                visible_len: text.chars().count(),
             }
         } else {
             plain_cell(text)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -267,33 +267,95 @@ fn print_list_with_stats(
     stats: &[WorktreeStatsStatus],
     color: ColorPolicy,
 ) {
+    let rows = worktrees
+        .iter()
+        .zip(stats)
+        .map(|(wt, stat)| StatsRow {
+            branch: plain_cell(wt.branch.as_deref().unwrap_or("(detached)")),
+            columns: format_stats_columns(stat, color),
+            path: wt.path.display().to_string(),
+        })
+        .collect::<Vec<_>>();
+    let widths = StatsColumnWidths::from_rows(&rows);
+
     println!(
-        "{:<20} {:<12} {:<10} {:<7} {:<14} PATH",
-        "BRANCH", "BASE", "COMMITS", "FILES", "DIFF"
+        "{} {} {} {} {} PATH",
+        align_left(&plain_cell("BRANCH"), widths.branch),
+        align_left(&plain_cell("BASE"), widths.base),
+        align_right(&plain_cell("COMMITS"), widths.commits),
+        align_right(&plain_cell("FILES"), widths.files),
+        align_right(&plain_cell("DIFF"), widths.diff)
     );
-    for (wt, stat) in worktrees.iter().zip(stats) {
-        let branch = wt.branch.as_deref().unwrap_or("(detached)");
-        let columns = format_stats_columns(stat, color);
+
+    for row in rows {
         println!(
             "{} {} {} {} {} {}",
-            pad_cell(branch, branch.len(), 20),
-            pad_cell(&columns.base, columns.base.len(), 12),
-            pad_cell(&columns.commits.rendered, columns.commits.visible_len, 10),
-            pad_cell(&columns.files, columns.files.len(), 7),
-            pad_cell(&columns.diff.rendered, columns.diff.visible_len, 14),
-            wt.path.display()
+            align_left(&row.branch, widths.branch),
+            align_left(&row.columns.base, widths.base),
+            align_right(&row.columns.commits, widths.commits),
+            align_right(&row.columns.files, widths.files),
+            align_right(&row.columns.diff, widths.diff),
+            row.path
         );
     }
 }
 
-fn pad_cell(text: &str, visible_len: usize, width: usize) -> String {
-    format!("{}{}", text, " ".repeat(width.saturating_sub(visible_len)))
+fn align_left(cell: &RenderedCell, width: usize) -> String {
+    format!(
+        "{}{}",
+        cell.rendered,
+        " ".repeat(width.saturating_sub(cell.visible_len))
+    )
+}
+
+fn align_right(cell: &RenderedCell, width: usize) -> String {
+    format!(
+        "{}{}",
+        " ".repeat(width.saturating_sub(cell.visible_len)),
+        cell.rendered
+    )
+}
+
+struct StatsRow {
+    branch: RenderedCell,
+    columns: StatsColumns,
+    path: String,
+}
+
+struct StatsColumnWidths {
+    branch: usize,
+    base: usize,
+    commits: usize,
+    files: usize,
+    diff: usize,
+}
+
+impl StatsColumnWidths {
+    fn from_rows(rows: &[StatsRow]) -> Self {
+        let mut widths = Self {
+            branch: "BRANCH".len(),
+            base: "BASE".len(),
+            commits: "COMMITS".len(),
+            files: "FILES".len(),
+            diff: "DIFF".len(),
+        };
+
+        for row in rows {
+            widths.branch = widths.branch.max(row.branch.visible_len);
+            widths.base = widths.base.max(row.columns.base.visible_len);
+            widths.commits = widths.commits.max(row.columns.commits.visible_len);
+            widths.files = widths.files.max(row.columns.files.visible_len);
+            widths.diff = widths.diff.max(row.columns.diff.visible_len);
+        }
+
+        widths
+    }
 }
 
 struct StatsColumns {
-    base: String,
+    base: RenderedCell,
     commits: RenderedCell,
-    files: String,
+    files: RenderedCell,
     diff: RenderedCell,
 }
 
@@ -305,15 +367,15 @@ struct RenderedCell {
 fn format_stats_columns(stat: &WorktreeStatsStatus, color: ColorPolicy) -> StatsColumns {
     match stat {
         WorktreeStatsStatus::Available(stats) => StatsColumns {
-            base: stats.base.clone(),
+            base: plain_cell(&stats.base),
             commits: format_commit_counts(stats.commits_ahead, stats.commits_behind, color),
-            files: stats.files_changed.to_string(),
+            files: plain_cell(&stats.files_changed.to_string()),
             diff: format_diff_counts(stats.insertions, stats.deletions, color),
         },
         WorktreeStatsStatus::Unavailable { base, .. } => StatsColumns {
-            base: base.clone(),
+            base: plain_cell(base),
             commits: plain_cell("unavailable"),
-            files: "—".to_string(),
+            files: plain_cell("—"),
             diff: plain_cell("—"),
         },
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,6 +12,7 @@ use crate::output::{
     StatusFormat,
 };
 use crate::worktree;
+use unicode_width::UnicodeWidthStr;
 
 pub fn run(cli: Cli) -> Result<()> {
     match cli.command {
@@ -437,7 +438,7 @@ fn joined_cell(cells: &[RenderedCell]) -> RenderedCell {
 fn plain_cell(text: &str) -> RenderedCell {
     RenderedCell {
         rendered: text.to_string(),
-        visible_len: text.chars().count(),
+        visible_len: UnicodeWidthStr::width(text),
     }
 }
 
@@ -468,7 +469,7 @@ impl ColorPolicy {
         if self.enabled {
             RenderedCell {
                 rendered: format!("{}{}\x1b[0m", sign.ansi_code(), text),
-                visible_len: text.chars().count(),
+                visible_len: UnicodeWidthStr::width(text),
             }
         } else {
             plain_cell(text)

--- a/tests/bindings/nu_test.nu
+++ b/tests/bindings/nu_test.nu
@@ -50,6 +50,13 @@ if ($output | str contains "feat-one") {
     fail "wt list: 'feat-one' not found in output"
 }
 
+let stats_output = (wt list --stats --color never | str join "\n")
+if ($stats_output | str contains "COMMITS") and ($stats_output | str contains "feat-one") {
+    pass "wt list --stats: forwards stats options"
+} else {
+    fail "wt list --stats: missing expected stats output"
+}
+
 # ── wt go ────────────────────────────────────────────────────────────
 cd $"($work)/repo"
 wt go feat-one

--- a/tests/cli_list_stats.rs
+++ b/tests/cli_list_stats.rs
@@ -180,6 +180,82 @@ fn list_json_omits_stats_without_flag() {
     assert!(entry.get("stats").is_none());
 }
 
+fn column_start(line: &str, column: &str) -> usize {
+    line.find(column)
+        .unwrap_or_else(|| panic!("column '{column}' not found in '{line}'"))
+}
+
+#[test]
+fn list_stats_human_output_dynamically_aligns_wide_stats_columns() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    let base_branch = "base-with-a-long-name";
+    fixtures::run_git(&["branch", base_branch], &repo_path);
+
+    let long_branch = "2385/line-native-startup-continuation-extra-long";
+    let long_wt_path = add_worktree(&repo_path, long_branch);
+    let large_insertions = (0..1200)
+        .map(|idx| format!("line {idx}\n"))
+        .collect::<String>();
+    fixtures::commit_file(
+        Path::new(&long_wt_path),
+        "large-feature.txt",
+        &large_insertions,
+        "large feature commit",
+    );
+
+    let diverged_branch = "diverged-large-counts";
+    let diverged_wt_path = add_worktree(&repo_path, diverged_branch);
+    fixtures::commit_file(
+        Path::new(&diverged_wt_path),
+        "feature.txt",
+        "feature\n",
+        "feature commit",
+    );
+    fixtures::commit_file(&repo_path, "main-1.txt", "main\n", "main commit 1");
+    fixtures::commit_file(&repo_path, "main-2.txt", "main\n", "main commit 2");
+
+    let detached_path = repo_path.join(".worktrees").join("detached-wide-stats");
+    fixtures::run_git(
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            &detached_path.display().to_string(),
+            "HEAD",
+        ],
+        &repo_path,
+    );
+
+    let base_name = "main";
+    let plain = list_human(
+        &repo_path,
+        &["--stats", "--against", base_name, "--color", "never"],
+    );
+    let colored = list_human(
+        &repo_path,
+        &["--stats", "--against", base_name, "--color", "always"],
+    );
+    let colored_plain = strip_stats_ansi(&colored);
+
+    assert_eq!(colored_plain, plain);
+
+    let lines = plain.lines().collect::<Vec<_>>();
+    let header = lines.first().expect("header line");
+    let base_start = column_start(header, "BASE");
+    let path_start = column_start(header, "PATH");
+
+    assert!(lines.iter().any(|line| line.contains("+1200 -0")));
+    assert!(lines.iter().any(|line| line.contains("+1 -2")));
+    assert!(lines.iter().any(|line| line.contains("unavailable")));
+
+    for line in lines.iter().skip(1) {
+        assert!(line[base_start..].starts_with(base_name), "{line}");
+        assert!(line[..path_start].contains(base_name), "{line}");
+        assert!(line[path_start..].trim_start().starts_with('/'), "{line}");
+    }
+}
+
 #[test]
 fn list_stats_color_always_colors_non_zero_signed_values() {
     let repo = fixtures::TestRepo::new();
@@ -198,8 +274,15 @@ fn list_stats_color_always_colors_non_zero_signed_values() {
     assert!(output.contains("\x1b[32m+1\x1b[0m"));
     assert!(output.contains("\x1b[31m-1\x1b[0m"));
     assert!(output.contains("\x1b[32m+1\x1b[0m \x1b[31m-1\x1b[0m"));
-    assert!(strip_stats_ansi(&output)
-        .contains("feat-color           main         +1 -1      1       +1 -1"));
+    let plain = strip_stats_ansi(&output);
+    let row = plain
+        .lines()
+        .find(|line| line.starts_with("feat-color"))
+        .expect("feat-color row");
+    assert_eq!(
+        row.split_whitespace().take(7).collect::<Vec<_>>(),
+        ["feat-color", "main", "+1", "-1", "1", "+1", "-1"]
+    );
 }
 
 #[test]
@@ -270,7 +353,13 @@ fn list_stats_does_not_color_zero_unavailable_or_json() {
     let json = list_json(&repo_path, &["--stats", "--color", "always"]);
     let json_text = serde_json::to_string(&json).expect("json text");
 
-    assert!(human.contains(" 0          0       +0 -0"));
+    let zero_row = strip_stats_ansi(&human)
+        .lines()
+        .find(|line| line.starts_with("main") || line.starts_with("feat-zero"))
+        .expect("zero stats row")
+        .to_string();
+    assert!(zero_row.contains(" 0"));
+    assert!(zero_row.contains("+0 -0"));
     assert!(human.contains("unavailable"));
     assert!(!human.contains("\x1b[32m+0"));
     assert!(!human.contains("\x1b[31m-0"));

--- a/tests/cli_list_stats.rs
+++ b/tests/cli_list_stats.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use unicode_width::UnicodeWidthStr;
 
 fn wt_core() -> Command {
     Command::new(assert_cmd::cargo_bin!("wt-core"))
@@ -197,6 +198,13 @@ fn char_start_of_text(line: &str, text: &str) -> usize {
     line[..byte_start].chars().count()
 }
 
+fn display_column_start(line: &str, text: &str) -> usize {
+    let byte_start = line
+        .find(text)
+        .unwrap_or_else(|| panic!("text '{text}' not found in '{line}'"));
+    UnicodeWidthStr::width(&line[..byte_start])
+}
+
 #[test]
 fn list_stats_human_output_dynamically_aligns_wide_stats_columns() {
     let repo = fixtures::TestRepo::new();
@@ -273,6 +281,40 @@ fn list_stats_human_output_dynamically_aligns_wide_stats_columns() {
             "{line}"
         );
     }
+}
+
+#[test]
+fn list_stats_human_output_aligns_visible_columns_for_wide_unicode_text() {
+    let repo = fixtures::TestRepo::new();
+    let repo_path = repo.path();
+    let unicode_branch = "feature/幅広統計";
+    let unicode_base = "基準ブランチ";
+    fixtures::run_git(&["branch", unicode_base], &repo_path);
+    let wt_path = add_worktree(&repo_path, unicode_branch);
+    fixtures::commit_file(
+        Path::new(&wt_path),
+        "unicode.txt",
+        "unicode branch\n",
+        "unicode branch commit",
+    );
+
+    let plain = list_human(
+        &repo_path,
+        &["--stats", "--against", unicode_base, "--color", "never"],
+    );
+    let header = plain.lines().next().expect("header line");
+    let path_display_start = display_column_start(header, "PATH");
+    let repo_prefix = repo_path.display().to_string();
+
+    let unicode_row = plain
+        .lines()
+        .find(|line| line.starts_with(unicode_branch))
+        .expect("unicode branch row");
+    assert_eq!(
+        display_column_start(unicode_row, &repo_prefix),
+        path_display_start,
+        "{unicode_row}"
+    );
 }
 
 #[test]

--- a/tests/cli_list_stats.rs
+++ b/tests/cli_list_stats.rs
@@ -185,12 +185,22 @@ fn column_start(line: &str, column: &str) -> usize {
         .unwrap_or_else(|| panic!("column '{column}' not found in '{line}'"))
 }
 
+fn char_column_start(line: &str, column: &str) -> usize {
+    let byte_start = column_start(line, column);
+    line[..byte_start].chars().count()
+}
+
+fn char_start_of_text(line: &str, text: &str) -> usize {
+    let byte_start = line
+        .find(text)
+        .unwrap_or_else(|| panic!("text '{text}' not found in '{line}'"));
+    line[..byte_start].chars().count()
+}
+
 #[test]
 fn list_stats_human_output_dynamically_aligns_wide_stats_columns() {
     let repo = fixtures::TestRepo::new();
     let repo_path = repo.path();
-    let base_branch = "base-with-a-long-name";
-    fixtures::run_git(&["branch", base_branch], &repo_path);
 
     let long_branch = "2385/line-native-startup-continuation-extra-long";
     let long_wt_path = add_worktree(&repo_path, long_branch);
@@ -214,6 +224,8 @@ fn list_stats_human_output_dynamically_aligns_wide_stats_columns() {
     );
     fixtures::commit_file(&repo_path, "main-1.txt", "main\n", "main commit 1");
     fixtures::commit_file(&repo_path, "main-2.txt", "main\n", "main commit 2");
+    let base_branch = "base-with-a-long-name";
+    fixtures::run_git(&["branch", base_branch], &repo_path);
 
     let detached_path = repo_path.join(".worktrees").join("detached-wide-stats");
     fixtures::run_git(
@@ -227,7 +239,7 @@ fn list_stats_human_output_dynamically_aligns_wide_stats_columns() {
         &repo_path,
     );
 
-    let base_name = "main";
+    let base_name = base_branch;
     let plain = list_human(
         &repo_path,
         &["--stats", "--against", base_name, "--color", "never"],
@@ -244,6 +256,8 @@ fn list_stats_human_output_dynamically_aligns_wide_stats_columns() {
     let header = lines.first().expect("header line");
     let base_start = column_start(header, "BASE");
     let path_start = column_start(header, "PATH");
+    let path_char_start = char_column_start(header, "PATH");
+    let repo_prefix = repo_path.display().to_string();
 
     assert!(lines.iter().any(|line| line.contains("+1200 -0")));
     assert!(lines.iter().any(|line| line.contains("+1 -2")));
@@ -252,7 +266,12 @@ fn list_stats_human_output_dynamically_aligns_wide_stats_columns() {
     for line in lines.iter().skip(1) {
         assert!(line[base_start..].starts_with(base_name), "{line}");
         assert!(line[..path_start].contains(base_name), "{line}");
-        assert!(line[path_start..].trim_start().starts_with('/'), "{line}");
+        assert!(line.contains(&repo_prefix), "{line}");
+        assert_eq!(
+            char_start_of_text(line, &repo_prefix),
+            path_char_start,
+            "{line}"
+        );
     }
 }
 

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -21,6 +21,12 @@ pub struct TestRepo {
     pub dir: TempDir,
 }
 
+impl Default for TestRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TestRepo {
     /// Create a new temporary git repo with an initial commit.
     pub fn new() -> Self {
@@ -82,6 +88,12 @@ pub struct ClonedTestRepo {
     pub _origin: TempDir,
     /// The cloned working copy.
     pub clone: TempDir,
+}
+
+impl Default for ClonedTestRepo {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ClonedTestRepo {


### PR DESCRIPTION
Closes #55.\n\n## Summary\n- dynamically compute visible column widths for human `wt list --stats` output\n- right-align stat columns while preserving left-aligned branch/base/path fields\n- keep ANSI-colored output visibly aligned and JSON output unchanged\n- add integration coverage for long branch names, large stats, detached unavailable rows, and color stripping parity\n\n## Validation\n- `cargo fmt --check`\n- `cargo test --test cli_list_stats`\n- `cargo clippy --all-targets -- -D warnings`\n- pre-commit hook: `cargo fmt`, `cargo clippy`, full `cargo test`, ast-grep