### PR TITLE
Make wt diff report missing difftool configuration

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -434,6 +434,143 @@ pub fn merge_abort(repo: &RepoRoot) {
     let _ = git(&["merge", "--abort"], repo.as_ref());
 }
 
+/// Verify Git has a usable difftool before launching an interactive diff.
+pub fn ensure_difftool_available(path: &Path, tool: Option<&str>) -> Result<()> {
+    match tool {
+        Some(tool) => ensure_explicit_difftool_available(path, tool),
+        None => ensure_default_difftool_available(path),
+    }
+}
+
+fn ensure_explicit_difftool_available(path: &Path, tool: &str) -> Result<()> {
+    if is_difftool_available(path, tool)? {
+        return Ok(());
+    }
+
+    Err(AppError::usage(format!(
+        "git difftool '{tool}' is not configured or available\n\n\
+Configure it, for example:\n  git config --global diff.tool {tool}\n\n\
+Or choose an available tool explicitly:\n  wt diff --tool nvimdiff <branch>\n\n\
+Available tools can be inspected with:\n  git difftool --tool-help"
+    )))
+}
+
+fn ensure_default_difftool_available(path: &Path) -> Result<()> {
+    let Some(tool) = configured_difftool(path)? else {
+        if !available_difftools(path)?.is_empty() {
+            return Ok(());
+        }
+
+        return Err(AppError::usage(
+            "no git difftool is configured or available\n\n\
+Configure one, for example:\n  git config --global diff.tool nvimdiff\n\n\
+Or run explicitly:\n  wt diff --tool nvimdiff <branch>\n\n\
+Available tools can be inspected with:\n  git difftool --tool-help"
+                .to_string(),
+        ));
+    };
+
+    if is_difftool_available(path, &tool)? {
+        return Ok(());
+    }
+
+    Err(AppError::usage(format!(
+        "configured git difftool '{tool}' is not available\n\n\
+Configure one, for example:\n  git config --global diff.tool nvimdiff\n\n\
+Or run explicitly:\n  wt diff --tool nvimdiff <branch>\n\n\
+Available tools can be inspected with:\n  git difftool --tool-help"
+    )))
+}
+
+fn configured_difftool(path: &Path) -> Result<Option<String>> {
+    let Some(tool) = git_config_get(path, "diff.tool")? else {
+        return git_config_get(path, "merge.tool");
+    };
+
+    Ok(Some(tool))
+}
+
+fn is_difftool_available(path: &Path, tool: &str) -> Result<bool> {
+    if git_config_get(path, &format!("difftool.{tool}.cmd"))?.is_some() {
+        return Ok(true);
+    }
+
+    Ok(available_difftools(path)?.contains(tool))
+}
+
+fn available_difftools(path: &Path) -> Result<HashSet<String>> {
+    let output = git_tool_help(path)?;
+    Ok(parse_available_difftools(&output))
+}
+
+fn parse_available_difftools(output: &str) -> HashSet<String> {
+    let mut tools = HashSet::new();
+
+    for line in output.lines() {
+        if line.starts_with("The following tools are valid, but not currently available:") {
+            break;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with("'git difftool")
+            || trimmed == "user-defined:"
+            || trimmed.starts_with("The following tools")
+        {
+            continue;
+        }
+
+        if let Some(name) = trimmed.split_whitespace().next() {
+            tools.insert(name.strip_suffix(".cmd").unwrap_or(name).to_string());
+        }
+    }
+
+    tools
+}
+
+fn git_config_get(path: &Path, key: &str) -> Result<Option<String>> {
+    let mut cmd = Cmd::new("git");
+    cmd.arg("-C").arg(path).arg("config").arg("--get").arg(key);
+
+    for var in GIT_ENV_OVERRIDES {
+        cmd.env_remove(var);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| AppError::git(format!("failed to run git config: {e}")))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok((!value.is_empty()).then_some(value))
+}
+
+fn git_tool_help(path: &Path) -> Result<String> {
+    let mut cmd = Cmd::new("git");
+    cmd.arg("-C").arg(path).arg("difftool").arg("--tool-help");
+
+    for var in GIT_ENV_OVERRIDES {
+        cmd.env_remove(var);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| AppError::git(format!("failed to run git difftool --tool-help: {e}")))?;
+
+    if !output.status.success() {
+        return Err(classify_git_error(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).to_string();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    Ok(combined)
+}
+
 /// Run Git's configured difftool for a branch comparison.
 pub fn difftool(repo: &RepoRoot, tool: Option<&str>, range: &str) -> Result<()> {
     let mut cmd = base_difftool(repo.as_ref(), tool);

--- a/src/git.rs
+++ b/src/git.rs
@@ -520,9 +520,15 @@ fn parse_available_difftools(output: &str) -> HashSet<String> {
             continue;
         }
 
-        if let Some(name) = trimmed.split_whitespace().next() {
-            tools.insert(name.strip_suffix(".cmd").unwrap_or(name).to_string());
+        let Some(name) = trimmed.split_whitespace().next() else {
+            continue;
+        };
+
+        if name.ends_with(':') {
+            continue;
         }
+
+        tools.insert(name.strip_suffix(".cmd").unwrap_or(name).to_string());
     }
 
     tools
@@ -729,6 +735,29 @@ branch refs/heads/other
         assert_eq!(result[2].path, PathBuf::from("/repo/.worktrees/other"));
         assert_eq!(result[2].branch.as_deref(), Some("other"));
         assert!(!result[2].is_main);
+    }
+
+    #[test]
+    fn parse_available_difftools_skips_headings_and_unavailable_tools() {
+        let raw = "\
+'git difftool --tool=<tool>' may be set to one of the following:\n\
+\t\tnvimdiff         Use Neovim\n\
+\n\
+\tuser-defined:\n\
+\t\tdelta.cmd git diff --no-index -- $LOCAL $REMOTE | delta\n\
+\n\
+The following tools are valid, but not currently available:\n\
+\t\tvimdiff          Use Vim\n\
+\n\
+Some of the tools listed above only work in a windowed environment.\n";
+
+        let tools = parse_available_difftools(raw);
+
+        assert!(tools.contains("nvimdiff"));
+        assert!(tools.contains("delta"));
+        assert!(!tools.contains("user-defined:"));
+        assert!(!tools.contains("vimdiff"));
+        assert!(!tools.contains("Some"));
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -511,12 +511,12 @@ fn parse_available_difftools(output: &str) -> HashSet<String> {
             break;
         }
 
+        if !line.starts_with(char::is_whitespace) {
+            continue;
+        }
+
         let trimmed = line.trim();
-        if trimmed.is_empty()
-            || trimmed.starts_with("'git difftool")
-            || trimmed == "user-defined:"
-            || trimmed.starts_with("The following tools")
-        {
+        if trimmed.is_empty() {
             continue;
         }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -133,6 +133,7 @@ pub fn diff(
     let command = difftool_command(repo, tool, &range);
 
     if !dry_run {
+        git::ensure_difftool_available(repo.as_ref(), tool)?;
         git::difftool(repo, tool, &range)?;
     }
 
@@ -153,6 +154,7 @@ pub fn diff_dirty(
     let command = dirty_difftool_command(&worktree.path, mode, tool);
 
     if !dry_run {
+        git::ensure_difftool_available(&worktree.path, tool)?;
         git::difftool_dirty(&worktree.path, mode, tool)?;
     }
 

--- a/tests/cli_diff.rs
+++ b/tests/cli_diff.rs
@@ -1,12 +1,83 @@
 mod fixtures;
 
+use std::path::Path;
+
 use assert_cmd::Command;
 use predicates::prelude::*;
+use tempfile::TempDir;
 
 use fixtures::commit_file;
 
 fn wt_core() -> Command {
     Command::new(assert_cmd::cargo_bin!("wt-core"))
+}
+
+struct IsolatedDifftoolEnv {
+    _temp: TempDir,
+    path: String,
+    home: String,
+    xdg_config_home: String,
+}
+
+impl IsolatedDifftoolEnv {
+    fn new() -> Self {
+        let temp = TempDir::new().expect("failed to create isolated git env");
+        let bin = temp.path().join("bin");
+        std::fs::create_dir(&bin).expect("failed to create isolated bin dir");
+        link_git_binary(&bin);
+
+        let home = temp.path().join("home");
+        let xdg_config_home = temp.path().join("xdg");
+        std::fs::create_dir(&home).expect("failed to create isolated home dir");
+        std::fs::create_dir(&xdg_config_home).expect("failed to create isolated xdg dir");
+
+        Self {
+            path: bin.display().to_string(),
+            home: home.display().to_string(),
+            xdg_config_home: xdg_config_home.display().to_string(),
+            _temp: temp,
+        }
+    }
+
+    fn apply(&self, cmd: &mut Command) {
+        cmd.env("PATH", &self.path)
+            .env("HOME", &self.home)
+            .env("XDG_CONFIG_HOME", &self.xdg_config_home)
+            .env("GIT_CONFIG_GLOBAL", os_null_path())
+            .env("GIT_CONFIG_NOSYSTEM", "1");
+    }
+}
+
+fn isolated_wt_core(env: &IsolatedDifftoolEnv) -> Command {
+    let mut cmd = wt_core();
+    env.apply(&mut cmd);
+    cmd
+}
+
+#[cfg(unix)]
+fn link_git_binary(bin: &Path) {
+    let git = std::process::Command::new("git")
+        .arg("--exec-path")
+        .output()
+        .expect("failed to locate git");
+    assert!(git.status.success(), "git --exec-path failed");
+
+    let exec_path = String::from_utf8_lossy(&git.stdout).trim().to_string();
+    std::os::unix::fs::symlink(Path::new(&exec_path).join("git"), bin.join("git"))
+        .expect("failed to link git into isolated PATH");
+}
+
+#[cfg(not(unix))]
+fn link_git_binary(_bin: &Path) {
+    panic!("isolated difftool PATH tests require unix symlinks");
+}
+
+fn os_null_path() -> &'static str {
+    if cfg!(windows) {
+        "NUL"
+    } else {
+        "/dev/null"
+    }
 }
 
 #[test]
@@ -57,6 +128,125 @@ fn diff_dry_run_respects_base_override_and_tool() {
         .success()
         .stdout(predicate::str::contains("--tool vimdiff"))
         .stdout(predicate::str::contains("HEAD...feature/tool"));
+}
+
+#[test]
+fn diff_non_dry_run_errors_before_launch_when_no_difftool_is_available() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let env = IsolatedDifftoolEnv::new();
+
+    wt_core()
+        .args(["add", "feature/no-difftool", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    isolated_wt_core(&env)
+        .args(["diff", "feature/no-difftool", "--repo", &repo_str])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no git difftool is configured or available",
+        ))
+        .stderr(predicate::str::contains(
+            "git config --global diff.tool nvimdiff",
+        ))
+        .stderr(predicate::str::contains("git difftool --tool-help"))
+        .stderr(predicate::str::contains("difftool..cmd").not());
+}
+
+#[test]
+fn diff_dirty_modes_error_before_launch_when_no_difftool_is_available() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let env = IsolatedDifftoolEnv::new();
+
+    wt_core()
+        .args(["add", "feature/dirty-no-difftool", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    for mode in ["--dirty", "--staged", "--unstaged"] {
+        isolated_wt_core(&env)
+            .args([
+                "diff",
+                mode,
+                "feature/dirty-no-difftool",
+                "--repo",
+                &repo_str,
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "no git difftool is configured or available",
+            ));
+    }
+}
+
+#[test]
+fn diff_explicit_unusable_tool_returns_wt_core_error() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/bad-tool", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    wt_core()
+        .args([
+            "diff",
+            "feature/bad-tool",
+            "--repo",
+            &repo_str,
+            "--tool",
+            "definitely-not-a-wt-difftool",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "git difftool 'definitely-not-a-wt-difftool' is not configured or available",
+        ))
+        .stderr(predicate::str::contains("wt diff --tool nvimdiff <branch>"));
+}
+
+#[test]
+fn diff_dry_run_and_print_command_bypass_missing_difftool_preflight() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let env = IsolatedDifftoolEnv::new();
+
+    wt_core()
+        .args(["add", "feature/isolated-dry-run", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    isolated_wt_core(&env)
+        .args([
+            "diff",
+            "feature/isolated-dry-run",
+            "--repo",
+            &repo_str,
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("git -C"))
+        .stdout(predicate::str::contains("difftool"));
+
+    isolated_wt_core(&env)
+        .args([
+            "diff",
+            "--dirty",
+            "feature/isolated-dry-run",
+            "--repo",
+            &repo_str,
+            "--print-command",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("git -C"))
+        .stdout(predicate::str::contains("difftool"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #56

## Summary
- add a wt-owned difftool preflight before non-dry-run branch and dirty diffs
- report clear remediation when no default difftool is usable or an explicit --tool cannot be resolved
- keep --dry-run/--print-command bypassing difftool availability checks
- add isolated integration coverage for branch, dirty/staged/unstaged, explicit tool, and dry-run paths

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --test cli_diff
- full cargo test via pre-commit hook