### PR TITLE
Add materialize command for detached checkouts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,6 +134,54 @@ pub enum Command {
         print_paths: bool,
     },
 
+    /// Materialize an explicit detached checkout at a workspace path
+    ///
+    /// Creates a clean detached checkout for a full commit SHA at an explicit
+    /// absolute --workspace-root. When --cache-root is provided, wt-core keeps
+    /// a conservative bare mirror cache under <cache-root>/<safe-repo-key>.git
+    /// and serializes refreshes per repository. When --object-source is
+    /// provided, it is treated as a read-only bare repository and takes
+    /// precedence over cache use. JSON output includes repository,
+    /// workspace_path, cache_path, requested_ref, requested_sha,
+    /// resolved_commit, mode, cache_status, source, and timings_ms.
+    Materialize {
+        /// Relative owner/repository-style repository slug
+        #[arg(long)]
+        repo_slug: String,
+
+        /// Remote repository URL used for fetching or cache population
+        #[arg(long)]
+        remote_url: Option<String>,
+
+        /// Ref used as fetch/reachability context
+        #[arg(long = "ref")]
+        ref_: Option<String>,
+
+        /// Full 40-character commit SHA to check out
+        #[arg(long)]
+        sha: String,
+
+        /// Absolute directory containing wt-core bare mirror caches
+        #[arg(long)]
+        cache_root: Option<PathBuf>,
+
+        /// Absolute path where the detached workspace will be created
+        #[arg(long)]
+        workspace_root: PathBuf,
+
+        /// Absolute path to a read-only bare repository used as an object source
+        #[arg(long)]
+        object_source: Option<PathBuf>,
+
+        /// Checkout mode; only detached is supported in this version
+        #[arg(long, value_enum, default_value_t = MaterializeMode::Detached)]
+        mode: MaterializeMode,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Open a difftool for a worktree branch or dirty worktree changes
     Diff {
         /// Branch name of the worktree to diff
@@ -230,6 +278,11 @@ pub enum Shell {
     Zsh,
     Fish,
     Nu,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MaterializeMode {
+    Detached,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,15 +1,15 @@
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
-use crate::cli::{Cli, ColorChoice, Command, Shell};
+use crate::cli::{Cli, ColorChoice, Command, MaterializeMode, Shell};
 use crate::domain::{self, BranchName, WorktreeStatsStatus};
 use crate::error::{AppError, Result};
 use crate::git;
 use crate::output::{
-    find_current_worktree, print_json, JsonDoctorResponse, JsonListResponse, JsonMergeResponse,
-    JsonPruneDryRunEntry, JsonPruneDryRunResponse, JsonPruneExecuteResponse, JsonPrunedEntry,
-    JsonResponse, JsonSkippedEntry, MergeFormat, NavigationFormat, PruneFormat, RemoveFormat,
-    StatusFormat,
+    find_current_worktree, print_json, JsonDoctorResponse, JsonListResponse,
+    JsonMaterializeResponse, JsonMaterializeTimings, JsonMergeResponse, JsonPruneDryRunEntry,
+    JsonPruneDryRunResponse, JsonPruneExecuteResponse, JsonPrunedEntry, JsonResponse,
+    JsonSkippedEntry, MergeFormat, NavigationFormat, PruneFormat, RemoveFormat, StatusFormat,
 };
 use crate::worktree;
 use unicode_width::UnicodeWidthStr;
@@ -74,6 +74,29 @@ pub fn run(cli: Cli) -> Result<()> {
             no_cleanup,
             repo,
             merge_fmt(json, print_paths),
+        ),
+        Command::Materialize {
+            repo_slug,
+            remote_url,
+            ref_,
+            sha,
+            cache_root,
+            workspace_root,
+            object_source,
+            mode,
+            json,
+        } => cmd_materialize(
+            crate::materialize::MaterializeOptions {
+                repo_slug,
+                remote_url,
+                ref_name: ref_,
+                sha,
+                cache_root,
+                workspace_root,
+                object_source,
+                mode,
+            },
+            json,
         ),
         Command::Diff {
             branch,
@@ -162,6 +185,44 @@ fn resolve_repo(repo: Option<PathBuf>) -> Result<domain::RepoRoot> {
 }
 
 // ── Commands ────────────────────────────────────────────────────────
+
+fn cmd_materialize(options: crate::materialize::MaterializeOptions, json: bool) -> Result<()> {
+    if options.mode != MaterializeMode::Detached {
+        return Err(AppError::usage(
+            "only detached materialize mode is supported".to_string(),
+        ));
+    }
+
+    let result = crate::materialize::materialize(options)?;
+    if json {
+        print_json(&JsonMaterializeResponse {
+            ok: true,
+            repository: result.repository,
+            workspace_path: result.workspace_path.display().to_string(),
+            cache_path: result.cache_path.map(|p| p.display().to_string()),
+            requested_ref: result.requested_ref,
+            requested_sha: result.requested_sha,
+            resolved_commit: result.resolved_commit,
+            mode: result.mode.to_string(),
+            cache_status: result.cache_status.to_string(),
+            source: result.source.to_string(),
+            timings_ms: JsonMaterializeTimings {
+                cache_lock: result.timings.cache_lock,
+                cache_refresh: result.timings.cache_refresh,
+                workspace_checkout: result.timings.workspace_checkout,
+                total: result.timings.total,
+            },
+        })?;
+    } else {
+        println!(
+            "Materialized {} at {} ({})",
+            result.resolved_commit,
+            result.workspace_path.display(),
+            result.mode
+        );
+    }
+    Ok(())
+}
 
 fn cmd_list(
     repo: Option<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod commands;
 mod domain;
 mod error;
 mod git;
+mod materialize;
 mod output;
 mod symlinks;
 mod worktree;

--- a/src/materialize.rs
+++ b/src/materialize.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use crate::cli::MaterializeMode;
+use crate::error::{AppError, Result};
+
+#[derive(Debug)]
+pub struct MaterializeOptions {
+    pub repo_slug: String,
+    pub remote_url: Option<String>,
+    pub ref_name: Option<String>,
+    pub sha: String,
+    pub cache_root: Option<PathBuf>,
+    pub workspace_root: PathBuf,
+    pub object_source: Option<PathBuf>,
+    pub mode: MaterializeMode,
+}
+
+#[derive(Debug)]
+pub struct MaterializeResult {
+    pub repository: String,
+    pub workspace_path: PathBuf,
+    pub cache_path: Option<PathBuf>,
+    pub requested_ref: Option<String>,
+    pub requested_sha: String,
+    pub resolved_commit: String,
+    pub mode: &'static str,
+    pub cache_status: &'static str,
+    pub source: &'static str,
+    pub timings: MaterializeTimings,
+}
+
+#[derive(Debug, Default)]
+pub struct MaterializeTimings {
+    pub cache_lock: u64,
+    pub cache_refresh: u64,
+    pub workspace_checkout: u64,
+    pub total: u64,
+}
+
+pub fn materialize(options: MaterializeOptions) -> Result<MaterializeResult> {
+    let MaterializeOptions {
+        repo_slug,
+        remote_url,
+        ref_name,
+        sha,
+        cache_root,
+        workspace_root,
+        object_source,
+        mode: _,
+    } = options;
+    let _ = (
+        repo_slug,
+        remote_url,
+        ref_name,
+        sha,
+        cache_root,
+        workspace_root,
+        object_source,
+    );
+
+    Err(AppError::usage(
+        "materialize is not implemented in this build".to_string(),
+    ))
+}

--- a/src/materialize.rs
+++ b/src/materialize.rs
@@ -1,7 +1,24 @@
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::cli::MaterializeMode;
 use crate::error::{AppError, Result};
+
+const CACHE_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+const CACHE_LOCK_RETRY: Duration = Duration::from_millis(50);
+const GIT_ENV_OVERRIDES: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_PREFIX",
+];
 
 #[derive(Debug)]
 pub struct MaterializeOptions {
@@ -37,28 +54,651 @@ pub struct MaterializeTimings {
     pub total: u64,
 }
 
-pub fn materialize(options: MaterializeOptions) -> Result<MaterializeResult> {
-    let MaterializeOptions {
-        repo_slug,
-        remote_url,
-        ref_name,
-        sha,
-        cache_root,
-        workspace_root,
-        object_source,
-        mode: _,
-    } = options;
-    let _ = (
-        repo_slug,
-        remote_url,
-        ref_name,
-        sha,
-        cache_root,
-        workspace_root,
-        object_source,
-    );
+struct ValidatedOptions {
+    repo_slug: String,
+    remote_url: Option<String>,
+    ref_name: Option<String>,
+    sha: String,
+    cache_root: Option<PathBuf>,
+    workspace_root: PathBuf,
+    object_source: Option<PathBuf>,
+}
 
+struct CacheLock {
+    path: PathBuf,
+}
+
+impl Drop for CacheLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+impl CacheLock {
+    fn acquire(path: &Path) -> Result<Self> {
+        let started = Instant::now();
+        loop {
+            match fs::create_dir(path) {
+                Ok(()) => {
+                    return Ok(Self {
+                        path: path.to_path_buf(),
+                    });
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                    if started.elapsed() >= CACHE_LOCK_TIMEOUT {
+                        return Err(AppError::conflict(format!(
+                            "timed out waiting for cache lock {}",
+                            path.display()
+                        )));
+                    }
+                    thread::sleep(CACHE_LOCK_RETRY);
+                }
+                Err(e) => {
+                    return Err(AppError::git(format!(
+                        "failed to acquire cache lock {}: {e}",
+                        path.display()
+                    )));
+                }
+            }
+        }
+    }
+}
+
+pub fn materialize(options: MaterializeOptions) -> Result<MaterializeResult> {
+    let started = Instant::now();
+    let request = validate_options(options)?;
+    ensure_workspace_available(&request.workspace_root)?;
+
+    let mut timings = MaterializeTimings::default();
+    let cache_path = request
+        .cache_root
+        .as_ref()
+        .map(|root| root.join(format!("{}.git", safe_repo_key(&request.repo_slug))));
+
+    let source_result = materialize_from_best_source(&request, &cache_path, &mut timings)?;
+    let resolved_commit = verify_workspace(&request.workspace_root, &request.sha)?;
+    timings.total = elapsed_ms(started);
+
+    Ok(MaterializeResult {
+        repository: request.repo_slug,
+        workspace_path: request.workspace_root,
+        cache_path,
+        requested_ref: request.ref_name,
+        requested_sha: request.sha,
+        resolved_commit,
+        mode: "detached",
+        cache_status: source_result.cache_status,
+        source: source_result.source,
+        timings,
+    })
+}
+
+struct SourceResult {
+    cache_status: &'static str,
+    source: &'static str,
+}
+
+fn materialize_from_best_source(
+    request: &ValidatedOptions,
+    cache_path: &Option<PathBuf>,
+    timings: &mut MaterializeTimings,
+) -> Result<SourceResult> {
+    if let Some(source) = &request.object_source {
+        materialize_from_object_source(source, request, timings)?;
+        return Ok(SourceResult {
+            cache_status: "bypassed",
+            source: "object_source",
+        });
+    }
+
+    if let Some(cache_path) = cache_path {
+        let cache_status = materialize_from_cache(cache_path, request, timings)?;
+        return Ok(SourceResult {
+            cache_status,
+            source: "cache",
+        });
+    }
+
+    materialize_from_remote(request, timings)?;
+    Ok(SourceResult {
+        cache_status: "bypassed",
+        source: "remote",
+    })
+}
+
+fn materialize_from_object_source(
+    source: &Path,
+    request: &ValidatedOptions,
+    timings: &mut MaterializeTimings,
+) -> Result<()> {
+    verify_bare_repo(source)?;
+    verify_commit_exists(source, &request.sha)?;
+    let started = Instant::now();
+    clone_local_bare(source, &request.workspace_root, &request.sha)?;
+    timings.workspace_checkout = elapsed_ms(started);
+    Ok(())
+}
+
+fn materialize_from_cache(
+    cache_path: &Path,
+    request: &ValidatedOptions,
+    timings: &mut MaterializeTimings,
+) -> Result<&'static str> {
+    let remote_url = request
+        .remote_url
+        .as_deref()
+        .ok_or_else(|| AppError::usage("--remote-url is required without --object-source"))?;
+    let cache_root = request
+        .cache_root
+        .as_ref()
+        .ok_or_else(|| AppError::invariant("cache path exists without cache root"))?;
+
+    create_dir_all(cache_root, "cache root")?;
+    let lock_path = cache_path.with_extension("git.lock");
+    let lock_started = Instant::now();
+    let _lock = CacheLock::acquire(&lock_path)?;
+    timings.cache_lock = elapsed_ms(lock_started);
+
+    let refresh_started = Instant::now();
+    let cache_status = refresh_cache(cache_path, remote_url)?;
+    timings.cache_refresh = elapsed_ms(refresh_started);
+
+    verify_commit_exists(cache_path, &request.sha)?;
+    let checkout_started = Instant::now();
+    clone_local_bare(cache_path, &request.workspace_root, &request.sha)?;
+    timings.workspace_checkout = elapsed_ms(checkout_started);
+    Ok(cache_status)
+}
+
+fn materialize_from_remote(
+    request: &ValidatedOptions,
+    timings: &mut MaterializeTimings,
+) -> Result<()> {
+    let remote_url = request
+        .remote_url
+        .as_deref()
+        .ok_or_else(|| AppError::usage("--remote-url is required without --object-source"))?;
+    let started = Instant::now();
+    checkout_from_remote(
+        remote_url,
+        request.ref_name.as_deref(),
+        &request.workspace_root,
+        &request.sha,
+    )?;
+    timings.workspace_checkout = elapsed_ms(started);
+    Ok(())
+}
+
+fn validate_options(options: MaterializeOptions) -> Result<ValidatedOptions> {
+    if options.mode != MaterializeMode::Detached {
+        return Err(AppError::usage(
+            "only detached materialize mode is supported".to_string(),
+        ));
+    }
+
+    let repo_slug = validate_repo_slug(&options.repo_slug)?;
+    validate_optional_remote(options.remote_url.as_deref())?;
+    validate_optional_ref(options.ref_name.as_deref())?;
+    validate_sha(&options.sha)?;
+    validate_absolute_path(&options.workspace_root, "--workspace-root")?;
+    validate_optional_absolute_path(options.cache_root.as_deref(), "--cache-root")?;
+    validate_optional_absolute_path(options.object_source.as_deref(), "--object-source")?;
+
+    if options.object_source.is_none() && options.remote_url.is_none() {
+        return Err(AppError::usage(
+            "--remote-url is required unless --object-source is provided".to_string(),
+        ));
+    }
+
+    Ok(ValidatedOptions {
+        repo_slug,
+        remote_url: options.remote_url,
+        ref_name: options.ref_name,
+        sha: options.sha,
+        cache_root: options.cache_root,
+        workspace_root: options.workspace_root,
+        object_source: options.object_source,
+    })
+}
+
+fn validate_repo_slug(slug: &str) -> Result<String> {
+    if slug.is_empty() || Path::new(slug).is_absolute() || slug_contains_control(slug) {
+        return Err(AppError::usage("invalid --repo-slug".to_string()));
+    }
+
+    let segments: Vec<&str> = slug.split('/').collect();
+    if segments.len() < 2 || segments.iter().any(invalid_slug_segment) {
+        return Err(AppError::usage("invalid --repo-slug".to_string()));
+    }
+
+    Ok(slug.to_string())
+}
+
+fn invalid_slug_segment(segment: &&str) -> bool {
+    segment.is_empty() || *segment == "." || *segment == ".." || segment.contains('\\')
+}
+
+fn slug_contains_control(slug: &str) -> bool {
+    slug.chars().any(char::is_control)
+}
+
+fn validate_optional_remote(remote_url: Option<&str>) -> Result<()> {
+    match remote_url {
+        Some(url) => validate_remote_url(url),
+        None => Ok(()),
+    }
+}
+
+fn validate_remote_url(url: &str) -> Result<()> {
+    if url.is_empty() || url.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return Err(AppError::usage("invalid --remote-url".to_string()));
+    }
+
+    if !has_supported_scheme(url) {
+        return Err(AppError::usage(
+            "unsupported --remote-url scheme; use https, http, ssh, git, or file".to_string(),
+        ));
+    }
+
+    if has_credential_userinfo(url) || has_credential_query(url) {
+        return Err(AppError::usage(
+            "--remote-url must not include credentials".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn has_supported_scheme(url: &str) -> bool {
+    ["https://", "http://", "ssh://", "git://", "file://"]
+        .iter()
+        .any(|scheme| url.starts_with(scheme))
+}
+
+fn has_credential_userinfo(url: &str) -> bool {
+    let Some((_, rest)) = url.split_once("://") else {
+        return false;
+    };
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .map(str::to_string)
+        .unwrap_or_default();
+    !authority.is_empty() && authority.contains('@')
+}
+
+fn has_credential_query(url: &str) -> bool {
+    let Some((_, after_query)) = url.split_once('?') else {
+        return false;
+    };
+    after_query
+        .split('#')
+        .next()
+        .unwrap_or_default()
+        .split('&')
+        .any(query_param_is_credential)
+}
+
+fn query_param_is_credential(param: &str) -> bool {
+    let key = param
+        .split('=')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    [
+        "token",
+        "password",
+        "secret",
+        "credential",
+        "access_key",
+        "private_key",
+        "auth",
+    ]
+    .iter()
+    .any(|needle| key.contains(needle))
+}
+
+fn validate_optional_ref(ref_name: Option<&str>) -> Result<()> {
+    match ref_name {
+        Some(name) => validate_ref(name),
+        None => Ok(()),
+    }
+}
+
+fn validate_ref(ref_name: &str) -> Result<()> {
+    if ref_name.is_empty() || ref_name.starts_with('-') || ref_name.starts_with('/') {
+        return Err(AppError::usage("invalid --ref".to_string()));
+    }
+
+    if ref_name.ends_with('/') || ref_name.ends_with(".lock") || ref_name.contains("//") {
+        return Err(AppError::usage("invalid --ref".to_string()));
+    }
+
+    if ref_name.contains("..") || ref_name.contains("@{") || ref_name.contains('\\') {
+        return Err(AppError::usage("invalid --ref".to_string()));
+    }
+
+    if ref_name.chars().any(invalid_ref_char) || ref_name.split('/').any(invalid_ref_segment) {
+        return Err(AppError::usage("invalid --ref".to_string()));
+    }
+
+    Ok(())
+}
+
+fn invalid_ref_char(ch: char) -> bool {
+    ch.is_control() || ch.is_whitespace() || matches!(ch, ':' | '?' | '*' | '[' | '^' | '~')
+}
+
+fn invalid_ref_segment(segment: &str) -> bool {
+    segment.is_empty() || segment == "." || segment == ".." || segment.ends_with(".lock")
+}
+
+fn validate_sha(sha: &str) -> Result<()> {
+    let valid = sha.len() == 40 && sha.chars().all(|c| c.is_ascii_hexdigit());
+    if valid {
+        return Ok(());
+    }
     Err(AppError::usage(
-        "materialize is not implemented in this build".to_string(),
+        "--sha must be a full 40-character hexadecimal commit SHA".to_string(),
     ))
+}
+
+fn validate_optional_absolute_path(path: Option<&Path>, flag: &str) -> Result<()> {
+    match path {
+        Some(path) => validate_absolute_path(path, flag),
+        None => Ok(()),
+    }
+}
+
+fn validate_absolute_path(path: &Path, flag: &str) -> Result<()> {
+    if path.is_absolute() {
+        return Ok(());
+    }
+    Err(AppError::usage(format!("{flag} must be an absolute path")))
+}
+
+fn ensure_workspace_available(path: &Path) -> Result<()> {
+    if path.exists() {
+        return ensure_existing_workspace_available(path);
+    }
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| AppError::usage("--workspace-root has no parent directory"))?;
+    create_dir_all(parent, "workspace parent")
+}
+
+fn ensure_existing_workspace_available(path: &Path) -> Result<()> {
+    if !path.is_dir() {
+        return Err(AppError::conflict(format!(
+            "workspace path exists and is not a directory: {}",
+            path.display()
+        )));
+    }
+
+    let mut entries = fs::read_dir(path).map_err(|e| {
+        AppError::conflict(format!(
+            "cannot inspect workspace path {}: {e}",
+            path.display()
+        ))
+    })?;
+    match entries.next() {
+        Some(Ok(_)) | Some(Err(_)) => Err(AppError::conflict(format!(
+            "workspace path already exists and is not empty: {}",
+            path.display()
+        ))),
+        None => Ok(()),
+    }
+}
+
+fn refresh_cache(cache_path: &Path, remote_url: &str) -> Result<&'static str> {
+    if cache_path.exists() {
+        refresh_existing_cache(cache_path, remote_url)?;
+        return Ok("refreshed");
+    }
+
+    let parent = cache_path
+        .parent()
+        .ok_or_else(|| AppError::invariant("cache path has no parent"))?;
+    create_dir_all(parent, "cache parent")?;
+    run_git_owned(
+        vec![
+            os("clone"),
+            os("--mirror"),
+            os(remote_url),
+            cache_path.as_os_str().to_os_string(),
+        ],
+        None,
+    )?;
+    Ok("cold")
+}
+
+fn refresh_existing_cache(cache_path: &Path, remote_url: &str) -> Result<()> {
+    if !cache_path.is_dir() {
+        return Err(AppError::conflict(format!(
+            "cache path exists and is not a directory: {}",
+            cache_path.display()
+        )));
+    }
+
+    verify_bare_repo(cache_path)?;
+    run_git_owned(
+        vec![
+            os("--git-dir"),
+            cache_path.as_os_str().to_os_string(),
+            os("remote"),
+            os("set-url"),
+            os("origin"),
+            os(remote_url),
+        ],
+        None,
+    )?;
+    run_git_owned(
+        vec![
+            os("--git-dir"),
+            cache_path.as_os_str().to_os_string(),
+            os("fetch"),
+            os("--prune"),
+            os("origin"),
+            os("+refs/heads/*:refs/heads/*"),
+            os("+refs/tags/*:refs/tags/*"),
+        ],
+        None,
+    )?;
+    Ok(())
+}
+
+fn verify_bare_repo(path: &Path) -> Result<()> {
+    if !path.is_dir() {
+        return Err(AppError::usage(format!(
+            "bare repository path does not exist: {}",
+            path.display()
+        )));
+    }
+
+    let output = run_git_owned(
+        vec![
+            os("--git-dir"),
+            path.as_os_str().to_os_string(),
+            os("rev-parse"),
+            os("--is-bare-repository"),
+        ],
+        None,
+    )?;
+    if output == "true" {
+        return Ok(());
+    }
+
+    Err(AppError::usage(format!(
+        "path is not a bare Git repository: {}",
+        path.display()
+    )))
+}
+
+fn verify_commit_exists(git_dir: &Path, sha: &str) -> Result<()> {
+    run_git_owned(
+        vec![
+            os("--git-dir"),
+            git_dir.as_os_str().to_os_string(),
+            os("cat-file"),
+            os("-e"),
+            os(format!("{sha}^{{commit}}")),
+        ],
+        None,
+    )?;
+    Ok(())
+}
+
+fn clone_local_bare(source: &Path, workspace: &Path, sha: &str) -> Result<()> {
+    create_workspace_parent(workspace)?;
+    run_git_owned(
+        vec![
+            os("clone"),
+            os("--no-local"),
+            os("--no-checkout"),
+            source.as_os_str().to_os_string(),
+            workspace.as_os_str().to_os_string(),
+        ],
+        None,
+    )?;
+    checkout_detached(workspace, sha)
+}
+
+fn checkout_from_remote(
+    remote_url: &str,
+    ref_name: Option<&str>,
+    workspace: &Path,
+    sha: &str,
+) -> Result<()> {
+    create_dir_all(workspace, "workspace")?;
+    run_git_owned(vec![os("init")], Some(workspace))?;
+    run_git_owned(
+        vec![os("remote"), os("add"), os("origin"), os(remote_url)],
+        Some(workspace),
+    )?;
+    let fetch_target = ref_name.unwrap_or(sha);
+    run_git_owned(
+        vec![os("fetch"), os("origin"), os(fetch_target)],
+        Some(workspace),
+    )?;
+    checkout_detached(workspace, sha)
+}
+
+fn checkout_detached(workspace: &Path, sha: &str) -> Result<()> {
+    run_git_owned(
+        vec![os("checkout"), os("--detach"), os(sha)],
+        Some(workspace),
+    )?;
+    Ok(())
+}
+
+fn verify_workspace(workspace: &Path, sha: &str) -> Result<String> {
+    let head = run_git_owned(vec![os("rev-parse"), os("HEAD")], Some(workspace))?;
+    if head != sha {
+        return Err(AppError::invariant(format!(
+            "materialized HEAD {} did not match requested SHA {}",
+            head, sha
+        )));
+    }
+
+    let status = run_git_owned(vec![os("status"), os("--porcelain")], Some(workspace))?;
+    if !status.is_empty() {
+        return Err(AppError::conflict(
+            "materialized workspace is not clean".to_string(),
+        ));
+    }
+
+    if run_git_success(
+        vec![os("symbolic-ref"), os("-q"), os("HEAD")],
+        Some(workspace),
+    ) {
+        return Err(AppError::invariant(
+            "materialized workspace is not detached".to_string(),
+        ));
+    }
+
+    Ok(head)
+}
+
+fn run_git_owned(args: Vec<OsString>, cwd: Option<&Path>) -> Result<String> {
+    let mut command = Command::new("git");
+    command.args(args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    clear_git_env(&mut command);
+
+    let output = command
+        .output()
+        .map_err(|e| AppError::git(format!("failed to run git: {e}")))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    Err(AppError::git(redact_credentials(&stderr)))
+}
+
+fn run_git_success(args: Vec<OsString>, cwd: Option<&Path>) -> bool {
+    let mut command = Command::new("git");
+    command.args(args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    clear_git_env(&mut command);
+    command
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn clear_git_env(command: &mut Command) {
+    for var in GIT_ENV_OVERRIDES {
+        command.env_remove(var);
+    }
+}
+
+fn redact_credentials(message: &str) -> String {
+    message
+        .replace("gho_", "<redacted>_")
+        .replace("token=", "token=<redacted>")
+        .replace("access_token=", "access_token=<redacted>")
+        .replace("password=", "password=<redacted>")
+}
+
+fn create_workspace_parent(workspace: &Path) -> Result<()> {
+    let parent = workspace
+        .parent()
+        .ok_or_else(|| AppError::usage("--workspace-root has no parent directory"))?;
+    create_dir_all(parent, "workspace parent")
+}
+
+fn create_dir_all(path: &Path, label: &str) -> Result<()> {
+    fs::create_dir_all(path)
+        .map_err(|e| AppError::git(format!("failed to create {label} {}: {e}", path.display())))
+}
+
+fn safe_repo_key(slug: &str) -> String {
+    slug.split('/')
+        .map(safe_repo_segment)
+        .collect::<Vec<String>>()
+        .join("__")
+}
+
+fn safe_repo_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '_' | '-' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+fn os(value: impl Into<OsString>) -> OsString {
+    value.into()
 }

--- a/src/materialize.rs
+++ b/src/materialize.rs
@@ -267,7 +267,7 @@ fn validate_repo_slug(slug: &str) -> Result<String> {
     }
 
     let segments: Vec<&str> = slug.split('/').collect();
-    if segments.len() < 2 || segments.iter().any(invalid_slug_segment) {
+    if segments.len() != 2 || segments.iter().any(invalid_slug_segment) {
         return Err(AppError::usage("invalid --repo-slug".to_string()));
     }
 
@@ -275,7 +275,12 @@ fn validate_repo_slug(slug: &str) -> Result<String> {
 }
 
 fn invalid_slug_segment(segment: &&str) -> bool {
-    segment.is_empty() || *segment == "." || *segment == ".." || segment.contains('\\')
+    segment.is_empty()
+        || *segment == "."
+        || *segment == ".."
+        || !segment
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
 }
 
 fn slug_contains_control(slug: &str) -> bool {

--- a/src/materialize.rs
+++ b/src/materialize.rs
@@ -395,7 +395,13 @@ fn invalid_ref_char(ch: char) -> bool {
 }
 
 fn invalid_ref_segment(segment: &str) -> bool {
-    segment.is_empty() || segment == "." || segment == ".." || segment.ends_with(".lock")
+    segment.is_empty()
+        || segment == "."
+        || segment == ".."
+        || segment == "@"
+        || segment.starts_with('.')
+        || segment.ends_with('.')
+        || segment.ends_with(".lock")
 }
 
 fn validate_sha(sha: &str) -> Result<()> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -356,6 +356,32 @@ pub struct JsonMergeResponse {
     pub pushed: bool,
 }
 
+/// JSON response for the materialize command.
+#[derive(Debug, Serialize)]
+pub struct JsonMaterializeResponse {
+    pub ok: bool,
+    pub repository: String,
+    pub workspace_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_ref: Option<String>,
+    pub requested_sha: String,
+    pub resolved_commit: String,
+    pub mode: String,
+    pub cache_status: String,
+    pub source: String,
+    pub timings_ms: JsonMaterializeTimings,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonMaterializeTimings {
+    pub cache_lock: u64,
+    pub cache_refresh: u64,
+    pub workspace_checkout: u64,
+    pub total: u64,
+}
+
 /// JSON response for the setup command.
 #[derive(Debug, Serialize)]
 pub struct JsonSetupResponse {

--- a/tests/cli_materialize.rs
+++ b/tests/cli_materialize.rs
@@ -1,0 +1,303 @@
+mod fixtures;
+
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+const GIT_ENV_OVERRIDES: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_PREFIX",
+];
+
+fn wt_core() -> Command {
+    Command::new(assert_cmd::cargo_bin!("wt-core"))
+}
+
+fn git_output(args: &[&str], cwd: &Path) -> String {
+    let output = git_command(args, cwd).output().expect("failed to run git");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git stdout was not utf8")
+        .trim()
+        .to_string()
+}
+
+fn git_success(args: &[&str], cwd: &Path) -> bool {
+    git_command(args, cwd)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn git_command(args: &[&str], cwd: &Path) -> StdCommand {
+    let mut command = StdCommand::new("git");
+    command.args(args).current_dir(cwd);
+    for var in GIT_ENV_OVERRIDES {
+        command.env_remove(var);
+    }
+    command
+}
+
+fn file_url(path: &Path) -> String {
+    format!("file://{}", path.display())
+}
+
+fn materialize_cached(
+    repo: &fixtures::ClonedTestRepo,
+    sha: &str,
+    cache_root: &Path,
+    workspace_root: &Path,
+) -> serde_json::Value {
+    let output = wt_core()
+        .arg("materialize")
+        .arg("--repo-slug")
+        .arg("owner/repo")
+        .arg("--remote-url")
+        .arg(file_url(&repo.origin_path()))
+        .arg("--ref")
+        .arg("refs/heads/main")
+        .arg("--sha")
+        .arg(sha)
+        .arg("--cache-root")
+        .arg(cache_root)
+        .arg("--workspace-root")
+        .arg(workspace_root)
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    serde_json::from_slice(&output).expect("invalid materialize json")
+}
+
+#[test]
+fn materialize_help_documents_contract() {
+    wt_core()
+        .args(["materialize", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("detached checkout"))
+        .stdout(predicate::str::contains("bare mirror cache"))
+        .stdout(predicate::str::contains("JSON output"))
+        .stdout(predicate::str::contains("--object-source"));
+}
+
+#[test]
+fn materialize_remote_with_cache_json_creates_detached_clean_workspace() {
+    let repo = fixtures::ClonedTestRepo::new();
+    let sha = git_output(&["rev-parse", "HEAD"], &repo.path());
+    let root = tempfile::tempdir().expect("temp dir");
+    let cache_root = root.path().join("cache");
+    let workspace_one = root.path().join("workspace-one");
+    let workspace_two = root.path().join("workspace-two");
+
+    let first = materialize_cached(&repo, &sha, &cache_root, &workspace_one);
+    assert_eq!(first["ok"], true);
+    assert_eq!(first["repository"], "owner/repo");
+    assert_eq!(first["workspace_path"], workspace_one.display().to_string());
+    assert_eq!(
+        first["cache_path"],
+        cache_root.join("owner__repo.git").display().to_string()
+    );
+    assert_eq!(first["requested_ref"], "refs/heads/main");
+    assert_eq!(first["requested_sha"], sha);
+    assert_eq!(first["resolved_commit"], sha);
+    assert_eq!(first["mode"], "detached");
+    assert_eq!(first["cache_status"], "cold");
+    assert_eq!(first["source"], "cache");
+    assert!(first["timings_ms"]["total"].is_number());
+
+    let second = materialize_cached(&repo, &sha, &cache_root, &workspace_two);
+    assert_eq!(second["cache_status"], "refreshed");
+    assert!(cache_root.join("owner__repo.git").is_dir());
+
+    assert_eq!(git_output(&["rev-parse", "HEAD"], &workspace_one), sha);
+    assert_eq!(git_output(&["status", "--porcelain"], &workspace_one), "");
+    assert!(!git_success(
+        &["symbolic-ref", "-q", "HEAD"],
+        &workspace_one
+    ));
+}
+
+#[test]
+fn materialize_from_object_source_without_permanent_alternates() {
+    let repo = fixtures::ClonedTestRepo::new();
+    let sha = git_output(&["rev-parse", "HEAD"], &repo.path());
+    let root = tempfile::tempdir().expect("temp dir");
+    let workspace = root.path().join("workspace");
+
+    let output = wt_core()
+        .arg("materialize")
+        .arg("--repo-slug")
+        .arg("owner/repo")
+        .arg("--object-source")
+        .arg(repo.origin_path())
+        .arg("--sha")
+        .arg(&sha)
+        .arg("--workspace-root")
+        .arg(&workspace)
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["source"], "object_source");
+    assert_eq!(json["cache_status"], "bypassed");
+    assert_eq!(git_output(&["rev-parse", "HEAD"], &workspace), sha);
+    assert!(!workspace.join(".git/objects/info/alternates").exists());
+}
+
+#[test]
+fn materialize_rejects_existing_non_empty_workspace() {
+    let repo = fixtures::ClonedTestRepo::new();
+    let sha = git_output(&["rev-parse", "HEAD"], &repo.path());
+    let root = tempfile::tempdir().expect("temp dir");
+    let workspace = root.path().join("workspace");
+    std::fs::create_dir(&workspace).expect("create workspace");
+    std::fs::write(workspace.join("file.txt"), "occupied").expect("write file");
+
+    wt_core()
+        .arg("materialize")
+        .arg("--repo-slug")
+        .arg("owner/repo")
+        .arg("--object-source")
+        .arg(repo.origin_path())
+        .arg("--sha")
+        .arg(sha)
+        .arg("--workspace-root")
+        .arg(workspace)
+        .assert()
+        .failure()
+        .code(5)
+        .stderr(predicate::str::contains("not empty"));
+}
+
+#[test]
+fn materialize_rejects_invalid_sha_and_unsafe_ref_before_git() {
+    let repo = fixtures::ClonedTestRepo::new();
+    let sha = git_output(&["rev-parse", "HEAD"], &repo.path());
+    let root = tempfile::tempdir().expect("temp dir");
+
+    wt_core()
+        .arg("materialize")
+        .arg("--repo-slug")
+        .arg("owner/repo")
+        .arg("--object-source")
+        .arg(repo.origin_path())
+        .arg("--sha")
+        .arg("abc123")
+        .arg("--workspace-root")
+        .arg(root.path().join("bad-sha"))
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("40-character"));
+
+    wt_core()
+        .arg("materialize")
+        .arg("--repo-slug")
+        .arg("owner/repo")
+        .arg("--remote-url")
+        .arg(file_url(&repo.origin_path()))
+        .arg("--ref")
+        .arg("refs/heads/main..evil")
+        .arg("--sha")
+        .arg(sha)
+        .arg("--workspace-root")
+        .arg(root.path().join("bad-ref"))
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("invalid --ref"));
+}
+
+#[test]
+fn materialize_rejects_credential_remote_url_without_leaking_secret() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let stderr = wt_core()
+        .arg("materialize")
+        .arg("--repo-slug")
+        .arg("owner/repo")
+        .arg("--remote-url")
+        .arg("https://user:secret@example.invalid/repo.git")
+        .arg("--sha")
+        .arg("0123456789abcdef0123456789abcdef01234567")
+        .arg("--workspace-root")
+        .arg(root.path().join("workspace"))
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("must not include credentials"))
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(stderr).expect("stderr utf8");
+    assert!(!stderr.contains("secret"));
+}
+
+#[test]
+fn concurrent_cached_materializations_share_cache_safely() {
+    let repo = fixtures::ClonedTestRepo::new();
+    let sha = git_output(&["rev-parse", "HEAD"], &repo.path());
+    let root = tempfile::tempdir().expect("temp dir");
+    let cache_root = root.path().join("cache");
+    let workspace_one = root.path().join("workspace-one");
+    let workspace_two = root.path().join("workspace-two");
+    let origin_url = file_url(&repo.origin_path());
+
+    let first = spawn_materialize(&sha, &origin_url, &cache_root, &workspace_one);
+    let second = spawn_materialize(&sha, &origin_url, &cache_root, &workspace_two);
+    first.join().expect("first thread panicked");
+    second.join().expect("second thread panicked");
+
+    assert_eq!(git_output(&["rev-parse", "HEAD"], &workspace_one), sha);
+    assert_eq!(git_output(&["rev-parse", "HEAD"], &workspace_two), sha);
+    assert!(cache_root.join("owner__repo.git").is_dir());
+}
+
+fn spawn_materialize(
+    sha: &str,
+    origin_url: &str,
+    cache_root: &Path,
+    workspace_root: &Path,
+) -> std::thread::JoinHandle<()> {
+    let sha = sha.to_string();
+    let origin_url = origin_url.to_string();
+    let cache_root = PathBuf::from(cache_root);
+    let workspace_root = PathBuf::from(workspace_root);
+
+    std::thread::spawn(move || {
+        wt_core()
+            .arg("materialize")
+            .arg("--repo-slug")
+            .arg("owner/repo")
+            .arg("--remote-url")
+            .arg(origin_url)
+            .arg("--ref")
+            .arg("refs/heads/main")
+            .arg("--sha")
+            .arg(sha)
+            .arg("--cache-root")
+            .arg(cache_root)
+            .arg("--workspace-root")
+            .arg(workspace_root)
+            .assert()
+            .success();
+    })
+}

--- a/tests/cli_materialize.rs
+++ b/tests/cli_materialize.rs
@@ -189,6 +189,29 @@ fn materialize_rejects_existing_non_empty_workspace() {
 }
 
 #[test]
+fn materialize_rejects_unsafe_repo_slugs_before_git() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let valid_sha = "0123456789abcdef0123456789abcdef01234567";
+
+    for slug in ["owner/repo/sub", "owner/re po", "owner/repo?", "../repo"] {
+        wt_core()
+            .arg("materialize")
+            .arg("--repo-slug")
+            .arg(slug)
+            .arg("--object-source")
+            .arg(root.path().join("missing.git"))
+            .arg("--sha")
+            .arg(valid_sha)
+            .arg("--workspace-root")
+            .arg(root.path().join("workspace"))
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(predicate::str::contains("invalid --repo-slug"));
+    }
+}
+
+#[test]
 fn materialize_rejects_invalid_sha_and_unsafe_ref_before_git() {
     let repo = fixtures::ClonedTestRepo::new();
     let sha = git_output(&["rev-parse", "HEAD"], &repo.path());

--- a/tests/cli_materialize.rs
+++ b/tests/cli_materialize.rs
@@ -232,22 +232,34 @@ fn materialize_rejects_invalid_sha_and_unsafe_ref_before_git() {
         .code(1)
         .stderr(predicate::str::contains("40-character"));
 
-    wt_core()
-        .arg("materialize")
-        .arg("--repo-slug")
-        .arg("owner/repo")
-        .arg("--remote-url")
-        .arg(file_url(&repo.origin_path()))
-        .arg("--ref")
-        .arg("refs/heads/main..evil")
-        .arg("--sha")
-        .arg(sha)
-        .arg("--workspace-root")
-        .arg(root.path().join("bad-ref"))
-        .assert()
-        .failure()
-        .code(1)
-        .stderr(predicate::str::contains("invalid --ref"));
+    for (ref_name, workspace_name) in [
+        ("refs/heads/main..evil", "bad-ref-dotdot"),
+        ("refs/heads/.hidden", "bad-ref-hidden"),
+        ("refs/heads/main.", "bad-ref-trailing-dot"),
+        ("@", "bad-ref-at"),
+    ] {
+        let workspace = root.path().join(workspace_name);
+        wt_core()
+            .arg("materialize")
+            .arg("--repo-slug")
+            .arg("owner/repo")
+            .arg("--remote-url")
+            .arg(file_url(&repo.origin_path()))
+            .arg("--ref")
+            .arg(ref_name)
+            .arg("--sha")
+            .arg(&sha)
+            .arg("--workspace-root")
+            .arg(&workspace)
+            .assert()
+            .failure()
+            .code(1)
+            .stderr(predicate::str::contains("invalid --ref"));
+        assert!(
+            !workspace.exists(),
+            "validation should happen before git setup"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #66.

Summary:
- Adds a new materialize subcommand for explicit detached workspace creation.
- Supports remote-backed materialization with optional bare mirror cache locking and refresh.
- Supports read-only bare object-source materialization without permanent alternates.
- Validates repo slugs, refs, full SHAs, absolute paths, workspace emptiness, and credential-bearing remote URLs.
- Adds JSON output and integration coverage for cache, object-source, validation, redaction, and concurrency.

Validation:
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test