### PR TITLE
feat: decouple worktree removal from branch cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,16 +211,13 @@ Example: branch `feature/auth` → `.worktrees/feature-auth--a1b2c3d4/`
 | `--print-cd-path` | Bare absolute path on stdout (for wrappers)  |
 | `--print-paths`   | Multi-line key values on stdout (for wrappers) |
 
-For `remove --print-paths`, the lines are `removed_path`, `repo_root`,
-`branch`, and `branch_deleted` in that order. The first three lines remain
-path/branch values; the fourth line makes preserved-branch cleanup explicit.
-
-`--json` emits one compact JSON object per line so machine consumers can parse stdout line-by-line.
-For `remove`, `worktree_removed` and `branch_deleted` explicitly report each
-lifecycle action. Prune dry-runs report `worktree_present` and
-`branch_will_be_deleted`; execute results report `worktree_removed` and
-`branch_deleted`. A preserved branch has a null prune `path` because no
-worktree remains.
+For `remove --print-paths`, the exact legacy protocol is three lines:
+`removed_path`, `repo_root`, and `branch`. This format is intentionally stable
+for already-installed shell bindings. Use `--json` when lifecycle status is
+needed: `worktree_removed` and `branch_deleted` explicitly report each action.
+Prune dry-runs report `worktree_present` and `branch_will_be_deleted`; execute
+results report `worktree_removed` and `branch_deleted`. A preserved branch has
+a null prune `path` because no worktree remains.
 
 JSON envelope example (`add`, `go`, `remove`):
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ these conventions upfront makes everything else predictable.
 
 - **Branch cleanup is the default.** `remove` and `merge` delete the local
   branch after removing the worktree (`git branch -d` by default, `-D` with
-  `--force`). This keeps the branch namespace clean.
+  `--force`). Use `remove --keep-branch` when staged integration still needs
+  the local branch, without keeping its worktree alive.
 
 - **Mainline is auto-detected.** Commands that need a mainline branch (`merge`,
   `prune`) resolve it automatically from `HEAD` of the default remote, so you
@@ -50,10 +51,12 @@ wt add <branch> [--base <rev>]         Create a worktree and branch
 wt go [<branch>] [-i]                  Switch to an existing worktree
 wt list [--stats]                      List all worktrees
 wt remove [<branch>] [--force]         Remove a worktree and its local branch
+                                      [--keep-branch] preserves the branch
 wt merge [<branch>] [--into <branch>]  Merge a branch and clean up
 wt diff [<branch>] [--dry-run]         Open difftool for branch or dirty changes
 wt materialize --sha <sha> ...         Create an explicit detached checkout
-wt prune [--execute] [--force]         Remove worktrees integrated into mainline
+wt prune [--execute] [--force]         Remove integrated worktrees and branches
+                                      [--integrated-into <rev>] sets the target
 wt doctor                              Diagnose worktree/repo health
 ```
 
@@ -101,12 +104,15 @@ wt list --stats --color never
 ### `wt remove`
 
 Removes a worktree and deletes its local branch. When called without a branch
-argument, infers the target from `cwd` or opens a fuzzy picker in a TTY.
+argument, infers the target from `cwd` or opens a fuzzy picker in a TTY. Use
+`--keep-branch` to remove only the worktree; dirty-worktree checks still apply,
+and default branch-deletion safety is unchanged.
 
 ```
-wt remove feature/auth     # explicit branch
-wt remove                  # infer from cwd or pick interactively
-wt remove --force          # remove even if dirty, use -D for branch
+wt remove feature/auth               # explicit branch and branch cleanup
+wt remove                             # infer from cwd or pick interactively
+wt remove --force                     # remove even if dirty, use -D for branch
+wt remove feature/auth --keep-branch  # remove worktree, preserve local branch
 ```
 
 ### `wt merge`
@@ -163,15 +169,18 @@ wt materialize \
 
 ### `wt prune`
 
-Scans all worktrees and identifies branches that are fully integrated into
-mainline. Integration is detected via both ancestry checks (merge/fast-forward)
-and patch-id comparison (rebase merges). Defaults to dry-run.
+Scans linked worktrees and preserved local branches and identifies branches
+that are fully integrated into the selected revision. Integration is detected
+via both ancestry checks (merge/fast-forward) and patch-id comparison (rebase
+merges). Defaults to dry-run. `--integrated-into` accepts any revision and
+`--mainline` remains an alias.
 
 ```
-wt prune                               # dry-run: show what would be pruned
-wt prune --execute                     # actually remove integrated worktrees
-wt prune --execute --force             # also remove dirty worktrees
-wt prune --mainline develop            # override mainline branch
+wt prune                                      # dry-run: show cleanup candidates
+wt prune --execute                            # remove worktrees and branches
+wt prune --execute --force                    # also remove dirty worktrees
+wt prune --integrated-into integration/release # use a staged integration target
+wt prune --mainline develop                   # backwards-compatible alias
 ```
 
 ### `wt doctor`
@@ -202,7 +211,16 @@ Example: branch `feature/auth` → `.worktrees/feature-auth--a1b2c3d4/`
 | `--print-cd-path` | Bare absolute path on stdout (for wrappers)  |
 | `--print-paths`   | Multi-line key values on stdout (for wrappers) |
 
+For `remove --print-paths`, the lines are `removed_path`, `repo_root`,
+`branch`, and `branch_deleted` in that order. The first three lines remain
+path/branch values; the fourth line makes preserved-branch cleanup explicit.
+
 `--json` emits one compact JSON object per line so machine consumers can parse stdout line-by-line.
+For `remove`, `worktree_removed` and `branch_deleted` explicitly report each
+lifecycle action. Prune dry-runs report `worktree_present` and
+`branch_will_be_deleted`; execute results report `worktree_removed` and
+`branch_deleted`. A preserved branch has a null prune `path` because no
+worktree remains.
 
 JSON envelope example (`add`, `go`, `remove`):
 
@@ -215,6 +233,15 @@ JSON envelope example (`add`, `go`, `remove`):
   "cd_path": "/abs/repo/.worktrees/feature-auth--a1b2c3d4",
   "branch": "feature/auth",
   "tracking": false
+}
+```
+
+A `remove --keep-branch --json` response includes the distinct cleanup state:
+
+```json
+{
+  "worktree_removed": true,
+  "branch_deleted": false
 }
 ```
 

--- a/bindings/bash/wt.bash
+++ b/bindings/bash/wt.bash
@@ -108,23 +108,28 @@ wt() {
 
             local cwd_before
             cwd_before=$(pwd)
-            # --print-paths outputs three lines: removed_path, repo_root, branch.
+            # --print-paths outputs four lines: removed_path, repo_root, branch, branch_deleted.
             # stderr is left connected to the terminal so the interactive picker
             # (if triggered) renders correctly and errors are visible.
             local result
             result=$(wt-core remove "$@" --print-paths)
             local rc=$?
             if [ $rc -eq 0 ]; then
-                local removed_path repo_root branch
+                local removed_path repo_root branch branch_deleted
                 removed_path=$(printf '%s\n' "$result" | sed -n '1p')
                 repo_root=$(printf '%s\n' "$result" | sed -n '2p')
                 branch=$(printf '%s\n' "$result" | sed -n '3p')
+                branch_deleted=$(printf '%s\n' "$result" | sed -n '4p')
                 case "$cwd_before" in
                     "${removed_path}"*)
                         cd "$repo_root" || true
                         ;;
                 esac
-                echo "Removed worktree and branch '${branch}'"
+                if [ "$branch_deleted" = true ]; then
+                    echo "Removed worktree and branch '${branch}'"
+                else
+                    echo "Removed worktree and kept branch '${branch}'"
+                fi
             else
                 return $rc
             fi

--- a/bindings/bash/wt.bash
+++ b/bindings/bash/wt.bash
@@ -108,27 +108,32 @@ wt() {
 
             local cwd_before
             cwd_before=$(pwd)
-            # --print-paths outputs four lines: removed_path, repo_root, branch, branch_deleted.
+            # --print-paths is the stable legacy three-line protocol:
+            # removed_path, repo_root, branch. Lifecycle status is explicit in
+            # --json; the binding also knows whether --keep-branch was requested.
+            local keep_branch=false
+            for arg in "$@"; do
+                [ "$arg" = "--keep-branch" ] && keep_branch=true
+            done
             # stderr is left connected to the terminal so the interactive picker
             # (if triggered) renders correctly and errors are visible.
             local result
             result=$(wt-core remove "$@" --print-paths)
             local rc=$?
             if [ $rc -eq 0 ]; then
-                local removed_path repo_root branch branch_deleted
+                local removed_path repo_root branch
                 removed_path=$(printf '%s\n' "$result" | sed -n '1p')
                 repo_root=$(printf '%s\n' "$result" | sed -n '2p')
                 branch=$(printf '%s\n' "$result" | sed -n '3p')
-                branch_deleted=$(printf '%s\n' "$result" | sed -n '4p')
                 case "$cwd_before" in
                     "${removed_path}"*)
                         cd "$repo_root" || true
                         ;;
                 esac
-                if [ "$branch_deleted" = true ]; then
-                    echo "Removed worktree and branch '${branch}'"
-                else
+                if [ "$keep_branch" = true ]; then
                     echo "Removed worktree and kept branch '${branch}'"
+                else
+                    echo "Removed worktree and branch '${branch}'"
                 fi
             else
                 return $rc

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -96,7 +96,15 @@ function wt --description "Git worktree manager"
             end
 
             set -l cwd_before (pwd)
-            # --print-paths outputs four lines: removed_path, repo_root, branch, branch_deleted.
+            # --print-paths is the stable legacy three-line protocol:
+            # removed_path, repo_root, branch. Lifecycle status is explicit in
+            # --json; the binding also knows whether --keep-branch was requested.
+            set -l keep_branch false
+            for arg in $argv
+                if test "$arg" = "--keep-branch"
+                    set keep_branch true
+                end
+            end
             # stderr is left connected to the terminal so the interactive picker
             # (if triggered) renders correctly and errors are visible.
             set -l lines (wt-core remove $argv --print-paths)
@@ -105,15 +113,14 @@ function wt --description "Git worktree manager"
                 set -l removed_path $lines[1]
                 set -l repo_root $lines[2]
                 set -l branch $lines[3]
-                set -l branch_deleted $lines[4]
                 # Check if cwd is under the removed worktree path
                 if string match -q "$removed_path*" "$cwd_before"
                     cd "$repo_root"; or true
                 end
-                if test "$branch_deleted" = true
-                    echo "Removed worktree and branch '$branch'"
-                else
+                if test "$keep_branch" = true
                     echo "Removed worktree and kept branch '$branch'"
+                else
+                    echo "Removed worktree and branch '$branch'"
                 end
             else
                 return $rc

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -96,7 +96,7 @@ function wt --description "Git worktree manager"
             end
 
             set -l cwd_before (pwd)
-            # --print-paths outputs three lines: removed_path, repo_root, branch.
+            # --print-paths outputs four lines: removed_path, repo_root, branch, branch_deleted.
             # stderr is left connected to the terminal so the interactive picker
             # (if triggered) renders correctly and errors are visible.
             set -l lines (wt-core remove $argv --print-paths)
@@ -105,11 +105,16 @@ function wt --description "Git worktree manager"
                 set -l removed_path $lines[1]
                 set -l repo_root $lines[2]
                 set -l branch $lines[3]
+                set -l branch_deleted $lines[4]
                 # Check if cwd is under the removed worktree path
                 if string match -q "$removed_path*" "$cwd_before"
                     cd "$repo_root"; or true
                 end
-                echo "Removed worktree and branch '$branch'"
+                if test "$branch_deleted" = true
+                    echo "Removed worktree and branch '$branch'"
+                else
+                    echo "Removed worktree and kept branch '$branch'"
+                end
             else
                 return $rc
             end

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -80,10 +80,11 @@ export def --env "wt go" [
     }
 }
 
-# Remove a worktree and its local branch
+# Remove a worktree, optionally preserving its local branch
 export def --env "wt remove" [
     branch?: string  # Branch name (defaults to current worktree)
     --force          # Force removal even if dirty
+    --keep-branch    # Preserve the local branch after removing its worktree
     --repo: path     # Repository path (defaults to cwd)
     --json           # Output as JSON
 ] {
@@ -92,6 +93,7 @@ export def --env "wt remove" [
     mut args = ["remove"]
     if $branch != null { $args = ($args | append $branch) }
     if $force { $args = ($args | append "--force") }
+    if $keep_branch { $args = ($args | append "--keep-branch") }
 
     if $json {
         # --json: machine output, no interactive picker.
@@ -120,12 +122,17 @@ export def --env "wt remove" [
         let removed_path = ($lines | get 0)
         let repo_root = ($lines | get 1)
         let branch_name = ($lines | get 2)
+        let branch_deleted = ($lines | get 3)
 
         if ($cwd_before | str starts-with $removed_path) {
             cd $repo_root
         }
 
-        print $"Removed worktree and branch '($branch_name)'"
+        if $branch_deleted == "true" {
+            print $"Removed worktree and branch '($branch_name)'"
+        } else {
+            print $"Removed worktree and kept branch '($branch_name)'"
+        }
     }
 }
 

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -118,20 +118,22 @@ export def --env "wt remove" [
         # inherited, keeping the interactive picker and error messages
         # visible in the terminal.
         let output = try { ^wt-core ...$full_args } catch { return }
+        # --print-paths is the stable legacy three-line protocol:
+        # removed_path, repo_root, branch. Lifecycle status is explicit in
+        # --json; the binding already knows whether --keep-branch was requested.
         let lines = ($output | lines)
         let removed_path = ($lines | get 0)
         let repo_root = ($lines | get 1)
         let branch_name = ($lines | get 2)
-        let branch_deleted = ($lines | get 3)
 
         if ($cwd_before | str starts-with $removed_path) {
             cd $repo_root
         }
 
-        if $branch_deleted == "true" {
-            print $"Removed worktree and branch '($branch_name)'"
-        } else {
+        if $keep_branch {
             print $"Removed worktree and kept branch '($branch_name)'"
+        } else {
+            print $"Removed worktree and branch '($branch_name)'"
         }
     }
 }

--- a/bindings/zsh/wt.zsh
+++ b/bindings/zsh/wt.zsh
@@ -108,25 +108,30 @@ wt() {
             fi
 
             local cwd_before="${PWD}"
-            # --print-paths outputs four lines: removed_path, repo_root, branch, branch_deleted.
+            # --print-paths is the stable legacy three-line protocol:
+            # removed_path, repo_root, branch. Lifecycle status is explicit in
+            # --json; the binding also knows whether --keep-branch was requested.
+            local keep_branch=false
+            for arg in "$@"; do
+                [[ "$arg" == "--keep-branch" ]] && keep_branch=true
+            done
             # stderr is left connected to the terminal so the interactive picker
             # (if triggered) renders correctly and errors are visible.
             local result
             result=$(wt-core remove "$@" --print-paths)
             local rc=$?
             if [[ $rc -eq 0 ]]; then
-                local removed_path repo_root branch branch_deleted
+                local removed_path repo_root branch
                 removed_path=$(printf '%s\n' "$result" | sed -n '1p')
                 repo_root=$(printf '%s\n' "$result" | sed -n '2p')
                 branch=$(printf '%s\n' "$result" | sed -n '3p')
-                branch_deleted=$(printf '%s\n' "$result" | sed -n '4p')
                 if [[ "$cwd_before" == "${removed_path}"* ]]; then
                     cd "$repo_root" || true
                 fi
-                if [[ "$branch_deleted" == true ]]; then
-                    echo "Removed worktree and branch '${branch}'"
-                else
+                if [[ "$keep_branch" == true ]]; then
                     echo "Removed worktree and kept branch '${branch}'"
+                else
+                    echo "Removed worktree and branch '${branch}'"
                 fi
             else
                 return $rc

--- a/bindings/zsh/wt.zsh
+++ b/bindings/zsh/wt.zsh
@@ -108,21 +108,26 @@ wt() {
             fi
 
             local cwd_before="${PWD}"
-            # --print-paths outputs three lines: removed_path, repo_root, branch.
+            # --print-paths outputs four lines: removed_path, repo_root, branch, branch_deleted.
             # stderr is left connected to the terminal so the interactive picker
             # (if triggered) renders correctly and errors are visible.
             local result
             result=$(wt-core remove "$@" --print-paths)
             local rc=$?
             if [[ $rc -eq 0 ]]; then
-                local removed_path repo_root branch
+                local removed_path repo_root branch branch_deleted
                 removed_path=$(printf '%s\n' "$result" | sed -n '1p')
                 repo_root=$(printf '%s\n' "$result" | sed -n '2p')
                 branch=$(printf '%s\n' "$result" | sed -n '3p')
+                branch_deleted=$(printf '%s\n' "$result" | sed -n '4p')
                 if [[ "$cwd_before" == "${removed_path}"* ]]; then
                     cd "$repo_root" || true
                 fi
-                echo "Removed worktree and branch '${branch}'"
+                if [[ "$branch_deleted" == true ]]; then
+                    echo "Removed worktree and branch '${branch}'"
+                else
+                    echo "Removed worktree and kept branch '${branch}'"
+                fi
             else
                 return $rc
             fi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,7 +103,7 @@ pub enum Command {
         #[arg(long)]
         json: bool,
 
-        /// Print removed_path, repo_root, branch, and branch_deleted (one per line) for shell wrappers
+        /// Print the legacy three-line removed_path, repo_root, branch protocol for shell wrappers
         #[arg(long, conflicts_with = "json")]
         print_paths: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,9 +87,13 @@ pub enum Command {
         /// Branch name (defaults to current worktree's branch)
         branch: Option<String>,
 
-        /// Force removal even if dirty; use -D for branch deletion
+        /// Force removal even if dirty; use -D for branch deletion unless the branch is kept
         #[arg(long)]
         force: bool,
+
+        /// Remove the worktree but preserve its local branch
+        #[arg(long)]
+        keep_branch: bool,
 
         /// Repository path (defaults to current directory)
         #[arg(long)]
@@ -99,7 +103,7 @@ pub enum Command {
         #[arg(long)]
         json: bool,
 
-        /// Print removed_path, repo_root, and branch (one per line) for shell wrappers
+        /// Print removed_path, repo_root, branch, and branch_deleted (one per line) for shell wrappers
         #[arg(long, conflicts_with = "json")]
         print_paths: bool,
     },
@@ -220,9 +224,9 @@ pub enum Command {
         repo: Option<PathBuf>,
     },
 
-    /// Remove worktrees whose branches are fully integrated into mainline
+    /// Remove worktrees and branches fully integrated into a target revision
     Prune {
-        /// Actually remove integrated worktrees (default is dry-run)
+        /// Actually remove integrated worktrees and branches (default is dry-run)
         #[arg(long)]
         execute: bool,
 
@@ -230,9 +234,9 @@ pub enum Command {
         #[arg(long, requires = "execute")]
         force: bool,
 
-        /// Override mainline branch (default: auto-detect)
-        #[arg(long)]
-        mainline: Option<String>,
+        /// Revision to evaluate integration against (default: auto-detect)
+        #[arg(long = "integrated-into", visible_alias = "mainline")]
+        integrated_into: Option<String>,
 
         /// Repository path (defaults to current directory)
         #[arg(long)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1154,10 +1154,12 @@ fn cmd_remove(
 
     match fmt {
         RemoveFormat::PrintPaths => {
+            // This is a stable legacy protocol used by installed shell
+            // bindings: exactly removed_path, repo_root, and branch.
+            // Lifecycle status is available in the explicit JSON response.
             println!("{removed_str}");
             println!("{root_str}");
             println!("{branch_name}");
-            println!("{}", result.branch_deleted);
         }
         RemoveFormat::Json => {
             let resp = JsonResponse::success(if result.branch_deleted {
@@ -1372,6 +1374,7 @@ fn cmd_prune_execute(
                     "not_integrated" => "not integrated",
                     "no_branch" => "no branch",
                     "removal_failed" => "removal failed",
+                    "stale_marker" => "stale preservation marker",
                     other => other,
                 };
                 println!("  Skipped {label} ({reason})");

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -50,12 +50,14 @@ pub fn run(cli: Cli) -> Result<()> {
         Command::Remove {
             branch,
             force,
+            keep_branch,
             repo,
             json,
             print_paths,
         } => cmd_remove(
             branch.as_deref().map(BranchName::new),
             force,
+            keep_branch,
             repo,
             remove_fmt(json, print_paths),
         ),
@@ -119,10 +121,16 @@ pub fn run(cli: Cli) -> Result<()> {
         Command::Prune {
             execute,
             force,
-            mainline,
+            integrated_into,
             repo,
             json,
-        } => cmd_prune(execute, force, mainline.as_deref(), repo, prune_fmt(json)),
+        } => cmd_prune(
+            execute,
+            force,
+            integrated_into.as_deref(),
+            repo,
+            prune_fmt(json),
+        ),
         Command::Setup { repo, json } => cmd_setup(repo, status_fmt(json)),
         Command::Init { shell } => cmd_init(shell),
         Command::Doctor { repo, json } => cmd_doctor(repo, status_fmt(json)),
@@ -1126,6 +1134,7 @@ fn cmd_merge(
 fn cmd_remove(
     branch: Option<BranchName>,
     force: bool,
+    keep_branch: bool,
     repo: Option<PathBuf>,
     fmt: RemoveFormat,
 ) -> Result<()> {
@@ -1136,7 +1145,8 @@ fn cmd_remove(
         None => resolve_action_branch(&repo, fmt == RemoveFormat::Json, "remove")?,
     };
 
-    let result = worktree::remove(&repo, resolved_branch.as_ref(), force)?;
+    let result =
+        worktree::remove_with_keep_branch(&repo, resolved_branch.as_ref(), force, keep_branch)?;
 
     let removed_str = result.removed_path.display().to_string();
     let root_str = result.repo_root.display().to_string();
@@ -1147,18 +1157,28 @@ fn cmd_remove(
             println!("{removed_str}");
             println!("{root_str}");
             println!("{branch_name}");
+            println!("{}", result.branch_deleted);
         }
         RemoveFormat::Json => {
-            let resp =
-                JsonResponse::success(format!("removed worktree for branch '{branch_name}'"))
-                    .with_event("reset")
-                    .with_repo_root(&root_str)
-                    .with_removed_path(&removed_str)
-                    .with_branch(branch_name.as_str());
+            let resp = JsonResponse::success(if result.branch_deleted {
+                format!("removed worktree for branch '{branch_name}'")
+            } else {
+                format!("removed worktree and kept branch '{branch_name}'")
+            })
+            .with_event("reset")
+            .with_repo_root(&root_str)
+            .with_removed_path(&removed_str)
+            .with_branch(branch_name.as_str())
+            .with_worktree_removed(true)
+            .with_branch_deleted(result.branch_deleted);
             print_json(&resp)?;
         }
         RemoveFormat::Human => {
-            println!("Removed worktree and branch '{branch_name}' ({removed_str})");
+            if result.branch_deleted {
+                println!("Removed worktree and branch '{branch_name}' ({removed_str})");
+            } else {
+                println!("Removed worktree and kept branch '{branch_name}' ({removed_str})");
+            }
         }
     }
     if let Some(w) = &result.warning {
@@ -1198,6 +1218,12 @@ fn format_prune_entry(entry: &worktree::WorktreePruneEntry) -> (String, Option<S
 }
 
 fn print_prune_entry_human(entry: &worktree::WorktreePruneEntry) {
+    let location = if entry.path.is_some() {
+        ""
+    } else {
+        " (branch only)"
+    };
+
     match &entry.status {
         worktree::IntegrationStatus::Integrated(method) => {
             let method_str = match method {
@@ -1205,15 +1231,29 @@ fn print_prune_entry_human(entry: &worktree::WorktreePruneEntry) {
                 worktree::IntegrationMethod::Rebase => "rebase",
             };
             let branch = entry.branch.as_deref().unwrap_or("(unknown)");
-            println!("  ✓ {branch:<20} integrated ({method_str})");
+            println!("  ✓ {branch:<20} integrated ({method_str}){location}");
         }
         worktree::IntegrationStatus::NotIntegrated => {
             let branch = entry.branch.as_deref().unwrap_or("(unknown)");
-            println!("  ✗ {branch:<20} not integrated");
+            println!("  ✗ {branch:<20} not integrated{location}");
         }
         worktree::IntegrationStatus::NoBranch => {
             println!("  ⚠ {:<20} no branch (detached HEAD)", "(detached)");
         }
+    }
+}
+
+fn print_prune_dry_run_summary(entries: &[worktree::WorktreePruneEntry], prunable: usize) {
+    let has_branch_only = entries.iter().any(|entry| entry.path.is_none());
+    match (entries.is_empty(), prunable, has_branch_only) {
+        (true, _, _) => println!("\nNo worktrees to prune."),
+        (false, 0, true) => println!("\nNo integrated worktrees or branches found."),
+        (false, 0, false) => println!("\nNo integrated worktrees found."),
+        (false, _, _) => println!(
+            "\n{prunable} integrated worktree{} or branch{} can be pruned. Run with --execute to remove worktrees and delete branches.",
+            if prunable == 1 { "" } else { "s" },
+            if prunable == 1 { "" } else { "es" }
+        ),
     }
 }
 
@@ -1241,7 +1281,12 @@ fn cmd_prune_dry_run(
                         branch: e.branch.clone(),
                         status,
                         method,
-                        path: e.path.display().to_string(),
+                        path: e.path.as_ref().map(|p| p.display().to_string()),
+                        worktree_present: e.path.is_some(),
+                        branch_will_be_deleted: matches!(
+                            &e.status,
+                            worktree::IntegrationStatus::Integrated(_)
+                        ),
                     }
                 })
                 .collect();
@@ -1258,16 +1303,7 @@ fn cmd_prune_dry_run(
             for entry in &result.entries {
                 print_prune_entry_human(entry);
             }
-            if result.entries.is_empty() {
-                println!("\nNo worktrees to prune.");
-            } else if prunable == 0 {
-                println!("\nNo integrated worktrees found.");
-            } else {
-                println!(
-                    "\n{prunable} integrated worktree{} can be pruned. Run with --execute to remove.",
-                    if prunable == 1 { "" } else { "s" }
-                );
-            }
+            print_prune_dry_run_summary(&result.entries, prunable);
         }
     }
     Ok(())
@@ -1288,7 +1324,9 @@ fn cmd_prune_execute(
                 .iter()
                 .map(|e| JsonPrunedEntry {
                     branch: e.branch.clone(),
-                    path: e.path.display().to_string(),
+                    path: e.path.as_ref().map(|p| p.display().to_string()),
+                    worktree_removed: e.worktree_removed,
+                    branch_deleted: e.branch_deleted,
                 })
                 .collect();
 
@@ -1298,7 +1336,7 @@ fn cmd_prune_execute(
                 .map(|e| JsonSkippedEntry {
                     branch: e.branch.clone(),
                     reason: e.reason.clone(),
-                    path: e.path.display().to_string(),
+                    path: e.path.as_ref().map(|p| p.display().to_string()),
                 })
                 .collect();
 
@@ -1313,7 +1351,20 @@ fn cmd_prune_execute(
         PruneFormat::Human => {
             println!("Mainline: {}", result.mainline);
             for entry in &result.pruned {
-                println!("  Removed {}", entry.branch);
+                match (entry.worktree_removed, entry.branch_deleted) {
+                    (true, true) => {
+                        println!("  Removed {} worktree and branch", entry.branch);
+                    }
+                    (true, false) => {
+                        println!("  Removed {} worktree; kept branch", entry.branch);
+                    }
+                    (false, true) => {
+                        println!("  Deleted {} branch (no worktree)", entry.branch);
+                    }
+                    (false, false) => {
+                        println!("  Kept {} branch (no worktree)", entry.branch);
+                    }
+                }
             }
             for entry in &result.skipped {
                 let label = entry.branch.as_deref().unwrap_or("(detached)");
@@ -1328,13 +1379,30 @@ fn cmd_prune_execute(
             for w in &result.warnings {
                 eprintln!("warning: {w}");
             }
-            let count = result.pruned.len();
-            if count == 0 {
+            let worktrees_removed = result
+                .pruned
+                .iter()
+                .filter(|entry| entry.worktree_removed)
+                .count();
+            let branches_deleted = result
+                .pruned
+                .iter()
+                .filter(|entry| entry.branch_deleted)
+                .count();
+            if worktrees_removed == 0 && branches_deleted == 0 {
                 println!("\nNo worktrees pruned.");
+            } else if result.pruned.len() == worktrees_removed
+                && branches_deleted == result.pruned.len()
+            {
+                println!(
+                    "\nPruned {worktrees_removed} worktree{}.",
+                    if worktrees_removed == 1 { "" } else { "s" }
+                );
             } else {
                 println!(
-                    "\nPruned {count} worktree{}.",
-                    if count == 1 { "" } else { "s" }
+                    "\nPruned {worktrees_removed} worktree{} and deleted {branches_deleted} branch{}.",
+                    if worktrees_removed == 1 { "" } else { "s" },
+                    if branches_deleted == 1 { "" } else { "es" }
                 );
             }
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -263,6 +263,21 @@ pub fn list_preserved_branches(repo: &RepoRoot) -> Result<Vec<PreservedBranch>> 
         .collect())
 }
 
+/// Return the marker object ID for a preserved branch, if one exists.
+pub fn preserved_branch_oid(repo: &RepoRoot, branch: &BranchName) -> Result<Option<String>> {
+    Ok(list_preserved_branches(repo)?
+        .into_iter()
+        .find(|preserved| preserved.name == branch.as_str())
+        .map(|preserved| preserved.oid))
+}
+
+/// Restore a previously captured lifecycle marker object ID.
+pub fn restore_preserved_branch(repo: &RepoRoot, branch: &BranchName, oid: &str) -> Result<()> {
+    let marker = format!("refs/wt-core/preserved/{}", branch.as_str());
+    git(&["update-ref", &marker, oid], repo.as_ref())?;
+    Ok(())
+}
+
 /// Resolve the current object ID of a local branch.
 pub fn branch_oid(repo: &RepoRoot, branch: &BranchName) -> Option<String> {
     let branch_ref = format!("refs/heads/{}^{{commit}}", branch.as_str());

--- a/src/git.rs
+++ b/src/git.rs
@@ -219,6 +219,39 @@ pub fn delete_branch(repo: &RepoRoot, branch: &BranchName, force: bool) -> Resul
     Ok(())
 }
 
+/// Record that a branch should survive worktree removal until a later prune.
+///
+/// The marker is a private ref rather than a file in the repository, so the
+/// state follows clones only when explicitly copied and does not alter branch
+/// names or worktree directories.
+pub fn mark_preserved_branch(repo: &RepoRoot, branch: &BranchName) -> Result<()> {
+    let marker = format!("refs/wt-core/preserved/{}", branch.as_str());
+    let branch_ref = format!("refs/heads/{}", branch.as_str());
+    git(&["update-ref", &marker, &branch_ref], repo.as_ref())?;
+    Ok(())
+}
+
+/// List branches explicitly preserved by `remove --keep-branch`.
+pub fn list_preserved_branches(repo: &RepoRoot) -> Result<Vec<String>> {
+    let output = git(
+        &[
+            "for-each-ref",
+            "--format=%(refname:strip=3)",
+            "refs/wt-core/preserved/",
+        ],
+        repo.as_ref(),
+    )?;
+
+    Ok(output.lines().map(str::to_string).collect())
+}
+
+/// Remove the lifecycle marker for a preserved branch.
+pub fn clear_preserved_branch(repo: &RepoRoot, branch: &BranchName) -> Result<()> {
+    let marker = format!("refs/wt-core/preserved/{}", branch.as_str());
+    git(&["update-ref", "-d", &marker], repo.as_ref())?;
+    Ok(())
+}
+
 /// Run a git command and return true if it exits successfully.
 ///
 /// Used for commands like `merge-base --is-ancestor` that communicate

--- a/src/git.rs
+++ b/src/git.rs
@@ -223,7 +223,8 @@ pub fn delete_branch(repo: &RepoRoot, branch: &BranchName, force: bool) -> Resul
 ///
 /// The marker is a private ref rather than a file in the repository, so the
 /// state follows clones only when explicitly copied and does not alter branch
-/// names or worktree directories.
+/// names or worktree directories. Its object ID is the branch incarnation
+/// that was explicitly preserved; prune must not authorize a later incarnation.
 pub fn mark_preserved_branch(repo: &RepoRoot, branch: &BranchName) -> Result<()> {
     let marker = format!("refs/wt-core/preserved/{}", branch.as_str());
     let branch_ref = format!("refs/heads/{}", branch.as_str());
@@ -231,18 +232,70 @@ pub fn mark_preserved_branch(repo: &RepoRoot, branch: &BranchName) -> Result<()>
     Ok(())
 }
 
+/// A branch preserved by `remove --keep-branch`, including its exact marker
+/// object ID. The ID is intentionally retained through prune planning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreservedBranch {
+    pub name: String,
+    pub oid: String,
+}
+
 /// List branches explicitly preserved by `remove --keep-branch`.
-pub fn list_preserved_branches(repo: &RepoRoot) -> Result<Vec<String>> {
+pub fn list_preserved_branches(repo: &RepoRoot) -> Result<Vec<PreservedBranch>> {
     let output = git(
         &[
             "for-each-ref",
-            "--format=%(refname:strip=3)",
+            "--format=%(refname:strip=3)%09%(objectname)",
             "refs/wt-core/preserved/",
         ],
         repo.as_ref(),
     )?;
 
-    Ok(output.lines().map(str::to_string).collect())
+    Ok(output
+        .lines()
+        .filter_map(|line| {
+            let (name, oid) = line.split_once('\t')?;
+            Some(PreservedBranch {
+                name: name.to_string(),
+                oid: oid.to_string(),
+            })
+        })
+        .collect())
+}
+
+/// Resolve the current object ID of a local branch.
+pub fn branch_oid(repo: &RepoRoot, branch: &BranchName) -> Option<String> {
+    let branch_ref = format!("refs/heads/{}^{{commit}}", branch.as_str());
+    git(&["rev-parse", "--verify", &branch_ref], repo.as_ref()).ok()
+}
+
+/// Resolve a revision to its peeled commit object ID.
+pub fn resolve_commit(repo: &RepoRoot, revision: &str) -> Result<String> {
+    let peeled = format!("{revision}^{{commit}}");
+    git(&["rev-parse", "--verify", &peeled], repo.as_ref())
+}
+
+/// Return a canonical short remote-tracking ref (`origin/topic`) when the
+/// supplied revision names one directly or through its full ref name.
+pub fn remote_branch_revision(repo: &RepoRoot, revision: &str) -> Option<String> {
+    let short = revision.strip_prefix("refs/remotes/").unwrap_or(revision);
+    let reference = format!("refs/remotes/{short}^{{commit}}");
+    git(&["rev-parse", "--verify", &reference], repo.as_ref())
+        .ok()
+        .map(|_| short.to_string())
+}
+
+/// Return the local branch corresponding to a canonical remote ref, if one
+/// exists. A remote ref itself is not a local worktree target.
+pub fn local_branch_for_remote(repo: &RepoRoot, remote_revision: &str) -> Option<String> {
+    let (_, branch) = remote_revision.split_once('/')?;
+    let branch_name = BranchName::new(branch);
+    branch_exists(repo, &branch_name).then_some(branch.to_string())
+}
+
+/// Resolve `HEAD` to its checked-out local branch when it is symbolic.
+pub fn current_branch(repo: &RepoRoot) -> Option<String> {
+    git(&["symbolic-ref", "--short", "HEAD"], repo.as_ref()).ok()
 }
 
 /// Remove the lifecycle marker for a preserved branch.

--- a/src/output.rs
+++ b/src/output.rs
@@ -24,7 +24,8 @@ pub enum StatusFormat {
 pub enum RemoveFormat {
     Human,
     Json,
-    /// `--print-paths`: prints removed_path, repo_root, and branch (one per line).
+    /// Stable legacy `--print-paths`: removed_path, repo_root, and branch
+    /// (exactly three lines). Lifecycle status is exposed by JSON.
     PrintPaths,
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -48,6 +48,12 @@ pub struct JsonResponse {
     pub removed_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
+    /// Whether the worktree was removed (only set for `remove`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_removed: Option<bool>,
+    /// Whether the local branch was deleted (only set for `remove`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch_deleted: Option<bool>,
     /// Whether the branch tracks a remote branch (only set for `add`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tracking: Option<bool>,
@@ -67,6 +73,8 @@ impl JsonResponse {
             cd_path: None,
             removed_path: None,
             branch: None,
+            worktree_removed: None,
+            branch_deleted: None,
             tracking: None,
             symlinks: None,
         }
@@ -94,6 +102,16 @@ impl JsonResponse {
 
     pub fn with_branch(mut self, branch: impl Into<String>) -> Self {
         self.branch = Some(branch.into());
+        self
+    }
+
+    pub fn with_worktree_removed(mut self, removed: bool) -> Self {
+        self.worktree_removed = Some(removed);
+        self
+    }
+
+    pub fn with_branch_deleted(mut self, deleted: bool) -> Self {
+        self.branch_deleted = Some(deleted);
         self
     }
 
@@ -304,7 +322,11 @@ pub struct JsonPruneDryRunEntry {
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
-    pub path: String,
+    pub path: Option<String>,
+    /// Whether executing this entry would remove a worktree.
+    pub worktree_present: bool,
+    /// Whether executing this entry would delete the local branch.
+    pub branch_will_be_deleted: bool,
 }
 
 /// JSON response for prune execute.
@@ -320,14 +342,16 @@ pub struct JsonPruneExecuteResponse {
 #[derive(Debug, Serialize)]
 pub struct JsonPrunedEntry {
     pub branch: String,
-    pub path: String,
+    pub path: Option<String>,
+    pub worktree_removed: bool,
+    pub branch_deleted: bool,
 }
 
 #[derive(Debug, Serialize)]
 pub struct JsonSkippedEntry {
     pub branch: Option<String>,
     pub reason: String,
-    pub path: String,
+    pub path: Option<String>,
 }
 
 /// Output format for the merge command.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -329,6 +329,15 @@ pub fn remove_with_keep_branch(
 
     let removed_path = wt.path.clone();
 
+    // Snapshot the previous marker before updating it. A repeated keep
+    // request may be retrying a branch that was already preserved, and a
+    // failed removal must not discard that valid cleanup eligibility.
+    let previous_marker = if keep_branch {
+        git::preserved_branch_oid(repo, &target_branch)?
+    } else {
+        None
+    };
+
     // Record preservation before removal so a successful worktree removal
     // cannot lose the branch's later prune eligibility.
     if keep_branch {
@@ -337,10 +346,23 @@ pub fn remove_with_keep_branch(
 
     // Remove worktree first, then optionally delete the branch. A failed
     // worktree removal prevents branch cleanup and preserves the old safety
-    // ordering. Roll back the marker too, so a failed keep operation does not
-    // leave stale lifecycle state behind.
+    // ordering. Restore a prior marker only when it still matches the branch;
+    // otherwise clear the newly-created marker instead of retaining invalid
+    // lifecycle state.
     if let Err(error) = git::remove_worktree(repo, &removed_path, force) {
-        let _ = keep_branch.then(|| git::clear_preserved_branch(repo, &target_branch));
+        match (
+            keep_branch,
+            previous_marker
+                .filter(|oid| git::branch_oid(repo, &target_branch).as_deref() == Some(oid)),
+        ) {
+            (true, Some(oid)) => {
+                let _ = git::restore_preserved_branch(repo, &target_branch, &oid);
+            }
+            (true, None) => {
+                let _ = git::clear_preserved_branch(repo, &target_branch);
+            }
+            (false, _) => {}
+        }
         return Err(error);
     }
     let (branch_deleted, warning) = if keep_branch {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::domain::{BranchName, RepoRoot, Worktree};
@@ -79,6 +80,8 @@ pub struct RemoveResult {
     pub removed_path: PathBuf,
     pub branch: BranchName,
     pub repo_root: PathBuf,
+    /// Whether the local branch was deleted by this operation.
+    pub branch_deleted: bool,
     /// Non-fatal warning (e.g. branch deletion failed after worktree removal).
     pub warning: Option<String>,
 }
@@ -291,6 +294,16 @@ pub fn go(repo: &RepoRoot, branch: &BranchName) -> Result<GoResult> {
 
 /// Remove a worktree and delete its local branch.
 pub fn remove(repo: &RepoRoot, branch: Option<&BranchName>, force: bool) -> Result<RemoveResult> {
+    remove_with_keep_branch(repo, branch, force, false)
+}
+
+/// Remove a worktree, optionally preserving its local branch.
+pub fn remove_with_keep_branch(
+    repo: &RepoRoot,
+    branch: Option<&BranchName>,
+    force: bool,
+    keep_branch: bool,
+) -> Result<RemoveResult> {
     let worktrees = git::list_worktrees(repo)?;
 
     // Resolve which branch to remove.
@@ -316,17 +329,39 @@ pub fn remove(repo: &RepoRoot, branch: Option<&BranchName>, force: bool) -> Resu
 
     let removed_path = wt.path.clone();
 
-    // Remove worktree first, then branch.
-    git::remove_worktree(repo, &removed_path, force)?;
-    // Branch deletion: best-effort — bubble warning instead of blocking.
-    let warning = git::delete_branch(repo, &target_branch, force)
-        .err()
-        .map(|e| format!("worktree removed but branch deletion failed: {e}"));
+    // Record preservation before removal so a successful worktree removal
+    // cannot lose the branch's later prune eligibility.
+    if keep_branch {
+        git::mark_preserved_branch(repo, &target_branch)?;
+    }
+
+    // Remove worktree first, then optionally delete the branch. A failed
+    // worktree removal prevents branch cleanup and preserves the old safety
+    // ordering. Roll back the marker too, so a failed keep operation does not
+    // leave stale lifecycle state behind.
+    if let Err(error) = git::remove_worktree(repo, &removed_path, force) {
+        let _ = keep_branch.then(|| git::clear_preserved_branch(repo, &target_branch));
+        return Err(error);
+    }
+    let (branch_deleted, warning) = if keep_branch {
+        (false, None)
+    } else {
+        // Branch deletion is best-effort: the worktree is already gone, so
+        // report a warning while accurately retaining the branch state.
+        match git::delete_branch(repo, &target_branch, force) {
+            Ok(()) => (true, None),
+            Err(e) => (
+                false,
+                Some(format!("worktree removed but branch deletion failed: {e}")),
+            ),
+        }
+    };
 
     Ok(RemoveResult {
         removed_path,
         branch: target_branch,
         repo_root: repo.to_path_buf(),
+        branch_deleted,
         warning,
     })
 }
@@ -356,7 +391,8 @@ pub enum IntegrationStatus {
 #[derive(Debug)]
 pub struct WorktreePruneEntry {
     pub branch: Option<String>,
-    pub path: std::path::PathBuf,
+    /// `None` means the branch was preserved after its worktree was removed.
+    pub path: Option<std::path::PathBuf>,
     pub status: IntegrationStatus,
 }
 
@@ -371,14 +407,17 @@ pub struct PruneDryRun {
 #[derive(Debug)]
 pub struct PrunedEntry {
     pub branch: String,
-    pub path: std::path::PathBuf,
+    /// `None` means this entry only deleted a preserved branch.
+    pub path: Option<std::path::PathBuf>,
+    pub worktree_removed: bool,
+    pub branch_deleted: bool,
 }
 
 /// An entry that was skipped during pruning.
 #[derive(Debug)]
 pub struct SkippedEntry {
     pub branch: Option<String>,
-    pub path: std::path::PathBuf,
+    pub path: Option<std::path::PathBuf>,
     pub reason: String,
 }
 
@@ -406,7 +445,7 @@ fn classify_integration(repo: &RepoRoot, branch: &str, mainline: &str) -> Integr
     IntegrationStatus::NotIntegrated
 }
 
-/// Dry-run: scan worktrees and report integration status without removing anything.
+/// Dry-run: scan worktrees and preserved local branches without removing anything.
 pub fn prune_dry_run(repo: &RepoRoot, mainline_override: Option<&str>) -> Result<PruneDryRun> {
     let mainline = match mainline_override {
         Some(m) => {
@@ -421,10 +460,14 @@ pub fn prune_dry_run(repo: &RepoRoot, mainline_override: Option<&str>) -> Result
     };
 
     let worktrees = git::list_worktrees(repo)?;
+    let worktree_branches: HashSet<String> = worktrees
+        .iter()
+        .filter_map(|wt| wt.branch.clone())
+        .collect();
     let mut entries = Vec::new();
 
     for wt in &worktrees {
-        if wt.is_main {
+        if wt.is_main || wt.branch.as_deref() == Some(mainline.as_str()) {
             continue;
         }
 
@@ -435,8 +478,24 @@ pub fn prune_dry_run(repo: &RepoRoot, mainline_override: Option<&str>) -> Result
 
         entries.push(WorktreePruneEntry {
             branch: wt.branch.clone(),
-            path: wt.path.clone(),
+            path: Some(wt.path.clone()),
             status,
+        });
+    }
+
+    // A worktree removed with --keep-branch no longer appears in `git
+    // worktree list`. Its private lifecycle marker lets a later prune delete
+    // the preserved branch once its commits reach the selected target,
+    // without treating every unrelated local branch as pruneable.
+    for branch in git::list_preserved_branches(repo)? {
+        if branch == mainline || worktree_branches.contains(&branch) {
+            continue;
+        }
+
+        entries.push(WorktreePruneEntry {
+            status: classify_integration(repo, &branch, &mainline),
+            branch: Some(branch),
+            path: None,
         });
     }
 
@@ -450,47 +509,79 @@ struct PruneAccumulator {
     warnings: Vec<String>,
 }
 
-/// Try to remove an integrated worktree and its branch.
+/// Try to remove an integrated worktree and delete its branch.
 ///
 /// When the branch was integrated via rebase (patch-id match), Git's own
 /// ancestry check (`git branch -d`) would refuse deletion because the
-/// original commits are not ancestors of mainline.  We auto-escalate to
-/// `-D` in that case since the cherry check already confirmed integration.
+/// original commits are not ancestors of mainline. We auto-escalate to `-D`
+/// in that case since the cherry check already confirmed integration.
 fn prune_integrated_entry(
     repo: &RepoRoot,
     entry: WorktreePruneEntry,
     force: bool,
     acc: &mut PruneAccumulator,
 ) {
-    let branch_name = entry.branch.clone().expect("integrated implies branch");
+    let Some(branch_name) = entry.branch.clone() else {
+        acc.skipped.push(SkippedEntry {
+            branch: None,
+            path: entry.path,
+            reason: "no_branch".to_string(),
+        });
+        return;
+    };
 
     let force_branch = force
         || matches!(
-            entry.status,
+            &entry.status,
             IntegrationStatus::Integrated(IntegrationMethod::Rebase)
         );
 
-    if let Err(e) = git::remove_worktree(repo, &entry.path, force) {
-        acc.warnings.push(format!(
-            "failed to remove worktree for '{branch_name}': {e}"
-        ));
-        acc.skipped.push(SkippedEntry {
-            branch: Some(branch_name),
-            path: entry.path,
-            reason: "removal_failed".to_string(),
-        });
-        return;
-    }
+    let worktree_removed = match entry.path.as_ref() {
+        Some(path) => match git::remove_worktree(repo, path, force) {
+            Ok(()) => true,
+            Err(e) => {
+                acc.warnings.push(format!(
+                    "failed to remove worktree for '{branch_name}': {e}"
+                ));
+                acc.skipped.push(SkippedEntry {
+                    branch: Some(branch_name),
+                    path: entry.path,
+                    reason: "removal_failed".to_string(),
+                });
+                return;
+            }
+        },
+        None => false,
+    };
 
     let bn = BranchName::new(&branch_name);
-    if let Err(e) = git::delete_branch(repo, &bn, force_branch) {
-        acc.warnings.push(format!(
-            "worktree removed but branch deletion failed for '{branch_name}': {e}"
-        ));
-    }
+    let branch_deleted = match git::delete_branch(repo, &bn, force_branch) {
+        Ok(()) => {
+            if let Err(e) = git::clear_preserved_branch(repo, &bn) {
+                acc.warnings.push(format!(
+                    "branch '{branch_name}' deleted but lifecycle marker cleanup failed: {e}"
+                ));
+            }
+            true
+        }
+        Err(e) => {
+            let subject = if worktree_removed {
+                "worktree removed"
+            } else {
+                "no worktree removed"
+            };
+            acc.warnings.push(format!(
+                "{subject} but branch deletion failed for '{branch_name}': {e}"
+            ));
+            false
+        }
+    };
+
     acc.pruned.push(PrunedEntry {
         branch: branch_name,
         path: entry.path,
+        worktree_removed,
+        branch_deleted,
     });
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -349,7 +349,16 @@ pub fn remove_with_keep_branch(
         // Branch deletion is best-effort: the worktree is already gone, so
         // report a warning while accurately retaining the branch state.
         match git::delete_branch(repo, &target_branch, force) {
-            Ok(()) => (true, None),
+            Ok(()) => {
+                let warning = git::clear_preserved_branch(repo, &target_branch)
+                    .err()
+                    .map(|e| {
+                        format!(
+                            "branch '{target_branch}' deleted but lifecycle marker cleanup failed: {e}"
+                        )
+                    });
+                (true, warning)
+            }
             Err(e) => (
                 false,
                 Some(format!("worktree removed but branch deletion failed: {e}")),
@@ -394,6 +403,15 @@ pub struct WorktreePruneEntry {
     /// `None` means the branch was preserved after its worktree was removed.
     pub path: Option<std::path::PathBuf>,
     pub status: IntegrationStatus,
+    /// Marker OID captured during planning for a preserved branch. Execution
+    /// rechecks it so a moved/recreated branch cannot be deleted by an old
+    /// preservation request.
+    pub preserved_oid: Option<String>,
+    /// `git branch -d` can only verify the currently checked-out branch. For
+    /// another branch, a commit, or a remote ref, integration was checked
+    /// against an explicit target, so deletion must use `-D` after that
+    /// check rather than accidentally retaining a valid candidate.
+    pub force_branch_delete: bool,
 }
 
 /// Result of a prune dry-run.
@@ -445,29 +463,127 @@ fn classify_integration(repo: &RepoRoot, branch: &str, mainline: &str) -> Integr
     IntegrationStatus::NotIntegrated
 }
 
-/// Dry-run: scan worktrees and preserved local branches without removing anything.
-pub fn prune_dry_run(repo: &RepoRoot, mainline_override: Option<&str>) -> Result<PruneDryRun> {
-    let mainline = match mainline_override {
-        Some(m) => {
-            if !git::rev_exists(repo, m) {
-                return Err(AppError::usage(format!(
-                    "mainline branch '{m}' does not exist"
-                )));
-            }
-            m.to_string()
-        }
+/// The revision used for integration checks plus the target identity that
+/// prune must protect. Branch refs have a stable local name; commit-only and
+/// remote refs additionally protect matching branch tips because their target
+/// worktree cannot always be identified by name.
+#[derive(Debug, Clone)]
+struct IntegrationTarget {
+    revision: String,
+    protected_branches: HashSet<String>,
+    protected_tip: Option<String>,
+    force_branch_delete: bool,
+}
+
+impl IntegrationTarget {
+    fn protects_branch(&self, repo: &RepoRoot, branch: &str) -> bool {
+        self.protected_branches.contains(branch)
+            || self.protected_tip.as_deref().is_some_and(|tip| {
+                git::branch_oid(repo, &BranchName::new(branch)).as_deref() == Some(tip)
+            })
+    }
+}
+
+fn local_branch_revision(repo: &RepoRoot, revision: &str) -> Option<String> {
+    if let Some(branch) = revision.strip_prefix("refs/heads/") {
+        let branch_name = BranchName::new(branch);
+        return git::branch_exists(repo, &branch_name).then_some(branch.to_string());
+    }
+
+    if revision == "HEAD" {
+        return git::current_branch(repo);
+    }
+
+    if revision.starts_with("refs/") {
+        return None;
+    }
+
+    let branch_name = BranchName::new(revision);
+    git::branch_exists(repo, &branch_name).then_some(revision.to_string())
+}
+
+fn resolve_integration_target(
+    repo: &RepoRoot,
+    mainline_override: Option<&str>,
+) -> Result<IntegrationTarget> {
+    let requested = match mainline_override {
+        Some(revision) => revision.to_string(),
         None => git::resolve_mainline(repo)?,
     };
+
+    if let Some(branch) = local_branch_revision(repo, &requested) {
+        let force_branch_delete = git::current_branch(repo).as_deref() != Some(branch.as_str());
+        return Ok(IntegrationTarget {
+            revision: branch.clone(),
+            protected_branches: [branch].into_iter().collect(),
+            protected_tip: None,
+            force_branch_delete,
+        });
+    }
+
+    if let Some(remote) = git::remote_branch_revision(repo, &requested) {
+        let protected_branches = git::local_branch_for_remote(repo, &remote)
+            .into_iter()
+            .collect();
+        return Ok(IntegrationTarget {
+            revision: remote,
+            protected_branches,
+            protected_tip: Some(git::resolve_commit(repo, &requested)?),
+            force_branch_delete: true,
+        });
+    }
+
+    let commit = git::resolve_commit(repo, &requested)
+        .map_err(|_| AppError::usage(format!("mainline branch '{requested}' does not exist")))?;
+
+    Ok(IntegrationTarget {
+        revision: commit.clone(),
+        protected_branches: HashSet::new(),
+        protected_tip: Some(commit),
+        force_branch_delete: true,
+    })
+}
+
+/// Dry-run: scan worktrees and preserved local branches without removing anything.
+pub fn prune_dry_run(repo: &RepoRoot, mainline_override: Option<&str>) -> Result<PruneDryRun> {
+    let target = resolve_integration_target(repo, mainline_override)?;
+    let mainline = target.revision.clone();
 
     let worktrees = git::list_worktrees(repo)?;
     let worktree_branches: HashSet<String> = worktrees
         .iter()
         .filter_map(|wt| wt.branch.clone())
         .collect();
+    let mut stale_marker_branches = HashSet::new();
+    let preserved_branches = git::list_preserved_branches(repo)?;
+    let mut valid_preserved_branches = Vec::new();
+
+    // Validate every marker before adding worktree entries. This also blocks a
+    // moved preserved branch that was recreated/reattached as a worktree from
+    // falling through the ordinary worktree cleanup path.
+    for preserved in preserved_branches {
+        let branch = BranchName::new(&preserved.name);
+        if git::branch_oid(repo, &branch).as_deref() != Some(preserved.oid.as_str()) {
+            git::clear_preserved_branch(repo, &branch)?;
+            stale_marker_branches.insert(preserved.name);
+        } else {
+            valid_preserved_branches.push(preserved);
+        }
+    }
+
     let mut entries = Vec::new();
 
     for wt in &worktrees {
-        if wt.is_main || wt.branch.as_deref() == Some(mainline.as_str()) {
+        if wt.is_main
+            || wt
+                .branch
+                .as_deref()
+                .is_some_and(|branch| target.protects_branch(repo, branch))
+            || wt
+                .branch
+                .as_deref()
+                .is_some_and(|branch| stale_marker_branches.contains(branch))
+        {
             continue;
         }
 
@@ -480,22 +596,30 @@ pub fn prune_dry_run(repo: &RepoRoot, mainline_override: Option<&str>) -> Result
             branch: wt.branch.clone(),
             path: Some(wt.path.clone()),
             status,
+            preserved_oid: None,
+            force_branch_delete: target.force_branch_delete,
         });
     }
 
     // A worktree removed with --keep-branch no longer appears in `git
     // worktree list`. Its private lifecycle marker lets a later prune delete
     // the preserved branch once its commits reach the selected target,
-    // without treating every unrelated local branch as pruneable.
-    for branch in git::list_preserved_branches(repo)? {
-        if branch == mainline || worktree_branches.contains(&branch) {
+    // without treating every unrelated local branch as pruneable. The marker
+    // OID is checked before planning; a moved, deleted, or recreated branch
+    // invalidates the old preservation request and its marker is cleared.
+    for preserved in valid_preserved_branches {
+        if worktree_branches.contains(&preserved.name)
+            || target.protects_branch(repo, &preserved.name)
+        {
             continue;
         }
 
         entries.push(WorktreePruneEntry {
-            status: classify_integration(repo, &branch, &mainline),
-            branch: Some(branch),
+            status: classify_integration(repo, &preserved.name, &mainline),
+            branch: Some(preserved.name),
             path: None,
+            preserved_oid: Some(preserved.oid),
+            force_branch_delete: target.force_branch_delete,
         });
     }
 
@@ -530,7 +654,34 @@ fn prune_integrated_entry(
         return;
     };
 
+    // Recheck the marker immediately before deleting. `prune_execute` plans
+    // first, so a branch moved between planning and execution must not be
+    // authorized by an old preservation marker.
+    match entry.preserved_oid.as_deref() {
+        Some(expected_oid)
+            if git::branch_oid(repo, &BranchName::new(&branch_name)).as_deref()
+                != Some(expected_oid) =>
+        {
+            git::clear_preserved_branch(repo, &BranchName::new(&branch_name))
+                .err()
+                .into_iter()
+                .for_each(|e| {
+                    acc.warnings.push(format!(
+                        "stale lifecycle marker for '{branch_name}' could not be cleared: {e}"
+                    ));
+                });
+            acc.skipped.push(SkippedEntry {
+                branch: Some(branch_name),
+                path: entry.path,
+                reason: "stale_marker".to_string(),
+            });
+            return;
+        }
+        _ => {}
+    }
+
     let force_branch = force
+        || entry.force_branch_delete
         || matches!(
             &entry.status,
             IntegrationStatus::Integrated(IntegrationMethod::Rebase)

--- a/tests/cli_add_remove.rs
+++ b/tests/cli_add_remove.rs
@@ -1,10 +1,62 @@
 mod fixtures;
 
+use std::process::Command as StdCommand;
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 
 fn wt_core() -> Command {
     Command::new(assert_cmd::cargo_bin!("wt-core"))
+}
+
+const GIT_ENV_OVERRIDES: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_PREFIX",
+];
+
+fn branch_exists(repo: &std::path::Path, branch: &str) -> bool {
+    let mut command = StdCommand::new("git");
+    command
+        .args(["show-ref", "--verify", &format!("refs/heads/{branch}")])
+        .current_dir(repo);
+    for var in GIT_ENV_OVERRIDES {
+        command.env_remove(var);
+    }
+    command
+        .output()
+        .expect("git show-ref failed")
+        .status
+        .success()
+}
+
+fn assert_branch_exists(repo: &std::path::Path, branch: &str) {
+    assert!(branch_exists(repo, branch), "branch should exist: {branch}");
+}
+
+fn assert_branch_deleted(repo: &std::path::Path, branch: &str) {
+    assert!(
+        !branch_exists(repo, branch),
+        "branch should be deleted: {branch}"
+    );
+}
+
+fn find_worktree_dir_optional(
+    repo: &std::path::Path,
+    slug_prefix: &str,
+) -> Option<std::path::PathBuf> {
+    std::fs::read_dir(repo.join(".worktrees"))
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(slug_prefix))
+        })
 }
 
 #[test]
@@ -178,6 +230,8 @@ fn remove_deletes_worktree_and_branch() {
         .assert()
         .success();
 
+    assert_branch_deleted(&repo.path(), "to-remove");
+
     // Verify worktree is gone
     let entries: Vec<_> = std::fs::read_dir(repo.path().join(".worktrees"))
         .unwrap_or_else(|_| std::fs::read_dir(repo.path()).expect("repo gone"))
@@ -237,10 +291,122 @@ fn remove_json_includes_removed_path() {
     assert_eq!(json["event"], "reset");
     assert!(json["removed_path"].as_str().is_some());
     assert!(json["repo_root"].as_str().is_some());
+    assert_eq!(json["worktree_removed"], true);
+    assert_eq!(json["branch_deleted"], true);
 }
 
 #[test]
-fn remove_print_paths_returns_three_lines() {
+fn remove_keep_branch_preserves_branch_and_reports_separate_cleanup() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "staged/source", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let output = wt_core()
+        .args([
+            "remove",
+            "staged/source",
+            "--keep-branch",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+    assert_eq!(json["worktree_removed"], true);
+    assert_eq!(json["branch_deleted"], false);
+    assert_eq!(
+        json["message"],
+        "removed worktree and kept branch 'staged/source'"
+    );
+    assert_branch_exists(&repo.path(), "staged/source");
+    assert!(find_worktree_dir_optional(&repo.path(), "staged-source").is_none());
+}
+
+#[test]
+fn remove_keep_branch_preserves_dirty_safety() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "staged/dirty", "--repo", &repo_str])
+        .assert()
+        .success();
+    let wt_dir = fixtures::find_worktree_dir(&repo.path(), "staged-dirty");
+    std::fs::write(wt_dir.join("uncommitted.txt"), "dirty").expect("write failed");
+
+    wt_core()
+        .args([
+            "remove",
+            "staged/dirty",
+            "--keep-branch",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(5);
+    assert_branch_exists(&repo.path(), "staged/dirty");
+    assert!(wt_dir.exists());
+
+    wt_core()
+        .args([
+            "remove",
+            "staged/dirty",
+            "--keep-branch",
+            "--force",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+    assert_branch_exists(&repo.path(), "staged/dirty");
+    assert!(!wt_dir.exists());
+}
+
+#[test]
+fn remove_keep_branch_print_paths_reports_branch_retained() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "staged/paths", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let output = wt_core()
+        .args([
+            "remove",
+            "staged/paths",
+            "--keep-branch",
+            "--print-paths",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("invalid utf8");
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 4, "expected exactly 4 lines: {stdout}");
+    assert_eq!(lines[2], "staged/paths");
+    assert_eq!(lines[3], "false");
+    assert_branch_exists(&repo.path(), "staged/paths");
+}
+
+#[test]
+fn remove_print_paths_returns_four_lines() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
 
@@ -266,7 +432,7 @@ fn remove_print_paths_returns_three_lines() {
 
     let stdout = String::from_utf8(output).expect("invalid utf8");
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert_eq!(lines.len(), 3, "expected exactly 3 lines: {stdout}");
+    assert_eq!(lines.len(), 4, "expected exactly 4 lines: {stdout}");
 
     // Line 1: removed worktree path (under .worktrees/)
     assert!(
@@ -287,6 +453,9 @@ fn remove_print_paths_returns_three_lines() {
         lines[2], "feature/paths-rm",
         "line 3 should be the real branch name, not the slug"
     );
+
+    // Line 4: branch was deleted by the default cleanup.
+    assert_eq!(lines[3], "true");
 
     // No line should be JSON
     assert!(!lines[0].starts_with('{'));
@@ -435,8 +604,9 @@ fn remove_no_branch_print_paths_uses_cwd_inference() {
 
     let stdout = String::from_utf8(output).expect("invalid utf8");
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert_eq!(lines.len(), 3);
+    assert_eq!(lines.len(), 4);
     assert_eq!(lines[2], "paths-infer");
+    assert_eq!(lines[3], "true");
 }
 
 #[test]
@@ -477,8 +647,9 @@ fn remove_no_branch_print_paths_from_nested_dir_uses_cwd_inference() {
 
     let stdout = String::from_utf8(output).expect("invalid utf8");
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert_eq!(lines.len(), 3);
+    assert_eq!(lines.len(), 4);
     assert_eq!(lines[2], "paths-infer-nested");
+    assert_eq!(lines[3], "true");
 }
 
 #[test]

--- a/tests/cli_add_remove.rs
+++ b/tests/cli_add_remove.rs
@@ -373,7 +373,7 @@ fn remove_keep_branch_preserves_dirty_safety() {
 }
 
 #[test]
-fn remove_keep_branch_print_paths_reports_branch_retained() {
+fn remove_keep_branch_print_paths_preserves_legacy_protocol() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
 
@@ -399,14 +399,13 @@ fn remove_keep_branch_print_paths_reports_branch_retained() {
 
     let stdout = String::from_utf8(output).expect("invalid utf8");
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert_eq!(lines.len(), 4, "expected exactly 4 lines: {stdout}");
+    assert_eq!(lines.len(), 3, "expected exactly 3 lines: {stdout}");
     assert_eq!(lines[2], "staged/paths");
-    assert_eq!(lines[3], "false");
     assert_branch_exists(&repo.path(), "staged/paths");
 }
 
 #[test]
-fn remove_print_paths_returns_four_lines() {
+fn remove_print_paths_returns_three_lines() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
 
@@ -432,7 +431,7 @@ fn remove_print_paths_returns_four_lines() {
 
     let stdout = String::from_utf8(output).expect("invalid utf8");
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert_eq!(lines.len(), 4, "expected exactly 4 lines: {stdout}");
+    assert_eq!(lines.len(), 3, "expected exactly 3 lines: {stdout}");
 
     // Line 1: removed worktree path (under .worktrees/)
     assert!(
@@ -453,9 +452,6 @@ fn remove_print_paths_returns_four_lines() {
         lines[2], "feature/paths-rm",
         "line 3 should be the real branch name, not the slug"
     );
-
-    // Line 4: branch was deleted by the default cleanup.
-    assert_eq!(lines[3], "true");
 
     // No line should be JSON
     assert!(!lines[0].starts_with('{'));
@@ -604,9 +600,8 @@ fn remove_no_branch_print_paths_uses_cwd_inference() {
 
     let stdout = String::from_utf8(output).expect("invalid utf8");
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert_eq!(lines.len(), 4);
+    assert_eq!(lines.len(), 3);
     assert_eq!(lines[2], "paths-infer");
-    assert_eq!(lines[3], "true");
 }
 
 #[test]
@@ -647,9 +642,8 @@ fn remove_no_branch_print_paths_from_nested_dir_uses_cwd_inference() {
 
     let stdout = String::from_utf8(output).expect("invalid utf8");
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert_eq!(lines.len(), 4);
+    assert_eq!(lines.len(), 3);
     assert_eq!(lines[2], "paths-infer-nested");
-    assert_eq!(lines[3], "true");
 }
 
 #[test]

--- a/tests/cli_add_remove.rs
+++ b/tests/cli_add_remove.rs
@@ -5,6 +5,8 @@ use std::process::Command as StdCommand;
 use assert_cmd::Command;
 use predicates::prelude::*;
 
+use fixtures::run_git;
+
 fn wt_core() -> Command {
     Command::new(assert_cmd::cargo_bin!("wt-core"))
 }
@@ -31,6 +33,21 @@ fn branch_exists(repo: &std::path::Path, branch: &str) -> bool {
         .expect("git show-ref failed")
         .status
         .success()
+}
+
+fn git_ref_hash(repo: &std::path::Path, reference: &str) -> Option<String> {
+    let mut command = StdCommand::new("git");
+    command
+        .args(["rev-parse", "--verify", reference])
+        .current_dir(repo);
+    for var in GIT_ENV_OVERRIDES {
+        command.env_remove(var);
+    }
+    let output = command.output().expect("git rev-parse failed");
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn assert_branch_exists(repo: &std::path::Path, branch: &str) {
@@ -356,6 +373,10 @@ fn remove_keep_branch_preserves_dirty_safety() {
         .code(5);
     assert_branch_exists(&repo.path(), "staged/dirty");
     assert!(wt_dir.exists());
+    assert!(
+        git_ref_hash(&repo.path(), "refs/wt-core/preserved/staged/dirty").is_none(),
+        "failed initial keep should not retain a new marker"
+    );
 
     wt_core()
         .args([
@@ -370,6 +391,76 @@ fn remove_keep_branch_preserves_dirty_safety() {
         .success();
     assert_branch_exists(&repo.path(), "staged/dirty");
     assert!(!wt_dir.exists());
+}
+
+#[test]
+fn remove_keep_branch_failed_retry_preserves_marker_for_later_prune() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let branch = "feature/retry-marker";
+
+    wt_core()
+        .args(["add", branch, "--repo", &repo_str])
+        .assert()
+        .success();
+    let feature_dir = fixtures::find_worktree_dir(&repo.path(), "feature-retry-marker");
+    fixtures::commit_file(&feature_dir, "feature.txt", "feature", "feature commit");
+
+    // The first removal preserves the branch and creates the valid marker
+    // that a later prune will use.
+    wt_core()
+        .args(["remove", branch, "--keep-branch", "--repo", &repo_str])
+        .assert()
+        .success();
+    let marker_ref = "refs/wt-core/preserved/feature/retry-marker";
+    let marker_oid = git_ref_hash(&repo.path(), marker_ref).expect("marker should exist");
+    assert_eq!(
+        Some(marker_oid.clone()),
+        git_ref_hash(&repo.path(), "refs/heads/feature/retry-marker")
+    );
+
+    // Reattach the preserved branch and make the worktree dirty. A failed
+    // repeated remove must keep the original marker intact.
+    let reattached = repo.path().join("retry-marker-reattached");
+    run_git(
+        &["worktree", "add", &reattached.display().to_string(), branch],
+        &repo.path(),
+    );
+    std::fs::write(reattached.join("uncommitted.txt"), "dirty")
+        .expect("failed to make reattached worktree dirty");
+    wt_core()
+        .args(["remove", branch, "--keep-branch", "--repo", &repo_str])
+        .assert()
+        .failure()
+        .code(5);
+    assert!(reattached.exists());
+    assert_eq!(
+        Some(marker_oid.clone()),
+        git_ref_hash(&repo.path(), marker_ref)
+    );
+
+    // Once the dirty worktree is forcibly detached and its feature is
+    // integrated, prune should still recognize the preserved branch.
+    run_git(&["checkout", "main"], &repo.path());
+    run_git(&["merge", branch], &repo.path());
+    wt_core()
+        .args([
+            "remove",
+            branch,
+            "--keep-branch",
+            "--force",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+    wt_core()
+        .args(["prune", "--execute", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    assert_branch_deleted(&repo.path(), branch);
+    assert!(git_ref_hash(&repo.path(), marker_ref).is_none());
 }
 
 #[test]

--- a/tests/cli_prune.rs
+++ b/tests/cli_prune.rs
@@ -231,6 +231,127 @@ fn prune_execute_no_integrated_worktrees() {
 
 // ── Mainline tests ──────────────────────────────────────────────────
 
+/// Create a linked integration target and a candidate worktree merged into it.
+/// The target is deliberately linked, so a raw revision comparison would
+/// incorrectly classify it as a prune candidate.
+fn setup_linked_integration_target(repo: &std::path::Path) -> (std::path::PathBuf, String) {
+    run_git(&["branch", "integration/release"], repo);
+    let target_dir = repo.join("integration-target");
+    run_git(
+        &[
+            "worktree",
+            "add",
+            &target_dir.display().to_string(),
+            "integration/release",
+        ],
+        repo,
+    );
+
+    let repo_str = repo.display().to_string();
+    wt_core()
+        .args(["add", "feature/target-candidate", "--repo", &repo_str])
+        .assert()
+        .success();
+    let candidate_dir = find_worktree_dir(repo, "feature-target-candidate");
+    commit_file(
+        &candidate_dir,
+        "target.txt",
+        "target candidate",
+        "target candidate",
+    );
+    run_git(
+        &["merge", "--no-ff", "feature/target-candidate"],
+        &target_dir,
+    );
+
+    let target_sha = git_ref_hash(&target_dir, "HEAD").expect("target should have a tip");
+    (target_dir, target_sha)
+}
+
+fn assert_target_survives_prune(
+    repo: &std::path::Path,
+    target_dir: &std::path::Path,
+    target_revision: &str,
+    expected_mainline: &str,
+) {
+    let repo_str = repo.display().to_string();
+    let output = wt_core()
+        .args([
+            "prune",
+            "--integrated-into",
+            target_revision,
+            "--execute",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+    assert_eq!(json["mainline"], expected_mainline);
+    assert!(target_dir.exists(), "selected target worktree was pruned");
+    assert_branch_exists(repo, "integration/release");
+    assert_branch_deleted(repo, "feature/target-candidate");
+}
+
+#[test]
+fn prune_never_prunes_linked_target_branch() {
+    let repo = fixtures::TestRepo::new();
+    let (target_dir, _) = setup_linked_integration_target(&repo.path());
+
+    assert_target_survives_prune(
+        &repo.path(),
+        &target_dir,
+        "integration/release",
+        "integration/release",
+    );
+}
+
+#[test]
+fn prune_canonicalizes_full_target_ref_and_protects_linked_target() {
+    let repo = fixtures::TestRepo::new();
+    let (target_dir, _) = setup_linked_integration_target(&repo.path());
+
+    assert_target_survives_prune(
+        &repo.path(),
+        &target_dir,
+        "refs/heads/integration/release",
+        "integration/release",
+    );
+}
+
+#[test]
+fn prune_protects_linked_target_selected_by_remote_ref() {
+    let repo = fixtures::TestRepo::new();
+    let (target_dir, target_sha) = setup_linked_integration_target(&repo.path());
+    run_git(
+        &[
+            "update-ref",
+            "refs/remotes/origin/integration/release",
+            &target_sha,
+        ],
+        &repo.path(),
+    );
+
+    assert_target_survives_prune(
+        &repo.path(),
+        &target_dir,
+        "origin/integration/release",
+        "origin/integration/release",
+    );
+}
+
+#[test]
+fn prune_conservatively_protects_target_selected_by_commit_sha() {
+    let repo = fixtures::TestRepo::new();
+    let (target_dir, target_sha) = setup_linked_integration_target(&repo.path());
+
+    assert_target_survives_prune(&repo.path(), &target_dir, &target_sha, &target_sha);
+}
+
 #[test]
 fn prune_integrated_into_removes_preserved_branch_without_worktree() {
     let repo = fixtures::TestRepo::new();
@@ -307,6 +428,174 @@ fn prune_integrated_into_removes_preserved_branch_without_worktree() {
     assert_eq!(pruned[0]["branch_deleted"], true);
     assert_eq!(pruned[0]["path"], serde_json::Value::Null);
     assert_branch_deleted(&repo.path(), "feature/staged");
+}
+
+#[test]
+fn prune_rejects_moved_preserved_branch_and_clears_marker() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/moved-marker", "--repo", &repo_str])
+        .assert()
+        .success();
+    let feature_dir = find_worktree_dir(&repo.path(), "feature-moved-marker");
+    commit_file(&feature_dir, "moved.txt", "moved", "moved feature");
+    run_git(&["checkout", "main"], &repo.path());
+    run_git(&["merge", "feature/moved-marker"], &repo.path());
+
+    wt_core()
+        .args([
+            "remove",
+            "feature/moved-marker",
+            "--keep-branch",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+
+    let marker = git_ref_hash(&repo.path(), "refs/wt-core/preserved/feature/moved-marker")
+        .expect("preservation marker should exist");
+    assert_eq!(marker, git_log_hash(&repo.path(), "feature/moved-marker"));
+    commit_file(
+        &repo.path(),
+        "after-preserve-move.txt",
+        "after preserve",
+        "advance target",
+    );
+
+    // A moved ref is a different branch incarnation and must not be pruned,
+    // even though its new tip is already integrated into main.
+    run_git(
+        &["branch", "-f", "feature/moved-marker", "main"],
+        &repo.path(),
+    );
+    let reattached = repo.path().join("moved-marker-reattached");
+    run_git(
+        &[
+            "worktree",
+            "add",
+            &reattached.display().to_string(),
+            "feature/moved-marker",
+        ],
+        &repo.path(),
+    );
+    wt_core()
+        .args(["prune", "--execute", "--json", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    assert_branch_exists(&repo.path(), "feature/moved-marker");
+    assert!(
+        reattached.exists(),
+        "stale reattached worktree should survive"
+    );
+    assert!(
+        git_ref_hash(&repo.path(), "refs/wt-core/preserved/feature/moved-marker").is_none(),
+        "stale marker should be cleared"
+    );
+}
+
+#[test]
+fn prune_rejects_recreated_preserved_branch_and_clears_marker() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/recreated-marker", "--repo", &repo_str])
+        .assert()
+        .success();
+    let feature_dir = find_worktree_dir(&repo.path(), "feature-recreated-marker");
+    commit_file(
+        &feature_dir,
+        "recreated.txt",
+        "recreated",
+        "recreated feature",
+    );
+    run_git(&["checkout", "main"], &repo.path());
+    run_git(&["merge", "feature/recreated-marker"], &repo.path());
+
+    wt_core()
+        .args([
+            "remove",
+            "feature/recreated-marker",
+            "--keep-branch",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+
+    commit_file(
+        &repo.path(),
+        "after-preserve-recreate.txt",
+        "after preserve",
+        "advance target",
+    );
+    run_git(&["branch", "-D", "feature/recreated-marker"], &repo.path());
+    run_git(
+        &["branch", "feature/recreated-marker", "main"],
+        &repo.path(),
+    );
+
+    wt_core()
+        .args(["prune", "--execute", "--json", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    assert_branch_exists(&repo.path(), "feature/recreated-marker");
+    assert!(
+        git_ref_hash(
+            &repo.path(),
+            "refs/wt-core/preserved/feature/recreated-marker"
+        )
+        .is_none(),
+        "recreated branch marker should be cleared"
+    );
+}
+
+#[test]
+fn successful_default_deletion_clears_an_existing_marker() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/clear-marker", "--repo", &repo_str])
+        .assert()
+        .success();
+    wt_core()
+        .args([
+            "remove",
+            "feature/clear-marker",
+            "--keep-branch",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+
+    // Reattach the preserved branch, then take the normal deletion path.
+    let reattached = repo.path().join("reattached-worktree");
+    run_git(
+        &[
+            "worktree",
+            "add",
+            &reattached.display().to_string(),
+            "feature/clear-marker",
+        ],
+        &repo.path(),
+    );
+    wt_core()
+        .args(["remove", "feature/clear-marker", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    assert_branch_deleted(&repo.path(), "feature/clear-marker");
+    assert!(
+        git_ref_hash(&repo.path(), "refs/wt-core/preserved/feature/clear-marker").is_none(),
+        "successful deletion should clear the marker"
+    );
 }
 
 #[test]
@@ -669,6 +958,20 @@ fn git_log_hash(repo: &std::path::Path, branch: &str) -> String {
     }
     let output = cmd.output().expect("git log failed");
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn git_ref_hash(repo: &std::path::Path, reference: &str) -> Option<String> {
+    let mut cmd = StdCommand::new("git");
+    cmd.args(["rev-parse", "--verify", reference])
+        .current_dir(repo);
+    for var in GIT_ENV_OVERRIDES {
+        cmd.env_remove(var);
+    }
+    let output = cmd.output().expect("git rev-parse failed");
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 /// Assert that a branch exists in the repo.

--- a/tests/cli_prune.rs
+++ b/tests/cli_prune.rs
@@ -232,6 +232,139 @@ fn prune_execute_no_integrated_worktrees() {
 // ── Mainline tests ──────────────────────────────────────────────────
 
 #[test]
+fn prune_integrated_into_removes_preserved_branch_without_worktree() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/staged", "--repo", &repo_str])
+        .assert()
+        .success();
+    let staged_dir = find_worktree_dir(&repo.path(), "feature-staged");
+    commit_file(&staged_dir, "staged.txt", "staged", "staged feature");
+
+    run_git(&["branch", "integration/release"], &repo.path());
+    run_git(&["checkout", "integration/release"], &repo.path());
+    run_git(&["merge", "feature/staged"], &repo.path());
+
+    // The source worktree is no longer needed, but the branch must survive
+    // until the integration target has landed.
+    wt_core()
+        .args([
+            "remove",
+            "feature/staged",
+            "--keep-branch",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+    assert_branch_exists(&repo.path(), "feature/staged");
+
+    let output = wt_core()
+        .args([
+            "prune",
+            "--integrated-into",
+            "integration/release",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+    assert_eq!(json["mainline"], "integration/release");
+    assert_eq!(json["prunable"], 1);
+    let candidates = json["worktrees"].as_array().expect("worktrees array");
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0]["branch"], "feature/staged");
+    assert_eq!(candidates[0]["path"], serde_json::Value::Null);
+    assert_eq!(candidates[0]["worktree_present"], false);
+    assert_eq!(candidates[0]["branch_will_be_deleted"], true);
+
+    let output = wt_core()
+        .args([
+            "prune",
+            "--integrated-into",
+            "integration/release",
+            "--execute",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+    let pruned = json["pruned"].as_array().expect("pruned array");
+    assert_eq!(pruned.len(), 1);
+    assert_eq!(pruned[0]["worktree_removed"], false);
+    assert_eq!(pruned[0]["branch_deleted"], true);
+    assert_eq!(pruned[0]["path"], serde_json::Value::Null);
+    assert_branch_deleted(&repo.path(), "feature/staged");
+}
+
+#[test]
+fn prune_later_mainline_cleanup_deletes_preserved_branch() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/eventual", "--repo", &repo_str])
+        .assert()
+        .success();
+    let staged_dir = find_worktree_dir(&repo.path(), "feature-eventual");
+    commit_file(&staged_dir, "eventual.txt", "eventual", "eventual feature");
+
+    run_git(&["branch", "integration/release"], &repo.path());
+    run_git(&["checkout", "integration/release"], &repo.path());
+    run_git(&["merge", "feature/eventual"], &repo.path());
+    wt_core()
+        .args([
+            "remove",
+            "feature/eventual",
+            "--keep-branch",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+
+    // The staged target has the feature, but main does not yet. The branch
+    // must remain preserved during this first prune.
+    run_git(&["checkout", "main"], &repo.path());
+    wt_core()
+        .args(["prune", "--execute", "--repo", &repo_str])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No worktrees pruned."));
+    assert_branch_exists(&repo.path(), "feature/eventual");
+
+    // Once the integration target lands on main, the next mainline prune can
+    // delete the preserved branch even though its worktree is already gone.
+    run_git(&["merge", "integration/release"], &repo.path());
+    let output = wt_core()
+        .args(["prune", "--execute", "--json", "--repo", &repo_str])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+    let pruned = json["pruned"].as_array().expect("pruned array");
+    assert_eq!(pruned.len(), 1);
+    assert_eq!(pruned[0]["branch"], "feature/eventual");
+    assert_eq!(pruned[0]["worktree_removed"], false);
+    assert_eq!(pruned[0]["branch_deleted"], true);
+    assert_branch_deleted(&repo.path(), "feature/eventual");
+}
+
+#[test]
 fn prune_mainline_auto_detects_main() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
@@ -536,6 +669,20 @@ fn git_log_hash(repo: &std::path::Path, branch: &str) -> String {
     }
     let output = cmd.output().expect("git log failed");
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// Assert that a branch exists in the repo.
+fn assert_branch_exists(repo: &std::path::Path, branch: &str) {
+    let mut cmd = StdCommand::new("git");
+    cmd.args(["show-ref", "--verify", &format!("refs/heads/{branch}")])
+        .current_dir(repo);
+    for var in GIT_ENV_OVERRIDES {
+        cmd.env_remove(var);
+    }
+    assert!(
+        cmd.output().expect("git show-ref failed").status.success(),
+        "branch should exist: {branch}"
+    );
 }
 
 /// Assert that a branch does not exist in the repo.


### PR DESCRIPTION
## Summary
- Add `remove --keep-branch` to separate worktree removal from local branch deletion.
- Add `prune --integrated-into <revision>` with lifecycle-aware dry-run and JSON output.
- Preserve existing default removal behavior and shell binding compatibility.

## Validation
- `git diff --check main...HEAD`
- Added CLI coverage for preserved branches, custom integration targets, dry-run, and eventual cleanup.

Closes #73