### PR TITLE
feat: merge into linked worktree targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,16 @@ wt remove --force          # remove even if dirty, use -D for branch
 ### `wt merge`
 
 Merges a worktree's branch into the auto-detected mainline using
-`--no-ff`, then removes the worktree and branch by default. Use `--into`
-to merge into a different branch that is already checked out in the main
-worktree. Conflicts cause an automatic `merge --abort` to keep the main
-worktree clean.
+`--no-ff`, then removes the source worktree and branch by default. Use
+`--into` to merge into a different branch that is already checked out in the
+main or a linked worktree. The merge and conflict abort run in the destination
+worktree, and conflicts cause an automatic `merge --abort` to keep it clean.
 
 ```
 wt merge                         # merge current worktree's branch
 wt merge feature/auth            # explicit branch
 wt merge feature/auth --into rc  # merge into checked-out branch rc
+wt merge feature/auth --into release/1.0  # destination may be linked
 wt merge --push                  # push target branch to origin after merge
 wt merge --no-cleanup            # keep worktree and branch after merge
 ```
@@ -226,6 +227,7 @@ JSON envelope example (`merge`):
   "message": "merged 'feature/auth' into main",
   "branch": "feature/auth",
   "mainline": "main",
+  "destination_path": "/abs/repo",
   "repo_root": "/abs/repo",
   "cleaned_up": true,
   "removed_path": "/abs/repo/.worktrees/feature-auth--a1b2c3d4",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ these conventions upfront makes everything else predictable.
 
 - **Three output modes everywhere.** Every command supports human-readable
   output (default), `--json` for machine consumption, and a
-  `--print-cd-path` / `--print-paths` mode for shell wrappers.
+  `--print-cd-path` / versioned `--print-paths` modes for shell wrappers.
 
 - **Interactive when appropriate.** When a branch argument is omitted in a
   TTY, `go`, `remove`, and `merge` present a fuzzy picker instead of failing.
@@ -201,9 +201,16 @@ Example: branch `feature/auth` → `.worktrees/feature-auth--a1b2c3d4/`
 | *(default)*       | Human-readable text                          |
 | `--json`          | Single-line JSON envelope on stdout          |
 | `--print-cd-path` | Bare absolute path on stdout (for wrappers)  |
-| `--print-paths`   | Multi-line key values on stdout (for wrappers) |
+| `--print-paths`   | Version 1 merge metadata on stdout (for wrappers) |
+| `--print-paths-v2` | Version 2 merge metadata, including destination path (for wrappers) |
 
 `--json` emits one compact JSON object per line so machine consumers can parse stdout line-by-line.
+
+The merge `--print-paths` protocol is version 1 and emits six lines:
+`repo_root`, `branch`, `mainline`, `cleaned_up`, `removed_path`, and
+`pushed`. It remains unchanged for existing consumers. Bindings use the
+explicitly versioned `--print-paths-v2` protocol, which emits those same six
+lines followed by `destination_path` as line seven.
 
 JSON envelope example (`add`, `go`, `remove`):
 

--- a/bindings/bash/wt.bash
+++ b/bindings/bash/wt.bash
@@ -173,18 +173,20 @@ wt() {
 
             local cwd_before
             cwd_before=$(pwd)
-            # --print-paths outputs: repo_root, branch, mainline, cleaned_up, removed_path, pushed
+            # --print-paths-v2 preserves the six legacy fields and appends
+            # destination_path as field seven.
             local result
-            result=$(wt-core merge "$@" --print-paths)
+            result=$(wt-core merge "$@" --print-paths-v2)
             local rc=$?
             if [ $rc -eq 0 ]; then
-                local repo_root branch mainline cleaned_up removed_path pushed
+                local repo_root branch mainline cleaned_up removed_path pushed destination_path
                 repo_root=$(printf '%s\n' "$result" | sed -n '1p')
                 branch=$(printf '%s\n' "$result" | sed -n '2p')
                 mainline=$(printf '%s\n' "$result" | sed -n '3p')
                 cleaned_up=$(printf '%s\n' "$result" | sed -n '4p')
                 removed_path=$(printf '%s\n' "$result" | sed -n '5p')
                 pushed=$(printf '%s\n' "$result" | sed -n '6p')
+                destination_path=$(printf '%s\n' "$result" | sed -n '7p')
                 if [ "$cleaned_up" = "true" ] && [ -n "$removed_path" ]; then
                     case "$cwd_before" in
                         "${removed_path}"*)
@@ -193,6 +195,7 @@ wt() {
                     esac
                 fi
                 echo "Merged '${branch}' into ${mainline}"
+                echo "Destination worktree: ${destination_path}"
                 if [ "$cleaned_up" = "true" ]; then
                     echo "Removed worktree and branch '${branch}'"
                 fi

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -151,8 +151,9 @@ function wt --description "Git worktree manager"
             end
 
             set -l cwd_before (pwd)
-            # --print-paths outputs: repo_root, branch, mainline, cleaned_up, removed_path, pushed
-            set -l lines (wt-core merge $argv --print-paths)
+            # --print-paths-v2 preserves the six legacy fields and appends
+            # destination_path as field seven.
+            set -l lines (wt-core merge $argv --print-paths-v2)
             set -l rc $status
             if test $rc -eq 0
                 set -l repo_root $lines[1]
@@ -161,12 +162,14 @@ function wt --description "Git worktree manager"
                 set -l cleaned_up $lines[4]
                 set -l removed_path $lines[5]
                 set -l pushed $lines[6]
+                set -l destination_path $lines[7]
                 if test "$cleaned_up" = "true" -a -n "$removed_path"
                     if string match -q "$removed_path*" "$cwd_before"
                         cd "$repo_root"; or true
                     end
                 end
                 echo "Merged '$branch' into $mainline"
+                echo "Destination worktree: $destination_path"
                 if test "$cleaned_up" = "true"
                     echo "Removed worktree and branch '$branch'"
                 end

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -106,7 +106,7 @@ export def --env "wt remove" [
 
         $result
     } else {
-        # --print-paths: allows the interactive picker to render on
+        # --print-paths allows the interactive picker to render on
         # stderr/tty while paths go to stdout (same pattern as `go`
         # with --print-cd-path).
         let full_args = (build-args $args $repo false false | append "--print-paths")
@@ -132,6 +132,7 @@ export def --env "wt remove" [
 # Merge a worktree's branch into mainline and clean up
 export def --env "wt merge" [
     branch?: string  # Branch name (defaults to current worktree)
+    --into: string   # Merge into a branch checked out in any worktree
     --push           # Push mainline to origin after merge
     --no-cleanup     # Keep worktree and branch after merge
     --repo: path     # Repository path (defaults to cwd)
@@ -141,6 +142,7 @@ export def --env "wt merge" [
 
     mut args = ["merge"]
     if $branch != null { $args = ($args | append $branch) }
+    if $into != null { $args = ($args | append ["--into" $into]) }
     if $push { $args = ($args | append "--push") }
     if $no_cleanup { $args = ($args | append "--no-cleanup") }
 
@@ -156,7 +158,10 @@ export def --env "wt merge" [
 
         $result
     } else {
-        let full_args = (build-args $args $repo false false | append "--print-paths")
+        # --print-paths-v2 preserves the six legacy fields and appends
+        # destination_path as field seven. This lets the binding expose
+        # linked-worktree merge destinations without changing v1.
+        let full_args = (build-args $args $repo false false | append "--print-paths-v2")
         let output = try { ^wt-core ...$full_args } catch { return }
         let lines = ($output | lines)
         let repo_root = ($lines | get 0)
@@ -165,6 +170,7 @@ export def --env "wt merge" [
         let cleaned_up = ($lines | get 3)
         let removed_path = ($lines | get 4)
         let pushed = ($lines | get 5)
+        let destination_path = ($lines | get 6)
 
         if $cleaned_up == "true" and $removed_path != "" {
             if ($cwd_before | str starts-with $removed_path) {
@@ -173,6 +179,7 @@ export def --env "wt merge" [
         }
 
         print $"Merged '($branch_name)' into ($mainline)"
+        print $"Destination worktree: ($destination_path)"
         if $cleaned_up == "true" {
             print $"Removed worktree and branch '($branch_name)'"
         }

--- a/bindings/zsh/wt.zsh
+++ b/bindings/zsh/wt.zsh
@@ -166,24 +166,27 @@ wt() {
             fi
 
             local cwd_before="${PWD}"
-            # --print-paths outputs: repo_root, branch, mainline, cleaned_up, removed_path, pushed
+            # --print-paths-v2 preserves the six legacy fields and appends
+            # destination_path as field seven.
             local result
-            result=$(wt-core merge "$@" --print-paths)
+            result=$(wt-core merge "$@" --print-paths-v2)
             local rc=$?
             if [[ $rc -eq 0 ]]; then
-                local repo_root branch mainline cleaned_up removed_path pushed
+                local repo_root branch mainline cleaned_up removed_path pushed destination_path
                 repo_root=$(printf '%s\n' "$result" | sed -n '1p')
                 branch=$(printf '%s\n' "$result" | sed -n '2p')
                 mainline=$(printf '%s\n' "$result" | sed -n '3p')
                 cleaned_up=$(printf '%s\n' "$result" | sed -n '4p')
                 removed_path=$(printf '%s\n' "$result" | sed -n '5p')
                 pushed=$(printf '%s\n' "$result" | sed -n '6p')
+                destination_path=$(printf '%s\n' "$result" | sed -n '7p')
                 if [[ "$cleaned_up" == "true" ]] && [[ -n "$removed_path" ]]; then
                     if [[ "$cwd_before" == "${removed_path}"* ]]; then
                         cd "$repo_root" || true
                     fi
                 fi
                 echo "Merged '${branch}' into ${mainline}"
+                echo "Destination worktree: ${destination_path}"
                 if [[ "$cleaned_up" == "true" ]]; then
                     echo "Removed worktree and branch '${branch}'"
                 fi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,7 +109,7 @@ pub enum Command {
         /// Branch name (defaults to current worktree's branch)
         branch: Option<String>,
 
-        /// Merge into this checked-out branch instead of the detected mainline
+        /// Merge into this branch checked out in the main or a linked worktree
         #[arg(long, value_name = "BRANCH")]
         into: Option<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,8 +130,12 @@ pub enum Command {
         json: bool,
 
         /// Print merge info (repo_root, branch, mainline, cleaned_up, removed_path, pushed — one per line) for shell wrappers
-        #[arg(long, conflicts_with = "json")]
+        #[arg(long, conflicts_with_all = ["json", "print_paths_v2"])]
         print_paths: bool,
+
+        /// Print version 2 merge info, including destination_path, for shell wrappers
+        #[arg(long, conflicts_with_all = ["json", "print_paths"])]
+        print_paths_v2: bool,
     },
 
     /// Materialize an explicit detached checkout at a workspace path

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -67,13 +67,14 @@ pub fn run(cli: Cli) -> Result<()> {
             repo,
             json,
             print_paths,
+            print_paths_v2,
         } => cmd_merge(
             branch.as_deref().map(BranchName::new),
             into,
             push,
             no_cleanup,
             repo,
-            merge_fmt(json, print_paths),
+            merge_fmt(json, print_paths, print_paths_v2),
         ),
         Command::Materialize {
             repo_slug,
@@ -157,8 +158,10 @@ fn remove_fmt(json: bool, print_paths: bool) -> RemoveFormat {
     }
 }
 
-fn merge_fmt(json: bool, print_paths: bool) -> MergeFormat {
-    if print_paths {
+fn merge_fmt(json: bool, print_paths: bool, print_paths_v2: bool) -> MergeFormat {
+    if print_paths_v2 {
+        MergeFormat::PrintPathsV2
+    } else if print_paths {
         MergeFormat::PrintPaths
     } else if json {
         MergeFormat::Json
@@ -1084,6 +1087,15 @@ fn cmd_merge(
             println!("{}", result.cleaned_up);
             println!("{removed_str}");
             println!("{}", result.pushed);
+        }
+        MergeFormat::PrintPathsV2 => {
+            println!("{root_str}");
+            println!("{branch_name}");
+            println!("{}", result.mainline);
+            println!("{}", result.cleaned_up);
+            println!("{removed_str}");
+            println!("{}", result.pushed);
+            println!("{}", result.destination_path.display());
         }
         MergeFormat::Json => {
             let event = if result.cleaned_up {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1097,6 +1097,7 @@ fn cmd_merge(
                 message: format!("merged '{}' into {}", branch_name, result.mainline),
                 branch: branch_name.to_string(),
                 mainline: result.mainline.clone(),
+                destination_path: result.destination_path.display().to_string(),
                 repo_root: root_str,
                 cleaned_up: result.cleaned_up,
                 removed_path: if result.cleaned_up {
@@ -1109,6 +1110,10 @@ fn cmd_merge(
         }
         MergeFormat::Human => {
             println!("Merged '{}' into {}", branch_name, result.mainline);
+            println!(
+                "Destination worktree: {}",
+                result.destination_path.display()
+            );
             if result.cleaned_up {
                 println!("Removed worktree and branch '{}'", branch_name);
             }

--- a/src/git.rs
+++ b/src/git.rs
@@ -400,6 +400,47 @@ pub fn rev_exists(repo: &RepoRoot, rev: &str) -> bool {
     git(&["rev-parse", "--verify", rev], repo.as_ref()).is_ok()
 }
 
+/// Return the path Git uses for a repository-local marker from `cwd`.
+fn git_path(cwd: &Path, marker: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(git(&["rev-parse", "--git-path", marker], cwd)?);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(cwd.join(path))
+    }
+}
+
+/// Detect an operation already in progress in a particular worktree.
+///
+/// Git stores these markers in the per-worktree git directory when linked
+/// worktrees are enabled, so resolving them from `path` avoids inspecting the
+/// main worktree's state by mistake.
+pub fn operation_state(path: &Path) -> Result<Option<&'static str>> {
+    let markers = [
+        ("merge", &["MERGE_HEAD"][..]),
+        ("rebase", &["rebase-merge", "rebase-apply"][..]),
+        ("cherry-pick", &["CHERRY_PICK_HEAD", "sequencer"][..]),
+        ("revert", &["REVERT_HEAD"][..]),
+    ];
+
+    for (state, state_markers) in markers {
+        for marker in state_markers {
+            if git_path(path, marker)?.exists() {
+                return Ok(Some(state));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Check whether this invocation's merge left a merge state to abort.
+pub fn merge_in_progress(path: &Path) -> bool {
+    git_path(path, "MERGE_HEAD")
+        .map(|marker| marker.exists())
+        .unwrap_or(false)
+}
+
 /// Check if a remote-tracking branch exists for `origin/<branch>`.
 pub fn remote_branch_exists(repo: &RepoRoot, branch: &BranchName) -> bool {
     let refspec = format!("refs/remotes/origin/{}", branch.as_str());

--- a/src/git.rs
+++ b/src/git.rs
@@ -212,10 +212,20 @@ pub fn remove_worktree(repo: &RepoRoot, dir: &Path, force: bool) -> Result<()> {
     Ok(())
 }
 
-/// Delete a local branch.
+/// Delete a local branch, using the main worktree as the merge base for
+/// Git's safe `-d` check.
 pub fn delete_branch(repo: &RepoRoot, branch: &BranchName, force: bool) -> Result<()> {
+    delete_branch_at(repo.as_ref(), branch, force)
+}
+
+/// Delete a local branch using `path` as the current worktree context.
+///
+/// The context matters for `git branch -d`: Git checks whether the branch is
+/// merged into the currently checked-out branch. Merge cleanup uses the
+/// destination worktree so linked-target merges satisfy that check.
+pub fn delete_branch_at(path: &Path, branch: &BranchName, force: bool) -> Result<()> {
     let flag = if force { "-D" } else { "-d" };
-    git(&["branch", flag, branch.as_str()], repo.as_ref())?;
+    git(&["branch", flag, branch.as_str()], path)?;
     Ok(())
 }
 
@@ -410,9 +420,10 @@ pub fn set_upstream(repo: &RepoRoot, branch: &BranchName) -> Result<()> {
 
 /// Merge a branch into the current branch using `--no-ff`.
 ///
-/// Must be run from the main worktree (the `repo` root). Returns `Ok(())`
-/// on a clean merge or an error if conflicts arise (or any other git failure).
-pub fn merge_no_ff(repo: &RepoRoot, branch: &str) -> Result<()> {
+/// `path` identifies the worktree whose checked-out branch is the merge
+/// destination. Returns `Ok(())` on a clean merge or an error if conflicts
+/// arise (or any other git failure).
+pub fn merge_no_ff(path: &Path, branch: &str) -> Result<()> {
     git(
         &[
             "merge",
@@ -421,17 +432,17 @@ pub fn merge_no_ff(repo: &RepoRoot, branch: &str) -> Result<()> {
             "-m",
             &format!("Merge branch '{branch}'"),
         ],
-        repo.as_ref(),
+        path,
     )?;
     Ok(())
 }
 
-/// Abort an in-progress merge.
+/// Abort an in-progress merge in the destination worktree.
 ///
 /// Best-effort: if there is no merge to abort, git returns an error that
 /// we silently ignore.
-pub fn merge_abort(repo: &RepoRoot) {
-    let _ = git(&["merge", "--abort"], repo.as_ref());
+pub fn merge_abort(path: &Path) {
+    let _ = git(&["merge", "--abort"], path);
 }
 
 /// Verify Git has a usable difftool before launching an interactive diff.
@@ -640,9 +651,9 @@ fn run_difftool(mut cmd: Cmd) -> Result<()> {
     Ok(())
 }
 
-/// Push a branch to `origin`.
-pub fn push(repo: &RepoRoot, branch: &str) -> Result<()> {
-    git(&["push", "origin", branch], repo.as_ref())?;
+/// Push a branch to `origin` from the worktree where it is checked out.
+pub fn push(path: &Path, branch: &str) -> Result<()> {
+    git(&["push", "origin", branch], path)?;
     Ok(())
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -335,7 +335,7 @@ pub struct JsonSkippedEntry {
 pub enum MergeFormat {
     Human,
     Json,
-    /// `--print-paths`: prints repo_root, branch, mainline, cleaned_up, removed_path, pushed (one per line).
+    /// `--print-paths`: prints repo_root, branch, mainline, cleaned_up, removed_path, pushed (one per line). The destination path is available in human and JSON output.
     PrintPaths,
 }
 
@@ -349,6 +349,7 @@ pub struct JsonMergeResponse {
     pub message: String,
     pub branch: String,
     pub mainline: String,
+    pub destination_path: String,
     pub repo_root: String,
     pub cleaned_up: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/output.rs
+++ b/src/output.rs
@@ -335,8 +335,10 @@ pub struct JsonSkippedEntry {
 pub enum MergeFormat {
     Human,
     Json,
-    /// `--print-paths`: prints repo_root, branch, mainline, cleaned_up, removed_path, pushed (one per line). The destination path is available in human and JSON output.
+    /// `--print-paths`: version 1, prints repo_root, branch, mainline, cleaned_up, removed_path, pushed (one per line).
     PrintPaths,
+    /// `--print-paths-v2`: prints the version 1 fields followed by destination_path.
+    PrintPathsV2,
 }
 
 /// JSON response for the merge command.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -291,6 +291,20 @@ pub fn go(repo: &RepoRoot, branch: &BranchName) -> Result<GoResult> {
 
 /// Remove a worktree and delete its local branch.
 pub fn remove(repo: &RepoRoot, branch: Option<&BranchName>, force: bool) -> Result<RemoveResult> {
+    remove_with_branch_context(repo, branch, force, repo.as_ref())
+}
+
+/// Remove a worktree and evaluate safe branch deletion from `branch_context`.
+///
+/// Merges into linked destinations need the destination worktree as the
+/// context for `git branch -d`; the ordinary `remove` command keeps its
+/// existing main-worktree context.
+fn remove_with_branch_context(
+    repo: &RepoRoot,
+    branch: Option<&BranchName>,
+    force: bool,
+    branch_context: &Path,
+) -> Result<RemoveResult> {
     let worktrees = git::list_worktrees(repo)?;
 
     // Resolve which branch to remove.
@@ -319,7 +333,7 @@ pub fn remove(repo: &RepoRoot, branch: Option<&BranchName>, force: bool) -> Resu
     // Remove worktree first, then branch.
     git::remove_worktree(repo, &removed_path, force)?;
     // Branch deletion: best-effort — bubble warning instead of blocking.
-    let warning = git::delete_branch(repo, &target_branch, force)
+    let warning = git::delete_branch_at(branch_context, &target_branch, force)
         .err()
         .map(|e| format!("worktree removed but branch deletion failed: {e}"));
 
@@ -604,6 +618,8 @@ pub fn doctor(repo: &RepoRoot) -> Result<Vec<Diagnostic>> {
 pub struct MergeResult {
     pub branch: BranchName,
     pub mainline: String,
+    /// Path of the worktree where the destination branch was checked out.
+    pub destination_path: PathBuf,
     pub repo_root: PathBuf,
     pub cleaned_up: bool,
     /// Path of the removed worktree (only set when `cleaned_up` is true).
@@ -613,14 +629,88 @@ pub struct MergeResult {
     pub warnings: Vec<String>,
 }
 
-/// Merge a worktree's branch into the mainline.
+#[derive(Debug)]
+struct MergeDestination {
+    branch: String,
+    path: PathBuf,
+}
+
+/// Resolve the worktree where a merge destination branch is checked out.
 ///
-/// 1. Resolve the target branch (argument, cwd inference, or picker)
-/// 2. Refuse if it is the main worktree
-/// 3. Resolve the target branch (`--into` or detected mainline)
-/// 4. Run `git merge --no-ff <branch>` from the main worktree
-/// 5. On conflict: abort the merge and return an error
-/// 6. On success: optionally remove the worktree+branch, optionally push
+/// Explicit destinations may be in the main worktree or any linked
+/// worktree. With no explicit destination, retain the legacy requirement
+/// that the auto-detected mainline is checked out in the main worktree.
+fn resolve_merge_destination(
+    repo: &RepoRoot,
+    worktrees: &[Worktree],
+    into: Option<&str>,
+) -> Result<MergeDestination> {
+    let mainline = into
+        .map(str::to_string)
+        .map(Ok)
+        .unwrap_or_else(|| git::resolve_mainline(repo))?;
+
+    if into.is_none() {
+        let main = worktrees
+            .iter()
+            .find(|wt| wt.is_main)
+            .ok_or_else(|| AppError::invariant("main worktree is not available".to_string()))?;
+        return match main.branch.as_deref() {
+            Some(branch) if branch == mainline => Ok(MergeDestination {
+                branch: mainline,
+                path: main.path.clone(),
+            }),
+            branch => Err(AppError::invariant(format!(
+                "main worktree is on '{}', expected '{mainline}' — checkout mainline first",
+                branch.unwrap_or("(detached)")
+            ))),
+        };
+    }
+
+    let matches: Vec<&Worktree> = worktrees
+        .iter()
+        .filter(|wt| wt.branch.as_deref() == Some(mainline.as_str()))
+        .collect();
+
+    match matches.as_slice() {
+        [] if git::rev_exists(repo, &mainline) => {
+            let main_wt_branch = worktrees
+                .iter()
+                .find(|wt| wt.is_main)
+                .and_then(|wt| wt.branch.as_deref());
+            Err(AppError::invariant(format!(
+                "main worktree is on '{}', expected '{mainline}' — checkout target branch first",
+                main_wt_branch.unwrap_or("(detached)")
+            )))
+        }
+        [] => Err(AppError::usage(format!(
+            "destination branch '{mainline}' is not checked out in a worktree"
+        ))),
+        [destination] => Ok(MergeDestination {
+            branch: mainline,
+            path: destination.path.clone(),
+        }),
+        _ => {
+            let paths = matches
+                .iter()
+                .map(|wt| wt.path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(AppError::invariant(format!(
+                "destination branch '{mainline}' is checked out in multiple worktrees: {paths}"
+            )))
+        }
+    }
+}
+
+/// Merge a worktree's branch into the selected destination.
+///
+/// 1. Resolve the source branch (argument, cwd inference, or picker)
+/// 2. Resolve the destination worktree (`--into` or detected mainline)
+/// 3. Refuse self-merges and source merges from the main worktree
+/// 4. Run `git merge --no-ff <branch>` from the destination worktree
+/// 5. On conflict: abort the merge in that worktree and return an error
+/// 6. On success: optionally remove only the source worktree+branch, optionally push
 pub fn merge(
     repo: &RepoRoot,
     branch: Option<&BranchName>,
@@ -636,8 +726,8 @@ pub fn merge(
         None => resolve_branch_from_cwd(&worktrees)?,
     };
 
-    // Find the worktree entry.
-    let wt = worktrees
+    // Find the source worktree entry.
+    let source_wt = worktrees
         .iter()
         .find(|wt| wt.branch.as_deref() == Some(target_branch.as_str()))
         .ok_or_else(|| {
@@ -645,42 +735,23 @@ pub fn merge(
         })?;
 
     // Never merge the main worktree into itself.
-    if wt.is_main {
+    if source_wt.is_main {
         return Err(AppError::invariant(
             "refusing to merge the main worktree".to_string(),
         ));
     }
 
-    // Resolve target and verify the main worktree is checked out to it.
-    let mainline = into
-        .map(str::to_string)
-        .map(Ok)
-        .unwrap_or_else(|| git::resolve_mainline(repo))?;
-    if target_branch.as_str() == mainline {
+    let destination = resolve_merge_destination(repo, &worktrees, into)?;
+    if target_branch.as_str() == destination.branch {
         return Err(AppError::invariant(
             "refusing to merge a branch into itself".to_string(),
         ));
     }
 
-    let main_wt_branch = worktrees
-        .iter()
-        .find(|w| w.is_main)
-        .and_then(|w| w.branch.as_deref());
-    let checkout_hint = match into {
-        Some(_) => "checkout target branch first",
-        None => "checkout mainline first",
-    };
-    if main_wt_branch != Some(&mainline) {
-        return Err(AppError::invariant(format!(
-            "main worktree is on '{}', expected '{mainline}' — {checkout_hint}",
-            main_wt_branch.unwrap_or("(detached)")
-        )));
-    }
-
-    // Attempt the merge from the main worktree's context.
-    if let Err(e) = git::merge_no_ff(repo, target_branch.as_str()) {
-        // Abort to restore the main worktree to a clean state.
-        git::merge_abort(repo);
+    // Attempt the merge from the selected destination worktree's context.
+    if let Err(e) = git::merge_no_ff(&destination.path, target_branch.as_str()) {
+        // Abort to restore the destination worktree to its pre-merge state.
+        git::merge_abort(&destination.path);
         return Err(AppError::conflict(format!(
             "merge conflicts with '{}' — merge aborted; use `git merge` directly to handle conflicts\n{e}",
             target_branch
@@ -689,13 +760,13 @@ pub fn merge(
 
     let mut warnings = Vec::new();
 
-    // Cleanup: remove worktree and branch (default behaviour).
+    // Cleanup: remove the source worktree and branch (default behaviour).
     // Downgraded to a warning because the merge has already been committed;
     // a hard error would hide the successful merge from the caller.
     let (cleaned_up, removed_path) = if no_cleanup {
         (false, None)
     } else {
-        match remove(repo, Some(&target_branch), false) {
+        match remove_with_branch_context(repo, Some(&target_branch), false, &destination.path) {
             Ok(result) => {
                 if let Some(w) = result.warning {
                     warnings.push(w);
@@ -709,9 +780,9 @@ pub fn merge(
         }
     };
 
-    // Push mainline to origin if requested.
+    // Push the selected destination branch to origin if requested.
     let pushed = if push {
-        match git::push(repo, &mainline) {
+        match git::push(&destination.path, &destination.branch) {
             Ok(()) => true,
             Err(e) => {
                 warnings.push(format!("merge succeeded but push failed: {e}"));
@@ -724,7 +795,8 @@ pub fn merge(
 
     Ok(MergeResult {
         branch: target_branch,
-        mainline,
+        mainline: destination.branch,
+        destination_path: destination.path,
         repo_root: repo.to_path_buf(),
         cleaned_up,
         removed_path,
@@ -746,6 +818,68 @@ mod tests {
             commit: "deadbee".to_string(),
             is_main,
         }
+    }
+
+    #[test]
+    fn resolve_merge_destination_accepts_linked_worktree() {
+        let repo = RepoRoot(PathBuf::from("/repo"));
+        let worktrees = vec![
+            wt("/repo", Some("main"), true),
+            wt(
+                "/repo/.worktrees/release--12345678",
+                Some("release/1.0"),
+                false,
+            ),
+        ];
+
+        let destination = resolve_merge_destination(&repo, &worktrees, Some("release/1.0"))
+            .expect("linked destination should resolve");
+
+        assert_eq!(destination.branch, "release/1.0");
+        assert_eq!(
+            destination.path,
+            PathBuf::from("/repo/.worktrees/release--12345678")
+        );
+    }
+
+    #[test]
+    fn resolve_merge_destination_rejects_missing_worktree() {
+        let repo = RepoRoot(PathBuf::from("/repo"));
+        let worktrees = vec![wt("/repo", Some("main"), true)];
+
+        let error = resolve_merge_destination(&repo, &worktrees, Some("release/1.0"))
+            .expect_err("missing destination should fail");
+
+        assert!(error
+            .message
+            .contains("destination branch 'release/1.0' is not checked out"));
+    }
+
+    #[test]
+    fn resolve_merge_destination_rejects_ambiguous_worktree() {
+        let repo = RepoRoot(PathBuf::from("/repo"));
+        let worktrees = vec![
+            wt("/repo", Some("main"), true),
+            wt(
+                "/repo/.worktrees/release-a--12345678",
+                Some("release/1.0"),
+                false,
+            ),
+            wt(
+                "/repo/.worktrees/release-b--87654321",
+                Some("release/1.0"),
+                false,
+            ),
+        ];
+
+        let error = resolve_merge_destination(&repo, &worktrees, Some("release/1.0"))
+            .expect_err("ambiguous destination should fail");
+
+        assert!(error
+            .message
+            .contains("destination branch 'release/1.0' is checked out in multiple worktrees"));
+        assert!(error.message.contains("release-a--12345678"));
+        assert!(error.message.contains("release-b--87654321"));
     }
 
     #[test]

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -703,14 +703,22 @@ fn resolve_merge_destination(
     }
 }
 
+/// Abort the merge marker created by this invocation, if any.
+fn abort_created_merge(path: &Path) {
+    if git::merge_in_progress(path) {
+        git::merge_abort(path);
+    }
+}
+
 /// Merge a worktree's branch into the selected destination.
 ///
 /// 1. Resolve the source branch (argument, cwd inference, or picker)
 /// 2. Resolve the destination worktree (`--into` or detected mainline)
 /// 3. Refuse self-merges and source merges from the main worktree
-/// 4. Run `git merge --no-ff <branch>` from the destination worktree
-/// 5. On conflict: abort the merge in that worktree and return an error
-/// 6. On success: optionally remove only the source worktree+branch, optionally push
+/// 4. Refuse destinations with an existing Git operation in progress
+/// 5. Run `git merge --no-ff <branch>` from the destination worktree
+/// 6. On conflict: abort only a merge state created by this invocation
+/// 7. On success: optionally remove only the source worktree+branch, optionally push
 pub fn merge(
     repo: &RepoRoot,
     branch: Option<&BranchName>,
@@ -748,10 +756,22 @@ pub fn merge(
         ));
     }
 
+    // Never inspect or mutate an operation that was started before this
+    // invocation. In particular, `git merge --abort` below must not erase a
+    // user's existing merge, rebase, cherry-pick, or revert state.
+    if let Some(state) = git::operation_state(&destination.path)? {
+        return Err(AppError::conflict(format!(
+            "destination worktree '{}' has an in-progress {state}; finish or abort it before merging",
+            destination.path.display()
+        )));
+    }
+
     // Attempt the merge from the selected destination worktree's context.
     if let Err(e) = git::merge_no_ff(&destination.path, target_branch.as_str()) {
-        // Abort to restore the destination worktree to its pre-merge state.
-        git::merge_abort(&destination.path);
+        // The preflight above established that any merge state now belongs to
+        // this invocation. Do not abort unrelated failures that created no
+        // merge state.
+        abort_created_merge(&destination.path);
         return Err(AppError::conflict(format!(
             "merge conflicts with '{}' — merge aborted; use `git merge` directly to handle conflicts\n{e}",
             target_branch

--- a/tests/bindings/bash_test.bash
+++ b/tests/bindings/bash_test.bash
@@ -85,4 +85,22 @@ wt remove feat-one 2>&1
     && pass "wt remove: worktree directory deleted" \
     || fail "wt remove: $WT_PATH still exists"
 
+# ── wt merge destination metadata ───────────────────────────────────
+wt add feat-merge >/dev/null 2>&1
+MERGE_WT_PATH="$PWD"
+printf 'merge content\n' > merge.txt
+git add merge.txt
+git commit -m "merge content" >/dev/null 2>&1
+MERGE_OUTPUT="$WORK/merge-output"
+wt merge feat-merge >"$MERGE_OUTPUT" 2>&1
+cat "$MERGE_OUTPUT" | grep -q "Destination worktree: $REPO_PATH" \
+    && pass "wt merge: human output includes destination path" \
+    || fail "wt merge: destination path missing from human output"
+[[ "$(pwd -P)" == "$REPO_PATH" ]] \
+    && pass "wt merge: cd back to destination repository" \
+    || fail "wt merge: expected $REPO_PATH, got $(pwd -P)"
+[[ ! -d "$MERGE_WT_PATH" ]] \
+    && pass "wt merge: source worktree deleted" \
+    || fail "wt merge: source worktree still exists"
+
 echo "All bash binding tests passed."

--- a/tests/bindings/fish_test.fish
+++ b/tests/bindings/fish_test.fish
@@ -115,4 +115,28 @@ else
     fail "wt remove: $WT_PATH still exists"
 end
 
+# ── wt merge destination metadata ───────────────────────────────────
+wt add feat-merge >/dev/null 2>&1
+set MERGE_WT_PATH $PWD
+printf 'merge content\n' > merge.txt
+git add merge.txt
+git commit -m "merge content" >/dev/null 2>&1
+set MERGE_OUTPUT "$WORK/merge-output"
+wt merge feat-merge > "$MERGE_OUTPUT" 2>&1
+if string match -q "*Destination worktree: $REPO_PATH*" (cat "$MERGE_OUTPUT")
+    pass "wt merge: human output includes destination path"
+else
+    fail "wt merge: destination path missing from human output"
+end
+if test (realpath "$PWD") = "$REPO_PATH"
+    pass "wt merge: cd back to destination repository"
+else
+    fail "wt merge: expected $REPO_PATH, got "(realpath "$PWD")
+end
+if not test -d "$MERGE_WT_PATH"
+    pass "wt merge: source worktree deleted"
+else
+    fail "wt merge: source worktree still exists"
+end
+
 echo "All fish binding tests passed."

--- a/tests/bindings/nu_test.nu
+++ b/tests/bindings/nu_test.nu
@@ -83,15 +83,28 @@ if not ($wt_path | path exists) {
 }
 
 # ── wt merge destination metadata ───────────────────────────────────
+# Validate every v2 field directly through Nu; the binding's human output is
+# printed rather than returned as pipeline data.
+wt add feat-protocol
+"protocol content" | save protocol.txt
+^git add protocol.txt
+^git commit -m "protocol content"
+let v2_output = (^wt-core merge feat-protocol --repo $expected_repo --no-cleanup --print-paths-v2 | str trim)
+let v2_lines = ($v2_output | lines)
+let expected_v2 = [$expected_repo, "feat-protocol", "master", "false", "", "false", $expected_repo]
+if $v2_lines == $expected_v2 {
+    pass "wt merge: validates exact v2 destination protocol"
+} else {
+    fail $"wt merge: unexpected v2 protocol: ($v2_output)"
+}
+wt remove feat-protocol
+
 wt add feat-merge
 let merge_wt_path = $env.PWD
 "merge content" | save merge.txt
 ^git add merge.txt
 ^git commit -m "merge content"
 wt merge feat-merge
-# Nushell's `print` is terminal output rather than pipeline data; the
-# destination metadata is visible in the command output above.
-pass "wt merge: human output includes destination path"
 if $env.PWD == $expected_repo {
     pass "wt merge: cd back to destination repository"
 } else {

--- a/tests/bindings/nu_test.nu
+++ b/tests/bindings/nu_test.nu
@@ -82,6 +82,45 @@ if not ($wt_path | path exists) {
     fail $"wt remove: ($wt_path) still exists"
 }
 
+# ── wt merge destination metadata ───────────────────────────────────
+wt add feat-merge
+let merge_wt_path = $env.PWD
+"merge content" | save merge.txt
+^git add merge.txt
+^git commit -m "merge content"
+wt merge feat-merge
+# Nushell's `print` is terminal output rather than pipeline data; the
+# destination metadata is visible in the command output above.
+pass "wt merge: human output includes destination path"
+if $env.PWD == $expected_repo {
+    pass "wt merge: cd back to destination repository"
+} else {
+    fail $"wt merge: expected ($expected_repo), got ($env.PWD)"
+}
+if not ($merge_wt_path | path exists) {
+    pass "wt merge: source worktree deleted"
+} else {
+    fail $"wt merge: ($merge_wt_path) still exists"
+}
+
+# ── wt merge --into forwarding ──────────────────────────────────────
+^git checkout -b release/nu-into
+^git checkout master
+let into_destination = $"($work)/repo/.linked-nu-into"
+^git worktree add $into_destination release/nu-into
+wt add feat-into
+"into content" | save into.txt
+^git add into.txt
+^git commit -m "into content"
+let into_result = (wt merge feat-into --into release/nu-into --no-cleanup --json)
+if $into_result.mainline == "release/nu-into" {
+    pass "wt merge --into: forwards destination branch"
+} else {
+    fail $"wt merge --into: unexpected destination ($into_result.mainline)"
+}
+wt remove feat-into --force
+^git worktree remove --force $into_destination
+
 cd /tmp
 ^rm -rf $work
 print "All nu binding tests passed."

--- a/tests/bindings/zsh_test.zsh
+++ b/tests/bindings/zsh_test.zsh
@@ -83,4 +83,22 @@ wt remove feat-one 2>&1
     && pass "wt remove: worktree directory deleted" \
     || fail "wt remove: $WT_PATH still exists"
 
+# ── wt merge destination metadata ───────────────────────────────────
+wt add feat-merge >/dev/null 2>&1
+MERGE_WT_PATH="$PWD"
+printf 'merge content\n' > merge.txt
+git add merge.txt
+git commit -m "merge content" >/dev/null 2>&1
+MERGE_OUTPUT="$WORK/merge-output"
+wt merge feat-merge >"$MERGE_OUTPUT" 2>&1
+grep -q "Destination worktree: $REPO_PATH" "$MERGE_OUTPUT" \
+    && pass "wt merge: human output includes destination path" \
+    || fail "wt merge: destination path missing from human output"
+[[ "$(pwd -P)" == "$REPO_PATH" ]] \
+    && pass "wt merge: cd back to destination repository" \
+    || fail "wt merge: expected $REPO_PATH, got $(pwd -P)"
+[[ ! -d "$MERGE_WT_PATH" ]] \
+    && pass "wt merge: source worktree deleted" \
+    || fail "wt merge: source worktree still exists"
+
 echo "All zsh binding tests passed."

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -545,6 +545,43 @@ fn merge_print_paths_returns_six_lines() {
 }
 
 #[test]
+fn merge_print_paths_v2_appends_destination_path() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/paths-v2", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let wt_dir = find_worktree_dir(&repo.path(), "feature-paths-v2");
+    commit_file(&wt_dir, "v2.txt", "v2 work", "v2 commit");
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/paths-v2",
+            "--repo",
+            &repo_str,
+            "--print-paths-v2",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("invalid utf8");
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 7, "expected 7 lines: {stdout}");
+    assert_eq!(lines[1], "feature/paths-v2");
+    assert_eq!(lines[2], "main");
+    assert_eq!(lines[3], "true");
+    assert_eq!(lines[5], "false");
+    assert_eq!(lines[6], repo_str);
+}
+
+#[test]
 fn merge_print_paths_into_reports_destination_branch() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
@@ -590,6 +627,25 @@ fn merge_print_paths_into_reports_destination_branch() {
     assert_eq!(lines[2], "release/paths");
 
     run_git(&["checkout", "main"], &repo.path());
+}
+
+#[test]
+fn merge_print_paths_v2_conflicts_with_json() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args([
+            "merge",
+            "any-branch",
+            "--repo",
+            &repo_str,
+            "--print-paths-v2",
+            "--json",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
 }
 
 #[test]
@@ -938,7 +994,92 @@ fn merge_no_branch_non_tty_from_main_worktree_errors() {
         .code(4);
 }
 
+#[test]
+fn merge_refuses_preexisting_destination_merge_without_aborting_it() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/preexisting-merge");
+
+    wt_core()
+        .args(["add", "feature/preexisting-merge", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-preexisting-merge");
+    commit_file(&source, "README.md", "source conflict", "source conflict");
+    commit_file(
+        &destination,
+        "README.md",
+        "destination conflict",
+        "destination conflict",
+    );
+
+    let merge_output = git_allow_failure(
+        &["merge", "--no-ff", "feature/preexisting-merge"],
+        &destination,
+    );
+    assert!(
+        !merge_output.status.success(),
+        "manual merge should leave a conflict"
+    );
+    let merge_head = git_path(&destination, "MERGE_HEAD");
+    let merge_head_before = std::fs::read(&merge_head).expect("MERGE_HEAD should exist");
+    let status_before = git_status(&destination);
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/preexisting-merge",
+            "--into",
+            "release/preexisting-merge",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(5)
+        .stderr(predicate::str::contains("in-progress merge"))
+        .stderr(predicate::str::contains("finish or abort it"))
+        .stderr(predicate::str::contains("merge aborted").not());
+
+    assert_eq!(
+        std::fs::read(&merge_head).expect("MERGE_HEAD should remain"),
+        merge_head_before,
+        "pre-existing merge marker must not be changed"
+    );
+    assert_eq!(
+        git_status(&destination),
+        status_before,
+        "pre-existing conflict state must be preserved"
+    );
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────
+
+/// Run a git command and return its raw output, allowing expected failures.
+fn git_allow_failure(args: &[&str], cwd: &std::path::Path) -> std::process::Output {
+    let mut cmd = StdCommand::new("git");
+    cmd.args(args).current_dir(cwd);
+    for var in GIT_ENV_OVERRIDES {
+        cmd.env_remove(var);
+    }
+    cmd.output().expect("failed to run git")
+}
+
+/// Resolve a git marker path for a specific worktree.
+fn git_path(cwd: &std::path::Path, marker: &str) -> std::path::PathBuf {
+    let output = git_allow_failure(&["rev-parse", "--git-path", marker], cwd);
+    assert!(output.status.success(), "git path lookup failed");
+    let path = std::path::PathBuf::from(
+        String::from_utf8(output.stdout)
+            .expect("invalid utf8")
+            .trim(),
+    );
+    if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    }
+}
 
 /// Get the git log as one-line entries.
 fn git_log_oneline(repo: &std::path::Path, branch: &str) -> String {

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -387,6 +387,7 @@ fn merge_json_output_structure() {
     assert_eq!(json["event"], "reset");
     assert_eq!(json["branch"], "feature/json-merge");
     assert_eq!(json["mainline"], "main");
+    assert_eq!(json["destination_path"], repo_str);
     assert!(json["repo_root"].as_str().is_some());
     assert_eq!(json["cleaned_up"], true);
     assert!(
@@ -681,6 +682,146 @@ fn merge_into_checked_out_non_mainline_branch() {
 }
 
 #[test]
+fn merge_into_linked_worktree_succeeds_and_cleans_only_source() {
+    let (repo, upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/linked");
+    let destination_str = destination.display().to_string();
+
+    run_git(&["push", "-u", "origin", "release/linked"], &repo.path());
+
+    wt_core()
+        .args(["add", "feature/linked", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let source = find_worktree_dir(&repo.path(), "feature-linked");
+    commit_file(&source, "linked.txt", "linked merge", "linked merge");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/linked",
+            "--into",
+            "release/linked",
+            "--push",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Merged 'feature/linked' into release/linked",
+        ))
+        .stdout(predicate::str::contains(format!(
+            "Destination worktree: {destination_str}"
+        )))
+        .stdout(predicate::str::contains("Pushed release/linked to origin"));
+
+    assert!(destination.exists(), "destination worktree must remain");
+    assert_branch_exists(&repo.path(), "release/linked");
+    assert_branch_deleted(&repo.path(), "feature/linked");
+
+    let destination_log = git_log_oneline(&destination, "HEAD");
+    assert!(
+        destination_log.contains("Merge branch 'feature/linked'"),
+        "merge commit should exist in linked destination: {destination_log}"
+    );
+
+    let upstream_log = git_log_oneline(upstream.path(), "release/linked");
+    assert!(
+        upstream_log.contains("Merge branch 'feature/linked'"),
+        "linked destination branch should be pushed: {upstream_log}"
+    );
+}
+
+#[test]
+fn merge_into_linked_worktree_dirty_destination_fails_and_aborts_there() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/dirty");
+
+    wt_core()
+        .args(["add", "feature/linked-dirty", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let source = find_worktree_dir(&repo.path(), "feature-linked-dirty");
+    commit_file(
+        &source,
+        "README.md",
+        "source changes README",
+        "source changes README",
+    );
+    std::fs::write(destination.join("README.md"), "dirty destination").expect("write failed");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/linked-dirty",
+            "--into",
+            "release/dirty",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("merge conflicts"))
+        .stderr(predicate::str::contains("merge aborted"));
+
+    let destination_status = git_status(&destination);
+    assert!(
+        destination_status.contains("README.md"),
+        "destination dirty state should be preserved: {destination_status}"
+    );
+    assert_branch_exists(&repo.path(), "feature/linked-dirty");
+    assert!(
+        !git_log_oneline(&destination, "HEAD").contains("Merge branch 'feature/linked-dirty'"),
+        "dirty destination must not receive a merge commit"
+    );
+}
+
+#[test]
+fn merge_into_unchecked_out_destination_fails_before_merge() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/missing-destination", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-missing-destination");
+    commit_file(
+        &source,
+        "missing.txt",
+        "missing destination",
+        "missing destination",
+    );
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/missing-destination",
+            "--into",
+            "release/not-checked-out",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "destination branch 'release/not-checked-out' is not checked out in a worktree",
+        ));
+
+    assert_branch_exists(&repo.path(), "feature/missing-destination");
+    assert!(
+        source.exists(),
+        "source worktree must remain after preflight failure"
+    );
+}
+
+#[test]
 fn merge_into_wrong_checked_out_destination_errors_before_merge() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
@@ -849,6 +990,18 @@ fn assert_branch_exists(repo: &std::path::Path, branch: &str) {
         !branches.is_empty(),
         "branch '{branch}' should exist but was not found"
     );
+}
+
+/// Check out an existing branch in a linked worktree for merge integration tests.
+fn add_linked_destination(repo: &fixtures::TestRepo, branch: &str) -> std::path::PathBuf {
+    run_git(&["checkout", "-b", branch], &repo.path());
+    run_git(&["checkout", "main"], &repo.path());
+
+    let slug = branch.replace('/', "-");
+    let destination = repo.path().join(format!(".linked-{slug}"));
+    let destination_str = destination.display().to_string();
+    run_git(&["worktree", "add", &destination_str, branch], &repo.path());
+    destination
 }
 
 /// Create a repo with a bare upstream configured as `origin`.


### PR DESCRIPTION
## Summary
- Resolve explicit `--into` targets in either the main or a uniquely checked-out linked worktree.
- Run merge, conflict recovery, cleanup, and optional push in the selected destination worktree.
- Expose destination worktree metadata while preserving the legacy `--print-paths` protocol.
- Add CLI, binding, and integration coverage for linked destinations, failure handling, cleanup, push, and output compatibility.

## Validation
- Accepted head verified: `9da96ea0932fa368d95c4939df8f5311f1e40ec0`.
- Feature worktree verified clean before publication.
- Added Rust and shell-binding coverage is included in the diff; tests were not rerun during this publication-only step.

## Compatibility notes
- Existing main-worktree merge behavior remains unchanged.
- Legacy `--print-paths` remains a six-line protocol; destination metadata is available through versioned v2 output and JSON/human output.

Closes #69
