### PR TITLE
Support merging into target branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ wt add <branch> [--base <rev>]         Create a worktree and branch
 wt go [<branch>] [-i]                  Switch to an existing worktree
 wt list                                List all worktrees
 wt remove [<branch>] [--force]         Remove a worktree and its local branch
-wt merge [<branch>] [--push]           Merge a branch into mainline and clean up
+wt merge [<branch>] [--into <branch>]  Merge a branch and clean up
 wt diff [<branch>] [--dry-run]         Open difftool for a branch vs mainline
 wt prune [--execute] [--force]         Remove worktrees integrated into mainline
 wt doctor                              Diagnose worktree/repo health
@@ -105,14 +105,17 @@ wt remove --force          # remove even if dirty, use -D for branch
 ### `wt merge`
 
 Merges a worktree's branch into the auto-detected mainline using
-`--no-ff`, then removes the worktree and branch by default. Conflicts
-cause an automatic `merge --abort` to keep the main worktree clean.
+`--no-ff`, then removes the worktree and branch by default. Use `--into`
+to merge into a different branch that is already checked out in the main
+worktree. Conflicts cause an automatic `merge --abort` to keep the main
+worktree clean.
 
 ```
-wt merge                    # merge current worktree's branch
-wt merge feature/auth       # explicit branch
-wt merge --push             # push mainline to origin after merge
-wt merge --no-cleanup       # keep worktree and branch after merge
+wt merge                         # merge current worktree's branch
+wt merge feature/auth            # explicit branch
+wt merge feature/auth --into rc  # merge into checked-out branch rc
+wt merge --push                  # push target branch to origin after merge
+wt merge --no-cleanup            # keep worktree and branch after merge
 ```
 
 ### `wt diff`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,7 +104,7 @@ pub enum Command {
         print_paths: bool,
     },
 
-    /// Merge a worktree's branch into mainline and clean up
+    /// Merge a worktree's branch into a checked-out target and clean up
     Merge {
         /// Branch name (defaults to current worktree's branch)
         branch: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,7 +109,11 @@ pub enum Command {
         /// Branch name (defaults to current worktree's branch)
         branch: Option<String>,
 
-        /// Push mainline to origin after successful merge
+        /// Merge into this checked-out branch instead of the detected mainline
+        #[arg(long, value_name = "BRANCH")]
+        into: Option<String>,
+
+        /// Push the target branch to origin after successful merge
         #[arg(long)]
         push: bool,
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -61,6 +61,7 @@ pub fn run(cli: Cli) -> Result<()> {
         ),
         Command::Merge {
             branch,
+            into,
             push,
             no_cleanup,
             repo,
@@ -68,6 +69,7 @@ pub fn run(cli: Cli) -> Result<()> {
             print_paths,
         } => cmd_merge(
             branch.as_deref().map(BranchName::new),
+            into,
             push,
             no_cleanup,
             repo,
@@ -984,6 +986,7 @@ fn resolve_diff_branch(repo: &domain::RepoRoot) -> Result<BranchName> {
 
 fn cmd_merge(
     branch: Option<BranchName>,
+    into: Option<String>,
     push: bool,
     no_cleanup: bool,
     repo: Option<PathBuf>,
@@ -996,7 +999,13 @@ fn cmd_merge(
         None => resolve_action_branch(&repo, fmt == MergeFormat::Json, "merge")?,
     };
 
-    let result = worktree::merge(&repo, resolved_branch.as_ref(), push, no_cleanup)?;
+    let result = worktree::merge(
+        &repo,
+        resolved_branch.as_ref(),
+        into.as_deref(),
+        push,
+        no_cleanup,
+    )?;
 
     let root_str = result.repo_root.display().to_string();
     let branch_name = &result.branch;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -617,13 +617,14 @@ pub struct MergeResult {
 ///
 /// 1. Resolve the target branch (argument, cwd inference, or picker)
 /// 2. Refuse if it is the main worktree
-/// 3. Resolve the mainline branch
+/// 3. Resolve the target branch (`--into` or detected mainline)
 /// 4. Run `git merge --no-ff <branch>` from the main worktree
 /// 5. On conflict: abort the merge and return an error
 /// 6. On success: optionally remove the worktree+branch, optionally push
 pub fn merge(
     repo: &RepoRoot,
     branch: Option<&BranchName>,
+    into: Option<&str>,
     push: bool,
     no_cleanup: bool,
 ) -> Result<MergeResult> {
@@ -650,17 +651,30 @@ pub fn merge(
         ));
     }
 
-    // Resolve mainline and verify the main worktree is checked out to it.
-    let mainline = git::resolve_mainline(repo)?;
+    // Resolve target and verify the main worktree is checked out to it.
+    let mainline = into
+        .map(str::to_string)
+        .map(Ok)
+        .unwrap_or_else(|| git::resolve_mainline(repo))?;
     let main_wt_branch = worktrees
         .iter()
         .find(|w| w.is_main)
         .and_then(|w| w.branch.as_deref());
+    let checkout_hint = match into {
+        Some(_) => "checkout target branch first",
+        None => "checkout mainline first",
+    };
     if main_wt_branch != Some(&mainline) {
         return Err(AppError::invariant(format!(
-            "main worktree is on '{}', expected '{mainline}' — checkout mainline first",
+            "main worktree is on '{}', expected '{mainline}' — {checkout_hint}",
             main_wt_branch.unwrap_or("(detached)")
         )));
+    }
+
+    if target_branch.as_str() == mainline {
+        return Err(AppError::invariant(
+            "refusing to merge a branch into itself".to_string(),
+        ));
     }
 
     // Attempt the merge from the main worktree's context.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -656,6 +656,12 @@ pub fn merge(
         .map(str::to_string)
         .map(Ok)
         .unwrap_or_else(|| git::resolve_mainline(repo))?;
+    if target_branch.as_str() == mainline {
+        return Err(AppError::invariant(
+            "refusing to merge a branch into itself".to_string(),
+        ));
+    }
+
     let main_wt_branch = worktrees
         .iter()
         .find(|w| w.is_main)
@@ -669,12 +675,6 @@ pub fn merge(
             "main worktree is on '{}', expected '{mainline}' — {checkout_hint}",
             main_wt_branch.unwrap_or("(detached)")
         )));
-    }
-
-    if target_branch.as_str() == mainline {
-        return Err(AppError::invariant(
-            "refusing to merge a branch into itself".to_string(),
-        ));
     }
 
     // Attempt the merge from the main worktree's context.

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -308,6 +308,57 @@ fn merge_push_failure_reports_warning() {
         .stderr(predicate::str::contains("warning:"));
 }
 
+#[test]
+fn merge_into_with_push_pushes_destination_branch() {
+    let (repo, upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+
+    run_git(&["checkout", "-b", "release/1.0"], &repo.path());
+    run_git(&["push", "-u", "origin", "release/1.0"], &repo.path());
+    run_git(&["checkout", "main"], &repo.path());
+
+    wt_core()
+        .args(["add", "feature/release-push", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let wt_dir = find_worktree_dir(&repo.path(), "feature-release-push");
+    commit_file(&wt_dir, "rp.txt", "release push", "add release push");
+
+    run_git(&["checkout", "release/1.0"], &repo.path());
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/release-push",
+            "--into",
+            "release/1.0",
+            "--push",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Merged 'feature/release-push' into release/1.0",
+        ))
+        .stdout(predicate::str::contains("Pushed release/1.0 to origin"));
+
+    let upstream_log = git_log_oneline(upstream.path(), "release/1.0");
+    assert!(
+        upstream_log.contains("Merge branch 'feature/release-push'"),
+        "merge commit should be pushed to release branch: {upstream_log}"
+    );
+
+    let upstream_main_log = git_log_oneline(upstream.path(), "main");
+    assert!(
+        !upstream_main_log.contains("Merge branch 'feature/release-push'"),
+        "merge commit should not be pushed to main: {upstream_main_log}"
+    );
+
+    run_git(&["checkout", "main"], &repo.path());
+}
+
 // ── JSON output tests ───────────────────────────────────────────────
 
 #[test]
@@ -533,6 +584,75 @@ fn merge_into_checked_out_non_mainline_branch() {
     );
 
     run_git(&["checkout", "main"], &repo.path());
+}
+
+#[test]
+fn merge_into_wrong_checked_out_destination_errors_before_merge() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    run_git(&["checkout", "-b", "release/1.0"], &repo.path());
+    run_git(&["checkout", "main"], &repo.path());
+
+    wt_core()
+        .args(["add", "feature/wrong-target", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let wt_dir = find_worktree_dir(&repo.path(), "feature-wrong-target");
+    commit_file(&wt_dir, "wrong.txt", "wrong target", "add wrong target");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/wrong-target",
+            "--into",
+            "release/1.0",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(4)
+        .stderr(predicate::str::contains("main worktree is on 'main'"))
+        .stderr(predicate::str::contains("expected 'release/1.0'"))
+        .stderr(predicate::str::contains("checkout target branch first"));
+
+    let release_log = git_log_oneline(&repo.path(), "release/1.0");
+    assert!(
+        !release_log.contains("Merge branch 'feature/wrong-target'"),
+        "merge commit should not exist on release branch: {release_log}"
+    );
+    assert_branch_exists(&repo.path(), "feature/wrong-target");
+}
+
+#[test]
+fn merge_into_refuses_source_equal_destination() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/self", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/self",
+            "--into",
+            "feature/self",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(4)
+        .stderr(predicate::str::contains(
+            "refusing to merge a branch into itself",
+        ));
+
+    assert_branch_exists(&repo.path(), "feature/self");
 }
 
 // ── Branch resolution ───────────────────────────────────────────────

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -487,6 +487,54 @@ fn merge_auto_detects_mainline() {
         .stdout(predicate::str::contains("into main"));
 }
 
+#[test]
+fn merge_into_checked_out_non_mainline_branch() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    run_git(&["checkout", "-b", "release/1.0"], &repo.path());
+    run_git(&["checkout", "main"], &repo.path());
+
+    wt_core()
+        .args(["add", "feature/release-fix", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let wt_dir = find_worktree_dir(&repo.path(), "feature-release-fix");
+    commit_file(&wt_dir, "fix.txt", "release fix", "add release fix");
+
+    run_git(&["checkout", "release/1.0"], &repo.path());
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/release-fix",
+            "--into",
+            "release/1.0",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Merged 'feature/release-fix' into release/1.0",
+        ));
+
+    let release_log = git_log_oneline(&repo.path(), "release/1.0");
+    assert!(
+        release_log.contains("Merge branch 'feature/release-fix'"),
+        "merge commit should exist on release branch: {release_log}"
+    );
+
+    let main_log = git_log_oneline(&repo.path(), "main");
+    assert!(
+        !main_log.contains("Merge branch 'feature/release-fix'"),
+        "merge commit should not exist on main: {main_log}"
+    );
+
+    run_git(&["checkout", "main"], &repo.path());
+}
+
 // ── Branch resolution ───────────────────────────────────────────────
 
 #[test]

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -437,6 +437,52 @@ fn merge_json_no_cleanup_shows_false() {
     );
 }
 
+#[test]
+fn merge_json_into_reports_destination_branch() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    run_git(&["checkout", "-b", "release/json"], &repo.path());
+    run_git(&["checkout", "main"], &repo.path());
+
+    wt_core()
+        .args(["add", "feature/json-release", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let wt_dir = find_worktree_dir(&repo.path(), "feature-json-release");
+    commit_file(&wt_dir, "json-release.txt", "json release", "json release");
+
+    run_git(&["checkout", "release/json"], &repo.path());
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/json-release",
+            "--into",
+            "release/json",
+            "--repo",
+            &repo_str,
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["branch"], "feature/json-release");
+    assert_eq!(json["mainline"], "release/json");
+    assert_eq!(
+        json["message"],
+        "merged 'feature/json-release' into release/json"
+    );
+
+    run_git(&["checkout", "main"], &repo.path());
+}
+
 // ── Print-paths output tests ────────────────────────────────────────
 
 #[test]
@@ -495,6 +541,54 @@ fn merge_print_paths_returns_six_lines() {
 
     // Line 6: pushed
     assert_eq!(lines[5], "false");
+}
+
+#[test]
+fn merge_print_paths_into_reports_destination_branch() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    run_git(&["checkout", "-b", "release/paths"], &repo.path());
+    run_git(&["checkout", "main"], &repo.path());
+
+    wt_core()
+        .args(["add", "feature/paths-release", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let wt_dir = find_worktree_dir(&repo.path(), "feature-paths-release");
+    commit_file(
+        &wt_dir,
+        "paths-release.txt",
+        "paths release",
+        "paths release",
+    );
+
+    run_git(&["checkout", "release/paths"], &repo.path());
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/paths-release",
+            "--into",
+            "release/paths",
+            "--repo",
+            &repo_str,
+            "--print-paths",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("invalid utf8");
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 6, "expected 6 lines: {stdout}");
+    assert_eq!(lines[1], "feature/paths-release");
+    assert_eq!(lines[2], "release/paths");
+
+    run_git(&["checkout", "main"], &repo.path());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `wt merge --into <branch>` to target a checked-out non-mainline destination branch
- keep default auto-detected mainline behavior unchanged when `--into` is omitted
- update merge output/docs and add integration coverage for a release-branch merge flow

Closes #60.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --test cli_merge`
- pre-commit hook: full `cargo test` and `ast-grep scan`
