### PR TITLE
feat: add worktree command execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   check:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "unicode-width",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,11 @@ unicode-width = "0.2"
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ these conventions upfront makes everything else predictable.
 
 - **Three output modes everywhere.** Every command supports human-readable
   output (default), `--json` for machine consumption, and a
-  `--print-cd-path` / `--print-paths` mode for shell wrappers.
+  `--print-cd-path` / `--print-paths` mode for shell wrappers. `exec --json`
+  is the exception: it writes metadata to stderr so the child owns stdout
+  unchanged.
 
 - **Interactive when appropriate.** When a branch argument is omitted in a
   TTY, `go`, `remove`, and `merge` present a fuzzy picker instead of failing.
@@ -48,6 +50,7 @@ these conventions upfront makes everything else predictable.
 ```
 wt add <branch> [--base <rev>]         Create a worktree and branch
 wt go [<branch>] [-i]                  Switch to an existing worktree
+wt exec <branch> -- <command...>       Run a command in a worktree
 wt list [--stats]                      List all worktrees
 wt remove [<branch>] [--force]         Remove a worktree and its local branch
 wt merge [<branch>] [--into <branch>]  Merge a branch and clean up
@@ -81,6 +84,21 @@ wt go feature/auth     # switch directly
 wt go                  # interactive picker (auto-selects if only one)
 wt go -i               # force picker even with one candidate
 ```
+
+### `wt exec`
+
+Resolves the branch using the same worktree lookup as `wt go`, then runs the
+command directly in that worktree. Arguments after `--` are passed unchanged;
+no shell is inserted. The child inherits stdin, stdout, and stderr, and its
+exit status is returned by `wt-core`.
+
+```bash
+wt exec feature/auth -- cargo test
+wt exec feature/auth -- make preview
+```
+
+Use `--json` to emit one compact metadata object on stderr before the child
+starts. This keeps child stdout suitable for command output and pipelines.
 
 ### `wt list`
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ wt exec feature/auth -- make preview
 Use `--json` to emit one compact `exec_resolved` metadata object on stderr
 before the child starts. The first line is resolution metadata, not a command
 result (`resolved: true` means only that the worktree was resolved). Child
-stdout and stderr remain inherited; child stderr follows on the same mixed
-stderr stream, so the entire stream is not one parseable JSON document.
+stdout and stderr remain inherited. After the metadata line, stderr may contain
+inherited child diagnostics or a `wt-core` launch error if the command cannot
+be started, so the entire stream is not one parseable JSON document.
 
 The metadata schema is:
 
@@ -246,7 +247,8 @@ Example: branch `feature/auth` → `.worktrees/feature-auth--a1b2c3d4/`
 
 For commands other than `exec`, `--json` emits one compact JSON object per
 line on stdout. `exec --json` emits only its first resolution line as JSON on
-stderr; the rest of stderr is the inherited child diagnostic stream.
+stderr; post-metadata stderr may contain inherited child diagnostics or a
+`wt-core` launch error if the command cannot be started.
 
 JSON envelope example (`add`, `go`, `remove`):
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ these conventions upfront makes everything else predictable.
 - **Three output modes everywhere.** Every command supports human-readable
   output (default), `--json` for machine consumption, and a
   `--print-cd-path` / `--print-paths` mode for shell wrappers. `exec --json`
-  is the exception: it writes metadata to stderr so the child owns stdout
-  unchanged.
+  is the exception: it writes resolution metadata to stderr so the child owns
+  stdout unchanged; child diagnostics may follow on that stderr stream.
 
 - **Interactive when appropriate.** When a branch argument is omitted in a
   TTY, `go`, `remove`, and `merge` present a fuzzy picker instead of failing.
@@ -97,8 +97,32 @@ wt exec feature/auth -- cargo test
 wt exec feature/auth -- make preview
 ```
 
-Use `--json` to emit one compact metadata object on stderr before the child
-starts. This keeps child stdout suitable for command output and pipelines.
+Use `--json` to emit one compact `exec_resolved` metadata object on stderr
+before the child starts. The first line is resolution metadata, not a command
+result (`resolved: true` means only that the worktree was resolved). Child
+stdout and stderr remain inherited; child stderr follows on the same mixed
+stderr stream, so the entire stream is not one parseable JSON document.
+
+The metadata schema is:
+
+```json
+{
+  "event": "exec_resolved",
+  "resolved": true,
+  "message": "resolved worktree for branch 'feature/auth'",
+  "branch": "feature/auth",
+  "repo_root": "/abs/repo",
+  "worktree_path": "/abs/repo/.worktrees/feature-auth--a1b2c3d4"
+}
+```
+
+On Unix, `wt-core` replaces itself with the resolved command, preserving
+native stdio, status, and signal behavior. On Windows, it waits for the child
+inside a kill-on-close Job Object so descendants are terminated if `wt-core`
+is terminated. If containment cannot be established, execution is stopped
+rather than leaving an uncontained child. Windows console-control behavior is
+still governed by Windows console semantics, and the short CreateProcess/job
+attachment interval is an unavoidable residual race.
 
 ### `wt list`
 
@@ -216,11 +240,13 @@ Example: branch `feature/auth` → `.worktrees/feature-auth--a1b2c3d4/`
 | Flag              | Behavior                                     |
 |-------------------|----------------------------------------------|
 | *(default)*       | Human-readable text                          |
-| `--json`          | Single-line JSON envelope on stdout          |
+| `--json`          | Single-line JSON envelope on stdout (except `exec`, which emits resolution metadata on stderr) |
 | `--print-cd-path` | Bare absolute path on stdout (for wrappers)  |
 | `--print-paths`   | Multi-line key values on stdout (for wrappers) |
 
-`--json` emits one compact JSON object per line so machine consumers can parse stdout line-by-line.
+For commands other than `exec`, `--json` emits one compact JSON object per
+line on stdout. `exec --json` emits only its first resolution line as JSON on
+stderr; the rest of stderr is the inherited child diagnostic stream.
 
 JSON envelope example (`add`, `go`, `remove`):
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,7 +92,8 @@ pub enum Command {
         #[arg(long)]
         repo: Option<PathBuf>,
 
-        /// Emit resolved worktree metadata as JSON on stderr
+        /// Emit one resolved-worktree metadata line on stderr
+        /// (child stderr follows on the same stream)
         #[arg(long)]
         json: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -80,6 +81,24 @@ pub enum Command {
         /// Print only the worktree path (for shell wrappers)
         #[arg(long, conflicts_with = "json")]
         print_cd_path: bool,
+    },
+
+    /// Execute a command in an existing worktree
+    Exec {
+        /// Branch name of the worktree to execute in
+        branch: String,
+
+        /// Repository path (defaults to current directory)
+        #[arg(long)]
+        repo: Option<PathBuf>,
+
+        /// Emit resolved worktree metadata as JSON on stderr
+        #[arg(long)]
+        json: bool,
+
+        /// Command and arguments to execute; must follow `--`
+        #[arg(last = true, required = true, num_args = 1.., value_name = "COMMAND")]
+        command: Vec<OsString>,
     },
 
     /// Remove a worktree and its local branch

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,10 @@
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::IsTerminal;
 use std::path::PathBuf;
-use std::process::{Command as ProcessCommand, ExitStatus, Stdio};
+use std::process::{Command as ProcessCommand, Stdio};
+
+#[cfg(not(unix))]
+use std::process::ExitStatus;
 
 use crate::cli::{Cli, ColorChoice, Command, MaterializeMode, Shell};
 use crate::domain::{self, BranchName, WorktreeStatsStatus};
@@ -17,9 +20,94 @@ use crate::output::{
 use crate::worktree;
 use unicode_width::UnicodeWidthStr;
 
+#[cfg(windows)]
+mod windows_job {
+    use std::io;
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawHandle;
+    use std::process::Child;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    /// Keeps the child and its descendants in a kill-on-close job.
+    ///
+    /// Windows has no Unix-style `exec`, so a terminated `wt-core` process
+    /// cannot otherwise guarantee that descendants do not outlive it.
+    pub struct ChildJob(HANDLE);
+
+    impl ChildJob {
+        pub fn for_child(child: &Child) -> io::Result<Self> {
+            // A private job with KILL_ON_JOB_CLOSE is closed automatically by
+            // the OS if wt-core is terminated without unwinding.
+            let handle =
+                // SAFETY: null attributes and name request an unnamed private job.
+                unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+            if handle.is_null() {
+                return Err(last_error());
+            }
+
+            let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            let configured =
+                // SAFETY: handle is valid and limits remains alive for this call.
+                unsafe {
+                    SetInformationJobObject(
+                        handle,
+                        JobObjectExtendedLimitInformation,
+                        (&limits as *const JOBOBJECT_EXTENDED_LIMIT_INFORMATION)
+                            .cast::<core::ffi::c_void>(),
+                        size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                    )
+                } != 0;
+            if !configured {
+                let error = last_error();
+                let _ =
+                    // SAFETY: handle was returned by CreateJobObjectW and is owned here.
+                    unsafe { CloseHandle(handle) };
+                return Err(error);
+            }
+
+            let assigned =
+                // SAFETY: handle is valid and the live child owns a valid process handle.
+                unsafe { AssignProcessToJobObject(handle, child.as_raw_handle()) } != 0;
+            if !assigned {
+                let error = last_error();
+                let _ =
+                    // SAFETY: handle was returned by CreateJobObjectW and is owned here.
+                    unsafe { CloseHandle(handle) };
+                return Err(error);
+            }
+
+            Ok(Self(handle))
+        }
+    }
+
+    impl Drop for ChildJob {
+        fn drop(&mut self) {
+            // Closing the final job handle terminates all remaining members.
+            let _ =
+                // SAFETY: self.0 is the owned handle returned by CreateJobObjectW.
+                unsafe { CloseHandle(self.0) };
+        }
+    }
+
+    fn last_error() -> io::Error {
+        let error =
+            // SAFETY: GetLastError has no preconditions and returns this thread's error.
+            unsafe { GetLastError() };
+        io::Error::from_raw_os_error(error as i32)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunOutcome {
     Success,
+    #[cfg_attr(unix, allow(dead_code))]
     Exit(i32),
 }
 
@@ -706,49 +794,85 @@ fn cmd_exec(
 
     if json {
         print_json_stderr(&JsonExecResponse {
-            ok: true,
-            message: format!("executing command in worktree for branch '{branch}'"),
+            event: "exec_resolved",
+            resolved: true,
+            message: format!("resolved worktree for branch '{branch}'"),
             branch: result.branch.to_string(),
             repo_root: result.repo_root.display().to_string(),
             worktree_path: result.worktree_path.display().to_string(),
         })?;
     }
 
-    let status = ProcessCommand::new(program)
+    let mut process = ProcessCommand::new(program);
+    process
         .args(&command[1..])
         .current_dir(&result.worktree_path)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .map_err(|error| {
-            AppError::usage(format!(
-                "failed to execute '{}': {error}",
-                program.to_string_lossy()
-            ))
-        })?;
+        .stderr(Stdio::inherit());
+    // Match internal Git invocations: a hook's GIT_DIR must not redirect the
+    // command away from the resolved worktree.
+    git::sanitize_git_environment(&mut process);
 
+    run_resolved_command(process, program)
+}
+
+#[cfg(unix)]
+fn run_resolved_command(mut process: ProcessCommand, program: &OsStr) -> Result<RunOutcome> {
+    use std::os::unix::process::CommandExt;
+
+    // Resolution has already completed. Replacing this process gives the
+    // command exact inherited stdio, exit status, and signal semantics; a
+    // supervisor terminating wt-core therefore terminates the command itself.
+    let error = process.exec();
+    Err(execution_error(program, error))
+}
+
+#[cfg(windows)]
+fn run_resolved_command(mut process: ProcessCommand, program: &OsStr) -> Result<RunOutcome> {
+    let mut child = process
+        .spawn()
+        .map_err(|error| execution_error(program, error))?;
+    let _job = match windows_job::ChildJob::for_child(&child) {
+        Ok(job) => job,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(AppError::usage(format!(
+                "failed to contain '{}': {error}",
+                program.to_string_lossy()
+            )));
+        }
+    };
+
+    let status = child
+        .wait()
+        .map_err(|error| execution_error(program, error))?;
     Ok(child_outcome(status))
 }
 
+#[cfg(not(any(unix, windows)))]
+fn run_resolved_command(mut process: ProcessCommand, program: &OsStr) -> Result<RunOutcome> {
+    let status = process
+        .status()
+        .map_err(|error| execution_error(program, error))?;
+    Ok(child_outcome(status))
+}
+
+fn execution_error(program: &OsStr, error: std::io::Error) -> AppError {
+    AppError::usage(format!(
+        "failed to execute '{}': {error}",
+        program.to_string_lossy()
+    ))
+}
+
+#[cfg(not(unix))]
 fn child_outcome(status: ExitStatus) -> RunOutcome {
     if status.success() {
-        return RunOutcome::Success;
+        RunOutcome::Success
+    } else {
+        RunOutcome::Exit(status.code().unwrap_or(1))
     }
-
-    let code = status.code().unwrap_or_else(|| {
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::ExitStatusExt;
-
-            status.signal().map_or(1, |signal| 128 + signal)
-        }
-        #[cfg(not(unix))]
-        {
-            1
-        }
-    });
-    RunOutcome::Exit(code)
 }
 
 /// Resolve a branch via interactive picker or error if not possible.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,20 +1,29 @@
+use std::ffi::OsString;
 use std::io::IsTerminal;
 use std::path::PathBuf;
+use std::process::{Command as ProcessCommand, ExitStatus, Stdio};
 
 use crate::cli::{Cli, ColorChoice, Command, MaterializeMode, Shell};
 use crate::domain::{self, BranchName, WorktreeStatsStatus};
 use crate::error::{AppError, Result};
 use crate::git;
 use crate::output::{
-    find_current_worktree, print_json, JsonDoctorResponse, JsonListResponse,
-    JsonMaterializeResponse, JsonMaterializeTimings, JsonMergeResponse, JsonPruneDryRunEntry,
-    JsonPruneDryRunResponse, JsonPruneExecuteResponse, JsonPrunedEntry, JsonResponse,
-    JsonSkippedEntry, MergeFormat, NavigationFormat, PruneFormat, RemoveFormat, StatusFormat,
+    find_current_worktree, print_json, print_json_stderr, JsonDoctorResponse, JsonExecResponse,
+    JsonListResponse, JsonMaterializeResponse, JsonMaterializeTimings, JsonMergeResponse,
+    JsonPruneDryRunEntry, JsonPruneDryRunResponse, JsonPruneExecuteResponse, JsonPrunedEntry,
+    JsonResponse, JsonSkippedEntry, MergeFormat, NavigationFormat, PruneFormat, RemoveFormat,
+    StatusFormat,
 };
 use crate::worktree;
 use unicode_width::UnicodeWidthStr;
 
-pub fn run(cli: Cli) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunOutcome {
+    Success,
+    Exit(i32),
+}
+
+pub fn run(cli: Cli) -> Result<RunOutcome> {
     match cli.command {
         Command::List {
             repo,
@@ -22,43 +31,55 @@ pub fn run(cli: Cli) -> Result<()> {
             stats,
             against,
             color,
-        } => cmd_list(repo, status_fmt(json), stats, against.as_deref(), color),
+        } => success(cmd_list(
+            repo,
+            status_fmt(json),
+            stats,
+            against.as_deref(),
+            color,
+        )),
         Command::Add {
             branch,
             base,
             repo,
             json,
             print_cd_path,
-        } => cmd_add(
+        } => success(cmd_add(
             &BranchName::new(&branch),
             base.as_deref(),
             repo,
             nav_fmt(json, print_cd_path),
-        ),
+        )),
         Command::Go {
             branch,
             interactive,
             repo,
             json,
             print_cd_path,
-        } => cmd_go(
+        } => success(cmd_go(
             branch.as_deref(),
             interactive,
             repo,
             nav_fmt(json, print_cd_path),
-        ),
+        )),
+        Command::Exec {
+            branch,
+            repo,
+            json,
+            command,
+        } => cmd_exec(&branch, repo, json, command),
         Command::Remove {
             branch,
             force,
             repo,
             json,
             print_paths,
-        } => cmd_remove(
+        } => success(cmd_remove(
             branch.as_deref().map(BranchName::new),
             force,
             repo,
             remove_fmt(json, print_paths),
-        ),
+        )),
         Command::Merge {
             branch,
             into,
@@ -67,14 +88,14 @@ pub fn run(cli: Cli) -> Result<()> {
             repo,
             json,
             print_paths,
-        } => cmd_merge(
+        } => success(cmd_merge(
             branch.as_deref().map(BranchName::new),
             into,
             push,
             no_cleanup,
             repo,
             merge_fmt(json, print_paths),
-        ),
+        )),
         Command::Materialize {
             repo_slug,
             remote_url,
@@ -85,7 +106,7 @@ pub fn run(cli: Cli) -> Result<()> {
             object_source,
             mode,
             json,
-        } => cmd_materialize(
+        } => success(cmd_materialize(
             crate::materialize::MaterializeOptions {
                 repo_slug,
                 remote_url,
@@ -97,7 +118,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 mode,
             },
             json,
-        ),
+        )),
         Command::Diff {
             branch,
             against,
@@ -108,25 +129,35 @@ pub fn run(cli: Cli) -> Result<()> {
             dry_run,
             print_command,
             repo,
-        } => cmd_diff(
+        } => success(cmd_diff(
             branch.as_deref().map(BranchName::new),
             against.as_deref(),
             DiffMode::from_flags(dirty, staged, unstaged)?,
             tool.as_deref(),
             dry_run || print_command,
             repo,
-        ),
+        )),
         Command::Prune {
             execute,
             force,
             mainline,
             repo,
             json,
-        } => cmd_prune(execute, force, mainline.as_deref(), repo, prune_fmt(json)),
-        Command::Setup { repo, json } => cmd_setup(repo, status_fmt(json)),
-        Command::Init { shell } => cmd_init(shell),
-        Command::Doctor { repo, json } => cmd_doctor(repo, status_fmt(json)),
+        } => success(cmd_prune(
+            execute,
+            force,
+            mainline.as_deref(),
+            repo,
+            prune_fmt(json),
+        )),
+        Command::Setup { repo, json } => success(cmd_setup(repo, status_fmt(json))),
+        Command::Init { shell } => success(cmd_init(shell)),
+        Command::Doctor { repo, json } => success(cmd_doctor(repo, status_fmt(json))),
     }
+}
+
+fn success(result: Result<()>) -> Result<RunOutcome> {
+    result.map(|()| RunOutcome::Success)
 }
 
 fn nav_fmt(json: bool, cd_path: bool) -> NavigationFormat {
@@ -659,6 +690,65 @@ fn cmd_go(
         }
     }
     Ok(())
+}
+
+fn cmd_exec(
+    branch: &str,
+    repo: Option<PathBuf>,
+    json: bool,
+    command: Vec<OsString>,
+) -> Result<RunOutcome> {
+    let program = command
+        .first()
+        .ok_or_else(|| AppError::usage("command is required after `--`"))?;
+    let repo = resolve_repo(repo)?;
+    let result = worktree::go(&repo, &BranchName::new(branch))?;
+
+    if json {
+        print_json_stderr(&JsonExecResponse {
+            ok: true,
+            message: format!("executing command in worktree for branch '{branch}'"),
+            branch: result.branch.to_string(),
+            repo_root: result.repo_root.display().to_string(),
+            worktree_path: result.worktree_path.display().to_string(),
+        })?;
+    }
+
+    let status = ProcessCommand::new(program)
+        .args(&command[1..])
+        .current_dir(&result.worktree_path)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|error| {
+            AppError::usage(format!(
+                "failed to execute '{}': {error}",
+                program.to_string_lossy()
+            ))
+        })?;
+
+    Ok(child_outcome(status))
+}
+
+fn child_outcome(status: ExitStatus) -> RunOutcome {
+    if status.success() {
+        return RunOutcome::Success;
+    }
+
+    let code = status.code().unwrap_or_else(|| {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+
+            status.signal().map_or(1, |signal| 128 + signal)
+        }
+        #[cfg(not(unix))]
+        {
+            1
+        }
+    });
+    RunOutcome::Exit(code)
 }
 
 /// Resolve a branch via interactive picker or error if not possible.

--- a/src/git.rs
+++ b/src/git.rs
@@ -17,6 +17,14 @@ const GIT_ENV_OVERRIDES: &[&str] = &[
     "GIT_PREFIX",
 ];
 
+/// Remove inherited Git context that could redirect a command to another
+/// repository (common when invoked from Git hooks).
+pub(crate) fn sanitize_git_environment(cmd: &mut Cmd) {
+    for var in GIT_ENV_OVERRIDES {
+        cmd.env_remove(var);
+    }
+}
+
 /// Run a git command and return stdout on success.
 ///
 /// Clears inherited `GIT_*` environment variables that could redirect
@@ -24,10 +32,7 @@ const GIT_ENV_OVERRIDES: &[&str] = &[
 fn git(args: &[&str], cwd: &Path) -> Result<String> {
     let mut cmd = Cmd::new("git");
     cmd.args(args).current_dir(cwd);
-
-    for var in GIT_ENV_OVERRIDES {
-        cmd.env_remove(var);
-    }
+    sanitize_git_environment(&mut cmd);
 
     let output = cmd
         .output()
@@ -226,10 +231,7 @@ pub fn delete_branch(repo: &RepoRoot, branch: &BranchName, force: bool) -> Resul
 fn git_success(args: &[&str], cwd: &Path) -> bool {
     let mut cmd = Cmd::new("git");
     cmd.args(args).current_dir(cwd);
-
-    for var in GIT_ENV_OVERRIDES {
-        cmd.env_remove(var);
-    }
+    sanitize_git_environment(&mut cmd);
 
     cmd.output().map(|o| o.status.success()).unwrap_or(false)
 }
@@ -537,10 +539,7 @@ fn parse_available_difftools(output: &str) -> HashSet<String> {
 fn git_config_get(path: &Path, key: &str) -> Result<Option<String>> {
     let mut cmd = Cmd::new("git");
     cmd.arg("-C").arg(path).arg("config").arg("--get").arg(key);
-
-    for var in GIT_ENV_OVERRIDES {
-        cmd.env_remove(var);
-    }
+    sanitize_git_environment(&mut cmd);
 
     let output = cmd
         .output()
@@ -557,10 +556,7 @@ fn git_config_get(path: &Path, key: &str) -> Result<Option<String>> {
 fn git_tool_help(path: &Path) -> Result<String> {
     let mut cmd = Cmd::new("git");
     cmd.arg("-C").arg(path).arg("difftool").arg("--tool-help");
-
-    for var in GIT_ENV_OVERRIDES {
-        cmd.env_remove(var);
-    }
+    sanitize_git_environment(&mut cmd);
 
     let output = cmd
         .output()
@@ -623,9 +619,7 @@ fn base_difftool(path: &Path, tool: Option<&str>) -> Cmd {
 }
 
 fn run_difftool(mut cmd: Cmd) -> Result<()> {
-    for var in GIT_ENV_OVERRIDES {
-        cmd.env_remove(var);
-    }
+    sanitize_git_environment(&mut cmd);
 
     let status = cmd
         .status()

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,8 @@ fn main() -> process::ExitCode {
     let cli = cli::Cli::parse();
 
     match commands::run(cli) {
-        Ok(()) => process::ExitCode::SUCCESS,
+        Ok(commands::RunOutcome::Success) => process::ExitCode::SUCCESS,
+        Ok(commands::RunOutcome::Exit(code)) => process::exit(code),
         Err(e) => {
             eprintln!("error: {e}");
             e.code.into()

--- a/src/output.rs
+++ b/src/output.rs
@@ -356,10 +356,14 @@ pub struct JsonMergeResponse {
     pub pushed: bool,
 }
 
-/// JSON response emitted on stderr when `exec --json` resolves a worktree.
+/// Resolution metadata emitted before an `exec --json` child starts.
+///
+/// This is intentionally not an execution result: child stdout and stderr
+/// remain inherited, and child stderr is appended to the same stderr stream.
 #[derive(Debug, Serialize)]
 pub struct JsonExecResponse {
-    pub ok: bool,
+    pub event: &'static str,
+    pub resolved: bool,
     pub message: String,
     pub branch: String,
     pub repo_root: String,
@@ -411,7 +415,8 @@ pub fn print_json(value: &impl Serialize) -> crate::error::Result<()> {
     Ok(())
 }
 
-/// Serialize execution metadata to stderr so the child owns stdout unchanged.
+/// Serialize pre-execution metadata to stderr so the child owns stdout
+/// unchanged. The stream may contain child diagnostics after this line.
 pub fn print_json_stderr(value: &impl Serialize) -> crate::error::Result<()> {
     eprintln!(
         "{}",

--- a/src/output.rs
+++ b/src/output.rs
@@ -356,6 +356,16 @@ pub struct JsonMergeResponse {
     pub pushed: bool,
 }
 
+/// JSON response emitted on stderr when `exec --json` resolves a worktree.
+#[derive(Debug, Serialize)]
+pub struct JsonExecResponse {
+    pub ok: bool,
+    pub message: String,
+    pub branch: String,
+    pub repo_root: String,
+    pub worktree_path: String,
+}
+
 /// JSON response for the materialize command.
 #[derive(Debug, Serialize)]
 pub struct JsonMaterializeResponse {
@@ -394,6 +404,16 @@ pub struct JsonSetupResponse {
 /// Serialize a value as a compact single-line JSON object to stdout.
 pub fn print_json(value: &impl Serialize) -> crate::error::Result<()> {
     println!(
+        "{}",
+        serde_json::to_string(value)
+            .map_err(|e| crate::error::AppError::invariant(format!("json error: {e}")))?
+    );
+    Ok(())
+}
+
+/// Serialize execution metadata to stderr so the child owns stdout unchanged.
+pub fn print_json_stderr(value: &impl Serialize) -> crate::error::Result<()> {
+    eprintln!(
         "{}",
         serde_json::to_string(value)
             .map_err(|e| crate::error::AppError::invariant(format!("json error: {e}")))?

--- a/tests/cli_exec.rs
+++ b/tests/cli_exec.rs
@@ -1,0 +1,159 @@
+mod fixtures;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn wt_core() -> Command {
+    Command::new(assert_cmd::cargo_bin!("wt-core"))
+}
+
+fn add_worktree(repo: &fixtures::TestRepo, branch: &str) {
+    wt_core()
+        .args(["add", branch, "--repo", &repo.path().display().to_string()])
+        .assert()
+        .success();
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_uses_worktree_cwd_and_preserves_argument_boundaries_and_stdio() {
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-target");
+    let worktree = fixtures::find_worktree_dir(&repo.path(), "exec-target")
+        .canonicalize()
+        .expect("worktree should exist");
+
+    let output = wt_core()
+        .args([
+            "exec",
+            "exec-target",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--",
+            "sh",
+            "-c",
+            "printf '%s\\n' \"$PWD\"; printf '<%s>\\n' \"$1\"; printf 'child-stderr\\n' >&2",
+            "exec-test",
+            "argument with spaces",
+        ])
+        .output()
+        .expect("exec should start");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert_eq!(
+        stdout,
+        format!("{}\n<argument with spaces>\n", worktree.display())
+    );
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("stderr should be utf8"),
+        "child-stderr\n"
+    );
+}
+
+#[test]
+fn exec_json_metadata_is_on_stderr_and_child_stdout_is_unchanged() {
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-json");
+
+    let output = wt_core()
+        .args([
+            "exec",
+            "exec-json",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--json",
+            "--",
+            "git",
+            "rev-parse",
+            "--show-toplevel",
+        ])
+        .output()
+        .expect("exec should start");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let expected = fixtures::find_worktree_dir(&repo.path(), "exec-json")
+        .canonicalize()
+        .expect("worktree should exist");
+    assert_eq!(stdout.trim(), expected.to_string_lossy());
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    let metadata: serde_json::Value = serde_json::from_str(stderr.trim())
+        .expect("--json should emit one metadata object on stderr");
+    assert_eq!(metadata["ok"], true);
+    assert_eq!(metadata["branch"], "exec-json");
+    assert_eq!(
+        metadata["repo_root"],
+        repo.path().to_string_lossy().to_string()
+    );
+    assert_eq!(
+        metadata["worktree_path"],
+        expected.to_string_lossy().to_string()
+    );
+}
+
+#[test]
+fn exec_fails_clearly_when_worktree_is_missing() {
+    let repo = fixtures::TestRepo::new();
+
+    wt_core()
+        .args([
+            "exec",
+            "missing-worktree",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--",
+            "git",
+            "--version",
+        ])
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "no worktree found for branch 'missing-worktree'",
+        ));
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_returns_nonzero_child_exit_status() {
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-status");
+
+    wt_core()
+        .args([
+            "exec",
+            "exec-status",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--",
+            "sh",
+            "-c",
+            "exit 23",
+        ])
+        .assert()
+        .code(23);
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_reports_signal_termination_with_shell_status() {
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-signal");
+
+    wt_core()
+        .args([
+            "exec",
+            "exec-signal",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--",
+            "sh",
+            "-c",
+            "kill -TERM $$",
+        ])
+        .assert()
+        .code(143);
+}

--- a/tests/cli_exec.rs
+++ b/tests/cli_exec.rs
@@ -2,6 +2,11 @@ mod fixtures;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::path::PathBuf;
+#[cfg(unix)]
+use std::process::{Command as ProcessCommand, Stdio};
+#[cfg(unix)]
+use std::{fs, thread, time::Duration};
 
 fn wt_core() -> Command {
     Command::new(assert_cmd::cargo_bin!("wt-core"))
@@ -12,6 +17,12 @@ fn add_worktree(repo: &fixtures::TestRepo, branch: &str) {
         .args(["add", branch, "--repo", &repo.path().display().to_string()])
         .assert()
         .success();
+}
+
+fn canonicalize_reported_path(value: &str) -> PathBuf {
+    PathBuf::from(value)
+        .canonicalize()
+        .expect("reported path should exist")
 }
 
 #[cfg(unix)]
@@ -51,6 +62,36 @@ fn exec_uses_worktree_cwd_and_preserves_argument_boundaries_and_stdio() {
     );
 }
 
+#[cfg(windows)]
+#[test]
+fn exec_uses_windows_command_cwd_and_status() {
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-windows");
+    let expected = fixtures::find_worktree_dir(&repo.path(), "exec-windows")
+        .canonicalize()
+        .expect("worktree should exist");
+
+    let output = wt_core()
+        .args([
+            "exec",
+            "exec-windows",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--",
+            "cmd",
+            "/C",
+            "echo %CD% & echo argument with spaces",
+        ])
+        .output()
+        .expect("exec should start");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let lines: Vec<_> = stdout.lines().map(str::trim).collect();
+    assert_eq!(canonicalize_reported_path(lines[0]), expected);
+    assert_eq!(lines[1], "argument with spaces");
+}
+
 #[test]
 fn exec_json_metadata_is_on_stderr_and_child_stdout_is_unchanged() {
     let repo = fixtures::TestRepo::new();
@@ -76,21 +117,62 @@ fn exec_json_metadata_is_on_stderr_and_child_stdout_is_unchanged() {
     let expected = fixtures::find_worktree_dir(&repo.path(), "exec-json")
         .canonicalize()
         .expect("worktree should exist");
-    assert_eq!(stdout.trim(), expected.to_string_lossy());
+    assert_eq!(canonicalize_reported_path(stdout.trim()), expected);
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    let metadata: serde_json::Value = serde_json::from_str(stderr.trim())
-        .expect("--json should emit one metadata object on stderr");
-    assert_eq!(metadata["ok"], true);
+    let metadata_line = stderr.lines().next().expect("metadata line should exist");
+    let metadata: serde_json::Value =
+        serde_json::from_str(metadata_line).expect("--json metadata should be valid JSON");
+    assert_eq!(metadata["event"], "exec_resolved");
+    assert_eq!(metadata["resolved"], true);
     assert_eq!(metadata["branch"], "exec-json");
     assert_eq!(
-        metadata["repo_root"],
-        repo.path().to_string_lossy().to_string()
+        canonicalize_reported_path(
+            metadata["repo_root"]
+                .as_str()
+                .expect("repo_root metadata should be a string")
+        ),
+        repo.path()
     );
     assert_eq!(
-        metadata["worktree_path"],
-        expected.to_string_lossy().to_string()
+        canonicalize_reported_path(
+            metadata["worktree_path"]
+                .as_str()
+                .expect("worktree_path metadata should be a string")
+        ),
+        expected
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_json_metadata_precedes_child_stderr() {
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-json-stderr");
+
+    let output = wt_core()
+        .args([
+            "exec",
+            "exec-json-stderr",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--json",
+            "--",
+            "sh",
+            "-c",
+            "printf 'child-stderr\\n' >&2",
+        ])
+        .output()
+        .expect("exec should start");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    let mut lines = stderr.lines();
+    let metadata: serde_json::Value =
+        serde_json::from_str(lines.next().expect("metadata line should exist"))
+            .expect("metadata should be the first stderr line");
+    assert_eq!(metadata["event"], "exec_resolved");
+    assert_eq!(lines.next(), Some("child-stderr"));
 }
 
 #[test]
@@ -116,34 +198,173 @@ fn exec_fails_clearly_when_worktree_is_missing() {
         ));
 }
 
-#[cfg(unix)]
+#[test]
+fn exec_json_metadata_stays_resolution_only_when_spawn_fails() {
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-json-spawn-failure");
+    let missing_program = repo.path().join("definitely-missing-exec-program");
+
+    let output = wt_core()
+        .args([
+            "exec",
+            "exec-json-spawn-failure",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--json",
+            "--",
+            &missing_program.display().to_string(),
+        ])
+        .output()
+        .expect("exec should start");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    let mut lines = stderr.lines();
+    let metadata: serde_json::Value =
+        serde_json::from_str(lines.next().expect("metadata line should exist"))
+            .expect("metadata should be valid JSON");
+    assert_eq!(metadata["event"], "exec_resolved");
+    assert_eq!(metadata["resolved"], true);
+    assert!(
+        lines.any(|line| line.contains("failed to execute")),
+        "spawn failure should be reported after resolution metadata"
+    );
+}
+
 #[test]
 fn exec_returns_nonzero_child_exit_status() {
     let repo = fixtures::TestRepo::new();
     add_worktree(&repo, "exec-status");
 
-    wt_core()
+    let mut command = wt_core();
+    command.args([
+        "exec",
+        "exec-status",
+        "--repo",
+        &repo.path().display().to_string(),
+        "--",
+    ]);
+    if cfg!(windows) {
+        command.args(["cmd", "/C", "exit 23"]);
+    } else {
+        command.args(["sh", "-c", "exit 23"]);
+    }
+    command.assert().code(23);
+}
+
+#[test]
+fn exec_sanitizes_inherited_git_context() {
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-git-env");
+    let git_dir = repo.path().join(".git");
+
+    let output = wt_core()
         .args([
             "exec",
-            "exec-status",
+            "exec-git-env",
             "--repo",
             &repo.path().display().to_string(),
             "--",
-            "sh",
-            "-c",
-            "exit 23",
+            "git",
+            "branch",
+            "--show-current",
         ])
-        .assert()
-        .code(23);
+        .env("GIT_DIR", &git_dir)
+        .output()
+        .expect("exec should start");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout)
+            .expect("stdout should be utf8")
+            .trim(),
+        "exec-git-env"
+    );
 }
 
 #[cfg(unix)]
 #[test]
-fn exec_reports_signal_termination_with_shell_status() {
+fn exec_replacement_receives_parent_signal_without_orphaning_child() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let repo = fixtures::TestRepo::new();
+    add_worktree(&repo, "exec-parent-signal");
+    let pid_file = repo.path().join("exec-parent-signal.pid");
+    let repo_arg = repo.path().display().to_string();
+    let pid_file_arg = pid_file.display().to_string();
+    let mut child = ProcessCommand::new(assert_cmd::cargo_bin!("wt-core"))
+        .args([
+            "exec",
+            "exec-parent-signal",
+            "--repo",
+            &repo_arg,
+            "--",
+            "sh",
+            "-c",
+            "printf '%s\\n' \"$$\" > \"$1\"; exec sleep 30",
+            "exec-parent-signal-test",
+            &pid_file_arg,
+        ])
+        .spawn()
+        .expect("exec should start");
+    let parent_pid = child.id();
+
+    let target_pid = (0..100).find_map(|_| {
+        let value = fs::read_to_string(&pid_file)
+            .ok()
+            .and_then(|value| value.trim().parse::<u32>().ok());
+        if value.is_none() {
+            thread::sleep(Duration::from_millis(10));
+        }
+        value
+    });
+    if target_pid.is_none() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    let target_pid = target_pid.expect("child pid should be written");
+
+    ProcessCommand::new("kill")
+        .stderr(Stdio::null())
+        .args(["-TERM", &parent_pid.to_string()])
+        .status()
+        .expect("kill should start")
+        .success()
+        .then_some(())
+        .expect("parent signal should be delivered");
+    let status = child.wait().expect("wt-core should exit after signal");
+    let target_alive = ProcessCommand::new("kill")
+        .stderr(Stdio::null())
+        .args(["-0", &target_pid.to_string()])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if target_alive {
+        let _ = ProcessCommand::new("kill")
+            .stderr(Stdio::null())
+            .args(["-KILL", &target_pid.to_string()])
+            .status();
+    }
+
+    assert_eq!(target_pid, parent_pid, "Unix exec should preserve the PID");
+    assert_eq!(
+        status.signal(),
+        Some(15),
+        "SIGTERM should reach the command"
+    );
+    assert!(!target_alive, "the command must not outlive wt-core");
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_reports_signal_termination_directly() {
+    use std::os::unix::process::ExitStatusExt;
+
     let repo = fixtures::TestRepo::new();
     add_worktree(&repo, "exec-signal");
 
-    wt_core()
+    let status = ProcessCommand::new(assert_cmd::cargo_bin!("wt-core"))
         .args([
             "exec",
             "exec-signal",
@@ -154,6 +375,7 @@ fn exec_reports_signal_termination_with_shell_status() {
             "-c",
             "kill -TERM $$",
         ])
-        .assert()
-        .code(143);
+        .status()
+        .expect("exec should start");
+    assert_eq!(status.signal(), Some(15));
 }


### PR DESCRIPTION
## Summary
- add `wt exec <branch> -- <command...>` to resolve an existing worktree and run a child directly in its directory
- preserve argument boundaries, inherited stdio, child exit status, and Unix signal behavior
- add Windows Job Object containment and CI coverage; document `--json` resolution metadata on stderr

## Platform behavior and residual Windows risks
- Unix replaces `wt-core` with the resolved command for native status and signal semantics.
- Windows contains the child tree in a kill-on-close Job Object and refuses to continue if containment setup fails.
- Windows console-control behavior remains subject to native console semantics, and the short CreateProcess/job-attachment interval has an unavoidable residual race; these risks are documented in the README.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --test cli_exec` (9 passed)

Closes #72
