### PR TITLE
Unify navigation output selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,14 @@ JSON envelope example (`merge`):
 
 ## Shell Integration
 
-Each binding wraps the binary and handles `cd` in the parent shell. A
-caller-supplied `--json` is passed through unchanged, so it returns the JSON
-document and does not change the shell's cwd. Without `--json`, bindings use
-the legacy path output internally and preserve the normal `cd` behavior.
+The direct `wt-core` CLI never changes its caller's cwd. Each binding wraps the
+binary and may `cd` in the parent shell: normal `add`/`go` use the legacy path
+output to enter a worktree, while normal `remove`/`merge` return to the
+repository root when cleanup removes the current worktree. With `--json`,
+`add` and `go` leave cwd unchanged; JSON `remove` and `merge` still perform that
+safe reset when needed. The JSON document remains raw on stdout (including in
+Nushell); pipe it through Nushell's `from json` explicitly when structured
+values are desired. Warnings and diagnostics remain on stderr.
 
 You can either source files from `bindings/` directly, or generate them with
 `wt-core init <shell>`.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ these conventions upfront makes everything else predictable.
 - **Dry-run first.** Destructive batch operations (`prune`) default to dry-run
   and require `--execute` to take action.
 
-- **Three output modes everywhere.** Every command supports human-readable
-  output (default), `--json` for machine consumption, and a
-  `--print-cd-path` / `--print-paths` mode for shell wrappers.
+- **One output contract for navigation.** `add`, `go`, `remove`, and `merge`
+  use human-readable output by default and `--json` as their canonical machine
+  format. The legacy `--print-cd-path` / `--print-paths` flags remain
+  available for existing shell scripts; if a legacy path flag is combined
+  with `--json`, JSON takes precedence.
 
 - **Interactive when appropriate.** When a branch argument is omitted in a
   TTY, `go`, `remove`, and `merge` present a fuzzy picker instead of failing.
@@ -195,14 +197,18 @@ Example: branch `feature/auth` → `.worktrees/feature-auth--a1b2c3d4/`
 
 ## Output Modes
 
-| Flag              | Behavior                                     |
-|-------------------|----------------------------------------------|
-| *(default)*       | Human-readable text                          |
-| `--json`          | Single-line JSON envelope on stdout          |
-| `--print-cd-path` | Bare absolute path on stdout (for wrappers)  |
-| `--print-paths`   | Multi-line key values on stdout (for wrappers) |
+| Flag              | Behavior                                                  |
+|-------------------|-----------------------------------------------------------|
+| *(default)*       | Human-readable text                                       |
+| `--json`          | One compact JSON document on stdout                       |
+| `--print-cd-path` | Legacy bare absolute path for `add` and `go`              |
+| `--print-paths`   | Legacy multi-line fields for `remove` and `merge`         |
 
-`--json` emits one compact JSON object per line so machine consumers can parse stdout line-by-line.
+For `add`, `go`, `remove`, and `merge`, `--json` is authoritative when it is
+combined with either legacy path flag. This lets a wrapper safely append its
+legacy selector while a caller requests JSON, without producing competing
+stdout formats. JSON is exactly one document on stdout; warnings and errors
+remain on stderr.
 
 JSON envelope example (`add`, `go`, `remove`):
 
@@ -246,7 +252,10 @@ JSON envelope example (`merge`):
 
 ## Shell Integration
 
-Each binding wraps the binary and handles `cd` in the parent shell.
+Each binding wraps the binary and handles `cd` in the parent shell. A
+caller-supplied `--json` is passed through unchanged, so it returns the JSON
+document and does not change the shell's cwd. Without `--json`, bindings use
+the legacy path output internally and preserve the normal `cd` behavior.
 
 You can either source files from `bindings/` directly, or generate them with
 `wt-core init <shell>`.

--- a/bindings/bash/wt.bash
+++ b/bindings/bash/wt.bash
@@ -2,6 +2,12 @@
 # Source this file in your .bashrc:
 #   source path/to/bindings/bash/wt.bash
 
+# Match complete path components, not merely a textual prefix. This keeps a
+# worktree named /repo/.worktrees/app from matching /repo/.worktrees/app-copy.
+wt__path_is_within() {
+    [[ "$1" == "$2" || "$1" == "$2"/* ]]
+}
+
 wt() {
     local cmd="${1:-}"
 
@@ -30,14 +36,15 @@ wt() {
                 return $?
             fi
 
-            local target
-            target=$(wt-core add "$@" --print-cd-path 2>/dev/null)
-            if [ $? -eq 0 ] && [ -n "$target" ]; then
+            local target rc
+            # Keep stdout private for the path while leaving stderr inherited so
+            # setup recommendations and warnings remain visible on success.
+            target=$(wt-core add "$@" --print-cd-path)
+            rc=$?
+            if [ $rc -eq 0 ] && [ -n "$target" ]; then
                 cd "$target" || return 1
             else
-                # Re-run without --print-cd-path to show the error message
-                wt-core add "$@"
-                return $?
+                return $rc
             fi
             ;;
         go)
@@ -95,30 +102,28 @@ wt() {
             done
 
             if [ "$want_json" = true ]; then
-                local cwd_before
-                cwd_before=$(pwd)
-                local output
-                output=$(wt-core remove "$@")
-                local rc=$?
+                local cwd_before nav_file output rc
+                cwd_before=$(pwd -P)
+                nav_file=$(mktemp "${TMPDIR:-/tmp}/wt-core-nav.XXXXXX") || return 1
+                output=$(wt-core remove "$@" --navigation-file "$nav_file")
+                rc=$?
                 if [ $rc -eq 0 ]; then
-                    # Extract paths from JSON for cd-out-of-removed-worktree logic
-                    local removed_path repo_root
-                    removed_path=$(printf '%s\n' "$output" | sed -n 's/.*"removed_path": *"\([^"]*\)".*/\1/p')
-                    repo_root=$(printf '%s\n' "$output" | sed -n 's/.*"repo_root": *"\([^"]*\)".*/\1/p')
-                    if [ -n "$removed_path" ] && [ -n "$repo_root" ]; then
-                        case "$cwd_before" in
-                            "${removed_path}"*)
-                                cd "$repo_root" || true
-                                ;;
-                        esac
+                    local -a navigation
+                    mapfile -d '' -t navigation < "$nav_file"
+                    if [ "${navigation[0]-}" = reset ] \
+                        && [ -n "${navigation[1]-}" ] \
+                        && [ -n "${navigation[2]-}" ] \
+                        && wt__path_is_within "$cwd_before" "${navigation[1]}"; then
+                        cd "${navigation[2]}" || true
                     fi
                 fi
+                rm -f "$nav_file"
                 printf '%s\n' "$output"
                 return $rc
             fi
 
             local cwd_before
-            cwd_before=$(pwd)
+            cwd_before=$(pwd -P)
             # --print-paths outputs three lines: removed_path, repo_root, branch.
             # stderr is left connected to the terminal so the interactive picker
             # (if triggered) renders correctly and errors are visible.
@@ -130,11 +135,9 @@ wt() {
                 removed_path=$(printf '%s\n' "$result" | sed -n '1p')
                 repo_root=$(printf '%s\n' "$result" | sed -n '2p')
                 branch=$(printf '%s\n' "$result" | sed -n '3p')
-                case "$cwd_before" in
-                    "${removed_path}"*)
-                        cd "$repo_root" || true
-                        ;;
-                esac
+                if wt__path_is_within "$cwd_before" "$removed_path"; then
+                    cd "$repo_root" || true
+                fi
                 echo "Removed worktree and branch '${branch}'"
             else
                 return $rc
@@ -160,30 +163,28 @@ wt() {
             done
 
             if [ "$want_json" = true ]; then
-                local cwd_before
-                cwd_before=$(pwd)
-                local output
-                output=$(wt-core merge "$@")
-                local rc=$?
+                local cwd_before nav_file output rc
+                cwd_before=$(pwd -P)
+                nav_file=$(mktemp "${TMPDIR:-/tmp}/wt-core-nav.XXXXXX") || return 1
+                output=$(wt-core merge "$@" --navigation-file "$nav_file")
+                rc=$?
                 if [ $rc -eq 0 ]; then
-                    local removed_path
-                    removed_path=$(printf '%s\n' "$output" | sed -n 's/.*"removed_path": *"\([^"]*\)".*/\1/p')
-                    if [ -n "$removed_path" ]; then
-                        case "$cwd_before" in
-                            "${removed_path}"*)
-                                local repo_root
-                                repo_root=$(printf '%s\n' "$output" | sed -n 's/.*"repo_root": *"\([^"]*\)".*/\1/p')
-                                cd "$repo_root" || true
-                                ;;
-                        esac
+                    local -a navigation
+                    mapfile -d '' -t navigation < "$nav_file"
+                    if [ "${navigation[0]-}" = reset ] \
+                        && [ -n "${navigation[1]-}" ] \
+                        && [ -n "${navigation[2]-}" ] \
+                        && wt__path_is_within "$cwd_before" "${navigation[1]}"; then
+                        cd "${navigation[2]}" || true
                     fi
                 fi
+                rm -f "$nav_file"
                 printf '%s\n' "$output"
                 return $rc
             fi
 
             local cwd_before
-            cwd_before=$(pwd)
+            cwd_before=$(pwd -P)
             # --print-paths outputs: repo_root, branch, mainline, cleaned_up, removed_path, pushed
             local result
             result=$(wt-core merge "$@" --print-paths)
@@ -197,11 +198,9 @@ wt() {
                 removed_path=$(printf '%s\n' "$result" | sed -n '5p')
                 pushed=$(printf '%s\n' "$result" | sed -n '6p')
                 if [ "$cleaned_up" = "true" ] && [ -n "$removed_path" ]; then
-                    case "$cwd_before" in
-                        "${removed_path}"*)
-                            cd "$repo_root" || true
-                            ;;
-                    esac
+                    if wt__path_is_within "$cwd_before" "$removed_path"; then
+                        cd "$repo_root" || true
+                    fi
                 fi
                 echo "Merged '${branch}' into ${mainline}"
                 if [ "$cleaned_up" = "true" ]; then

--- a/bindings/bash/wt.bash
+++ b/bindings/bash/wt.bash
@@ -19,6 +19,17 @@ wt() {
                 esac
             done
 
+            # JSON is a caller-selected machine format. Do not append a
+            # path-only flag, which would otherwise change the JSON stream.
+            local want_json=false
+            for arg in "$@"; do
+                case "$arg" in --json) want_json=true ;; esac
+            done
+            if [ "$want_json" = true ]; then
+                wt-core add "$@"
+                return $?
+            fi
+
             local target
             target=$(wt-core add "$@" --print-cd-path 2>/dev/null)
             if [ $? -eq 0 ] && [ -n "$target" ]; then

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -1,6 +1,25 @@
 # wt — Git worktree manager (Fish binding)
 # Source this file or place in ~/.config/fish/conf.d/wt.fish
 
+# Match complete path components without treating path characters as a glob.
+function wt__path_is_within
+    set -l child $argv[1]
+    set -l parent $argv[2]
+    if test "$child" = "$parent"
+        return 0
+    end
+    set -l prefix "$parent/"
+    test (string sub -s 1 -l (string length -- "$prefix") -- "$child") = "$prefix"
+end
+
+function wt__navigation_file
+    set -l tmpdir /tmp
+    if set -q TMPDIR
+        set tmpdir $TMPDIR
+    end
+    mktemp "$tmpdir/wt-core-nav.XXXXXX"
+end
+
 function wt --description "Git worktree manager"
     set -l cmd $argv[1]
 
@@ -29,12 +48,14 @@ function wt --description "Git worktree manager"
                 return $status
             end
 
-            set -l target (wt-core add $argv --print-cd-path 2>/dev/null)
-            if test $status -eq 0 -a -n "$target"
+            # Keep stdout private for the path while leaving stderr inherited so
+            # setup recommendations and warnings remain visible on success.
+            set -l target (wt-core add $argv --print-cd-path)
+            set -l rc $status
+            if test $rc -eq 0 -a -n "$target"
                 cd "$target"
             else
-                wt-core add $argv
-                return $status
+                return $rc
             end
 
         case go
@@ -92,18 +113,22 @@ function wt --description "Git worktree manager"
 
             if test "$want_json" = true
                 set -l cwd_before (pwd)
-                set -l output (wt-core remove $argv)
+                set -l nav_file (wt__navigation_file)
+                if test $status -ne 0
+                    return 1
+                end
+                set -l output (wt-core remove $argv --navigation-file "$nav_file")
                 set -l rc $status
                 if test $rc -eq 0
-                    # Extract paths from JSON for cd-out-of-removed-worktree logic
-                    set -l removed_path (printf '%s\n' $output | sed -n 's/.*"removed_path": *"\([^"]*\)".*/\1/p')
-                    set -l repo_root (printf '%s\n' $output | sed -n 's/.*"repo_root": *"\([^"]*\)".*/\1/p')
-                    if test -n "$removed_path" -a -n "$repo_root"
-                        if string match -q "$removed_path*" "$cwd_before"
-                            cd "$repo_root"; or true
-                        end
+                    set -l navigation (string split0 < "$nav_file")
+                    if test "$navigation[1]" = reset \
+                        -a -n "$navigation[2]" \
+                        -a -n "$navigation[3]" \
+                        -a (wt__path_is_within "$cwd_before" "$navigation[2]")
+                        cd "$navigation[3]"; or true
                     end
                 end
+                rm -f -- "$nav_file"
                 printf '%s\n' $output
                 return $rc
             end
@@ -118,8 +143,8 @@ function wt --description "Git worktree manager"
                 set -l removed_path $lines[1]
                 set -l repo_root $lines[2]
                 set -l branch $lines[3]
-                # Check if cwd is under the removed worktree path
-                if string match -q "$removed_path*" "$cwd_before"
+                # Check if cwd is under the removed worktree path.
+                if wt__path_is_within "$cwd_before" "$removed_path"
                     cd "$repo_root"; or true
                 end
                 echo "Removed worktree and branch '$branch'"
@@ -148,17 +173,22 @@ function wt --description "Git worktree manager"
 
             if test "$want_json" = true
                 set -l cwd_before (pwd)
-                set -l output (wt-core merge $argv)
+                set -l nav_file (wt__navigation_file)
+                if test $status -ne 0
+                    return 1
+                end
+                set -l output (wt-core merge $argv --navigation-file "$nav_file")
                 set -l rc $status
                 if test $rc -eq 0
-                    set -l removed_path (printf '%s\n' $output | sed -n 's/.*"removed_path": *"\([^"]*\)".*/\1/p')
-                    if test -n "$removed_path"
-                        if string match -q "$removed_path*" "$cwd_before"
-                            set -l repo_root (printf '%s\n' $output | sed -n 's/.*"repo_root": *"\([^"]*\)".*/\1/p')
-                            cd "$repo_root"; or true
-                        end
+                    set -l navigation (string split0 < "$nav_file")
+                    if test "$navigation[1]" = reset \
+                        -a -n "$navigation[2]" \
+                        -a -n "$navigation[3]" \
+                        -a (wt__path_is_within "$cwd_before" "$navigation[2]")
+                        cd "$navigation[3]"; or true
                     end
                 end
+                rm -f -- "$nav_file"
                 printf '%s\n' $output
                 return $rc
             end
@@ -175,7 +205,7 @@ function wt --description "Git worktree manager"
                 set -l removed_path $lines[5]
                 set -l pushed $lines[6]
                 if test "$cleaned_up" = "true" -a -n "$removed_path"
-                    if string match -q "$removed_path*" "$cwd_before"
+                    if wt__path_is_within "$cwd_before" "$removed_path"
                         cd "$repo_root"; or true
                     end
                 end

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -2,6 +2,7 @@
 # Source this file or place in ~/.config/fish/conf.d/wt.fish
 
 # Match complete path components without treating path characters as a glob.
+# Call this directly in conditions so Fish preserves its exit status.
 function wt__path_is_within
     set -l child $argv[1]
     set -l parent $argv[2]
@@ -50,8 +51,16 @@ function wt --description "Git worktree manager"
 
             # Keep stdout private for the path while leaving stderr inherited so
             # setup recommendations and warnings remain visible on success.
-            set -l target (wt-core add $argv --print-cd-path)
+            # Run wt-core as a simple command: Fish command substitutions do
+            # not inherit a caller's stderr redirection.
+            set -l path_file (wt__navigation_file)
+            if test $status -ne 0
+                return 1
+            end
+            wt-core add $argv --print-cd-path >"$path_file"
             set -l rc $status
+            set -l target (cat "$path_file")
+            rm -f -- "$path_file"
             if test $rc -eq 0 -a -n "$target"
                 cd "$target"
             else
@@ -84,8 +93,15 @@ function wt --description "Git worktree manager"
 
             # --print-cd-path works with the interactive picker:
             # the picker UI renders on stderr/tty, the path goes to stdout.
-            set -l target (wt-core go $argv --print-cd-path)
+            # Run wt-core as a simple command for caller stderr redirections.
+            set -l path_file (wt__navigation_file)
+            if test $status -ne 0
+                return 1
+            end
+            wt-core go $argv --print-cd-path >"$path_file"
             set -l rc $status
+            set -l target (cat "$path_file")
+            rm -f -- "$path_file"
             if test $rc -eq 0 -a -n "$target"
                 cd "$target"
             else
@@ -123,9 +139,10 @@ function wt --description "Git worktree manager"
                     set -l navigation (string split0 < "$nav_file")
                     if test "$navigation[1]" = reset \
                         -a -n "$navigation[2]" \
-                        -a -n "$navigation[3]" \
-                        -a (wt__path_is_within "$cwd_before" "$navigation[2]")
-                        cd "$navigation[3]"; or true
+                        -a -n "$navigation[3]"
+                        if wt__path_is_within "$cwd_before" "$navigation[2]"
+                            cd "$navigation[3]"; or true
+                        end
                     end
                 end
                 rm -f -- "$nav_file"
@@ -183,9 +200,10 @@ function wt --description "Git worktree manager"
                     set -l navigation (string split0 < "$nav_file")
                     if test "$navigation[1]" = reset \
                         -a -n "$navigation[2]" \
-                        -a -n "$navigation[3]" \
-                        -a (wt__path_is_within "$cwd_before" "$navigation[2]")
-                        cd "$navigation[3]"; or true
+                        -a -n "$navigation[3]"
+                        if wt__path_is_within "$cwd_before" "$navigation[2]"
+                            cd "$navigation[3]"; or true
+                        end
                     end
                 end
                 rm -f -- "$nav_file"

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -16,6 +16,19 @@ function wt --description "Git worktree manager"
                 end
             end
 
+            # JSON is a caller-selected machine format. Do not append a
+            # path-only flag, which would otherwise change the JSON stream.
+            set -l want_json false
+            for arg in $argv
+                if test "$arg" = "--json"
+                    set want_json true
+                end
+            end
+            if test "$want_json" = true
+                wt-core add $argv
+                return $status
+            end
+
             set -l target (wt-core add $argv --print-cd-path 2>/dev/null)
             if test $status -eq 0 -a -n "$target"
                 cd "$target"

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -45,6 +45,8 @@ export def --env "wt add" [
     --repo: path        # Repository path (defaults to cwd)
     --json              # Output as JSON (no cd)
 ] {
+    # JSON is the canonical machine format; keep it separate from the
+    # legacy path-only output used for the parent-shell cd.
     if $json {
         mut args = (build-args ["add" $branch] $repo true false)
         if $base != null { $args = ($args | append ["--base" $base]) }

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -17,6 +17,24 @@ def --wrapped wt [
     }
 }
 
+# Return true only when child is the parent itself or a descendant directory.
+def path-is-within [child: string parent: string] {
+    try { $child | path relative-to $parent; true } catch { false }
+}
+
+# Read the NUL-delimited navigation record written by wt-core. This keeps
+# paths out of JSON parsing and preserves quotes and backslashes verbatim.
+def read-navigation [file: path] {
+    open --raw $file
+    | bytes split 0x[00]
+    | each { |field| $field | decode utf-8 }
+}
+
+def navigation-file [] {
+    let tmpdir = ($env.TMPDIR? | default "/tmp")
+    ^mktemp $"($tmpdir)/wt-core-nav.XXXXXX" | str trim
+}
+
 # List all worktrees
 export def "wt list" [
     --repo: path        # Repository path (defaults to cwd)
@@ -32,7 +50,8 @@ export def "wt list" [
 
     let full_args = (build-args $args $repo $json false)
     if $json {
-        ^wt-core ...$full_args | from json
+        let output = try { ^wt-core ...$full_args } catch { return }
+        $output
     } else {
         ^wt-core ...$full_args
     }
@@ -50,7 +69,8 @@ export def --env "wt add" [
     if $json {
         mut args = (build-args ["add" $branch] $repo true false)
         if $base != null { $args = ($args | append ["--base" $base]) }
-        ^wt-core ...$args | from json
+        let output = try { ^wt-core ...$args } catch { return }
+        $output
     } else {
         mut args = (build-args ["add" $branch] $repo false true)
         if $base != null { $args = ($args | append ["--base" $base]) }
@@ -72,7 +92,8 @@ export def --env "wt go" [
 
     if $json {
         let full_args = (build-args $args $repo true false)
-        ^wt-core ...$full_args | from json
+        let output = try { ^wt-core ...$full_args } catch { return }
+        $output
     } else {
         # --print-cd-path works with the interactive picker:
         # the picker UI renders on stderr/tty, the path goes to stdout.
@@ -96,17 +117,49 @@ export def --env "wt remove" [
     if $force { $args = ($args | append "--force") }
 
     if $json {
-        # --json: machine output, no interactive picker.
-        let full_args = (build-args $args $repo true false)
-        let result = (^wt-core ...$full_args | from json)
-
-        if ($result.ok) and ($result.removed_path? != null) {
-            if ($cwd_before | str starts-with $result.removed_path) {
-                cd $result.repo_root
+        # Run from the repository root so removing the current worktree does
+        # not invalidate Nushell's own cwd while it captures stdout.
+        let command_repo = if $repo != null {
+            $repo | path expand
+        } else {
+            try {
+                ^git rev-parse --path-format=absolute --git-common-dir
+                | str trim
+                | path dirname
+            } catch { return }
+        }
+        if $branch == null {
+            let inferred_branch = try { ^git branch --show-current | str trim } catch { "" }
+            if $inferred_branch != "" {
+                $args = ($args | append $inferred_branch)
             }
         }
-
-        $result
+        cd $command_repo
+        let effective_repo = if $repo != null { $command_repo } else { null }
+        let nav_file = (navigation-file)
+        let full_args = (build-args $args $effective_repo true false | append ["--navigation-file" $nav_file])
+        let output = try { ^wt-core ...$full_args } catch {
+            cd $cwd_before
+            ^rm -f $nav_file
+            return
+        }
+        let navigation = if ($nav_file | path exists) {
+            try { read-navigation $nav_file } catch { [] }
+        } else {
+            []
+        }
+        if (
+            (($navigation | get 0 | default "") == "reset")
+            and (($navigation | get 1 | default "") != "")
+            and (($navigation | get 2 | default "") != "")
+            and (path-is-within $cwd_before ($navigation | get 1))
+        ) {
+            cd ($navigation | get 2)
+        } else {
+            cd $cwd_before
+        }
+        ^rm -f $nav_file
+        $output
     } else {
         # --print-paths: allows the interactive picker to render on
         # stderr/tty while paths go to stdout (same pattern as `go`
@@ -123,7 +176,7 @@ export def --env "wt remove" [
         let repo_root = ($lines | get 1)
         let branch_name = ($lines | get 2)
 
-        if ($cwd_before | str starts-with $removed_path) {
+        if (path-is-within $cwd_before $removed_path) {
             cd $repo_root
         }
 
@@ -147,16 +200,49 @@ export def --env "wt merge" [
     if $no_cleanup { $args = ($args | append "--no-cleanup") }
 
     if $json {
-        let full_args = (build-args $args $repo true false)
-        let result = (^wt-core ...$full_args | from json)
-
-        if ($result.ok) and ($result.removed_path? != null) {
-            if ($cwd_before | str starts-with ($result.removed_path)) {
-                cd $result.repo_root
+        # Run from the repository root so cleanup cannot invalidate Nushell's
+        # cwd while it captures stdout.
+        let command_repo = if $repo != null {
+            $repo | path expand
+        } else {
+            try {
+                ^git rev-parse --path-format=absolute --git-common-dir
+                | str trim
+                | path dirname
+            } catch { return }
+        }
+        if $branch == null {
+            let inferred_branch = try { ^git branch --show-current | str trim } catch { "" }
+            if $inferred_branch != "" {
+                $args = ($args | append $inferred_branch)
             }
         }
-
-        $result
+        cd $command_repo
+        let effective_repo = if $repo != null { $command_repo } else { null }
+        let nav_file = (navigation-file)
+        let full_args = (build-args $args $effective_repo true false | append ["--navigation-file" $nav_file])
+        let output = try { ^wt-core ...$full_args } catch {
+            cd $cwd_before
+            ^rm -f $nav_file
+            return
+        }
+        let navigation = if ($nav_file | path exists) {
+            try { read-navigation $nav_file } catch { [] }
+        } else {
+            []
+        }
+        if (
+            (($navigation | get 0 | default "") == "reset")
+            and (($navigation | get 1 | default "") != "")
+            and (($navigation | get 2 | default "") != "")
+            and (path-is-within $cwd_before ($navigation | get 1))
+        ) {
+            cd ($navigation | get 2)
+        } else {
+            cd $cwd_before
+        }
+        ^rm -f $nav_file
+        $output
     } else {
         let full_args = (build-args $args $repo false false | append "--print-paths")
         let output = try { ^wt-core ...$full_args } catch { return }
@@ -169,7 +255,7 @@ export def --env "wt merge" [
         let pushed = ($lines | get 5)
 
         if $cleaned_up == "true" and $removed_path != "" {
-            if ($cwd_before | str starts-with $removed_path) {
+            if (path-is-within $cwd_before $removed_path) {
                 cd $repo_root
             }
         }
@@ -191,7 +277,8 @@ export def "wt doctor" [
 ] {
     let args = (build-args ["doctor"] $repo $json false)
     if $json {
-        ^wt-core ...$args | from json
+        let output = try { ^wt-core ...$args } catch { return }
+        $output
     } else {
         ^wt-core ...$args
     }

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -35,6 +35,13 @@ def navigation-file [] {
     ^mktemp $"($tmpdir)/wt-core-nav.XXXXXX" | str trim
 }
 
+# Nushell turns a failed external command into a ShellError. Re-raise that
+# error instead of returning, so the original stderr remains visible and the
+# caller receives wt-core's non-zero exit status.
+def run-core [args: list<string>] {
+    try { ^wt-core ...$args } catch { |err| error make $err }
+}
+
 # List all worktrees
 export def "wt list" [
     --repo: path        # Repository path (defaults to cwd)
@@ -50,7 +57,7 @@ export def "wt list" [
 
     let full_args = (build-args $args $repo $json false)
     if $json {
-        let output = try { ^wt-core ...$full_args } catch { return }
+        let output = (run-core $full_args)
         $output
     } else {
         ^wt-core ...$full_args
@@ -69,7 +76,7 @@ export def --env "wt add" [
     if $json {
         mut args = (build-args ["add" $branch] $repo true false)
         if $base != null { $args = ($args | append ["--base" $base]) }
-        let output = try { ^wt-core ...$args } catch { return }
+        let output = (run-core $args)
         $output
     } else {
         mut args = (build-args ["add" $branch] $repo false true)
@@ -92,7 +99,7 @@ export def --env "wt go" [
 
     if $json {
         let full_args = (build-args $args $repo true false)
-        let output = try { ^wt-core ...$full_args } catch { return }
+        let output = (run-core $full_args)
         $output
     } else {
         # --print-cd-path works with the interactive picker:
@@ -126,7 +133,7 @@ export def --env "wt remove" [
                 ^git rev-parse --path-format=absolute --git-common-dir
                 | str trim
                 | path dirname
-            } catch { return }
+            } catch { |err| error make $err }
         }
         if $branch == null {
             let inferred_branch = try { ^git branch --show-current | str trim } catch { "" }
@@ -138,10 +145,10 @@ export def --env "wt remove" [
         let effective_repo = if $repo != null { $command_repo } else { null }
         let nav_file = (navigation-file)
         let full_args = (build-args $args $effective_repo true false | append ["--navigation-file" $nav_file])
-        let output = try { ^wt-core ...$full_args } catch {
+        let output = try { run-core $full_args } catch { |err|
             cd $cwd_before
             ^rm -f $nav_file
-            return
+            error make $err
         }
         let navigation = if ($nav_file | path exists) {
             try { read-navigation $nav_file } catch { [] }
@@ -170,7 +177,7 @@ export def --env "wt remove" [
         # directly would silently swallow the failure).  Stderr is
         # inherited, keeping the interactive picker and error messages
         # visible in the terminal.
-        let output = try { ^wt-core ...$full_args } catch { return }
+        let output = (run-core $full_args)
         let lines = ($output | lines)
         let removed_path = ($lines | get 0)
         let repo_root = ($lines | get 1)
@@ -209,7 +216,7 @@ export def --env "wt merge" [
                 ^git rev-parse --path-format=absolute --git-common-dir
                 | str trim
                 | path dirname
-            } catch { return }
+            } catch { |err| error make $err }
         }
         if $branch == null {
             let inferred_branch = try { ^git branch --show-current | str trim } catch { "" }
@@ -221,10 +228,10 @@ export def --env "wt merge" [
         let effective_repo = if $repo != null { $command_repo } else { null }
         let nav_file = (navigation-file)
         let full_args = (build-args $args $effective_repo true false | append ["--navigation-file" $nav_file])
-        let output = try { ^wt-core ...$full_args } catch {
+        let output = try { run-core $full_args } catch { |err|
             cd $cwd_before
             ^rm -f $nav_file
-            return
+            error make $err
         }
         let navigation = if ($nav_file | path exists) {
             try { read-navigation $nav_file } catch { [] }
@@ -245,7 +252,7 @@ export def --env "wt merge" [
         $output
     } else {
         let full_args = (build-args $args $repo false false | append "--print-paths")
-        let output = try { ^wt-core ...$full_args } catch { return }
+        let output = (run-core $full_args)
         let lines = ($output | lines)
         let repo_root = ($lines | get 0)
         let branch_name = ($lines | get 1)
@@ -277,7 +284,7 @@ export def "wt doctor" [
 ] {
     let args = (build-args ["doctor"] $repo $json false)
     if $json {
-        let output = try { ^wt-core ...$args } catch { return }
+        let output = (run-core $args)
         $output
     } else {
         ^wt-core ...$args

--- a/bindings/zsh/wt.zsh
+++ b/bindings/zsh/wt.zsh
@@ -2,6 +2,11 @@
 # Source this file in your .zshrc:
 #   source path/to/bindings/zsh/wt.zsh
 
+# Match complete path components, not merely a textual prefix.
+wt__path_is_within() {
+    [[ "$1" == "$2" || "$1" == "$2"/* ]]
+}
+
 wt() {
     emulate -L zsh
 
@@ -33,13 +38,15 @@ wt() {
                 return $?
             fi
 
-            local target
-            target=$(wt-core add "$@" --print-cd-path 2>/dev/null)
-            if [[ $? -eq 0 ]] && [[ -n "$target" ]]; then
+            local target rc
+            # Keep stdout private for the path while leaving stderr inherited so
+            # setup recommendations and warnings remain visible on success.
+            target=$(wt-core add "$@" --print-cd-path)
+            rc=$?
+            if [[ $rc -eq 0 ]] && [[ -n "$target" ]]; then
                 cd "$target" || return 1
             else
-                wt-core add "$@"
-                return $?
+                return $rc
             fi
             ;;
         go)
@@ -99,26 +106,31 @@ wt() {
             done
 
             if [[ "$want_json" == true ]]; then
-                local cwd_before="${PWD}"
-                local output
-                output=$(wt-core remove "$@")
-                local rc=$?
+                local cwd_before nav_file output rc
+                cwd_before=$(pwd -P)
+                nav_file=$(mktemp "${TMPDIR:-/tmp}/wt-core-nav.XXXXXX") || return 1
+                output=$(wt-core remove "$@" --navigation-file "$nav_file")
+                rc=$?
                 if [[ $rc -eq 0 ]]; then
-                    # Extract paths from JSON for cd-out-of-removed-worktree logic
-                    local removed_path repo_root
-                    removed_path=$(printf '%s\n' "$output" | sed -n 's/.*"removed_path": *"\([^"]*\)".*/\1/p')
-                    repo_root=$(printf '%s\n' "$output" | sed -n 's/.*"repo_root": *"\([^"]*\)".*/\1/p')
-                    if [[ -n "$removed_path" ]] && [[ -n "$repo_root" ]]; then
-                        if [[ "$cwd_before" == "${removed_path}"* ]]; then
-                            cd "$repo_root" || true
-                        fi
+                    local nav_fd nav_action nav_removed nav_root
+                    exec {nav_fd}<"$nav_file"
+                    IFS= read -r -d $'\0' nav_action <&$nav_fd
+                    IFS= read -r -d $'\0' nav_removed <&$nav_fd
+                    IFS= read -r -d $'\0' nav_root <&$nav_fd
+                    exec {nav_fd}<&-
+                    if [[ "$nav_action" == reset ]] && [[ -n "$nav_removed" ]] \
+                        && [[ -n "$nav_root" ]] \
+                        && wt__path_is_within "$cwd_before" "$nav_removed"; then
+                        cd "$nav_root" || true
                     fi
                 fi
+                rm -f "$nav_file"
                 printf '%s\n' "$output"
                 return $rc
             fi
 
-            local cwd_before="${PWD}"
+            local cwd_before
+            cwd_before=$(pwd -P)
             # --print-paths outputs three lines: removed_path, repo_root, branch.
             # stderr is left connected to the terminal so the interactive picker
             # (if triggered) renders correctly and errors are visible.
@@ -130,7 +142,7 @@ wt() {
                 removed_path=$(printf '%s\n' "$result" | sed -n '1p')
                 repo_root=$(printf '%s\n' "$result" | sed -n '2p')
                 branch=$(printf '%s\n' "$result" | sed -n '3p')
-                if [[ "$cwd_before" == "${removed_path}"* ]]; then
+                if wt__path_is_within "$cwd_before" "$removed_path"; then
                     cd "$repo_root" || true
                 fi
                 echo "Removed worktree and branch '${branch}'"
@@ -159,24 +171,31 @@ wt() {
             done
 
             if [[ "$want_json" == true ]]; then
-                local cwd_before="${PWD}"
-                local output
-                output=$(wt-core merge "$@")
-                local rc=$?
+                local cwd_before nav_file output rc
+                cwd_before=$(pwd -P)
+                nav_file=$(mktemp "${TMPDIR:-/tmp}/wt-core-nav.XXXXXX") || return 1
+                output=$(wt-core merge "$@" --navigation-file "$nav_file")
+                rc=$?
                 if [[ $rc -eq 0 ]]; then
-                    local removed_path
-                    removed_path=$(printf '%s\n' "$output" | sed -n 's/.*"removed_path": *"\([^"]*\)".*/\1/p')
-                    if [[ -n "$removed_path" ]] && [[ "$cwd_before" == "${removed_path}"* ]]; then
-                        local repo_root
-                        repo_root=$(printf '%s\n' "$output" | sed -n 's/.*"repo_root": *"\([^"]*\)".*/\1/p')
-                        cd "$repo_root" || true
+                    local nav_fd nav_action nav_removed nav_root
+                    exec {nav_fd}<"$nav_file"
+                    IFS= read -r -d $'\0' nav_action <&$nav_fd
+                    IFS= read -r -d $'\0' nav_removed <&$nav_fd
+                    IFS= read -r -d $'\0' nav_root <&$nav_fd
+                    exec {nav_fd}<&-
+                    if [[ "$nav_action" == reset ]] && [[ -n "$nav_removed" ]] \
+                        && [[ -n "$nav_root" ]] \
+                        && wt__path_is_within "$cwd_before" "$nav_removed"; then
+                        cd "$nav_root" || true
                     fi
                 fi
+                rm -f "$nav_file"
                 printf '%s\n' "$output"
                 return $rc
             fi
 
-            local cwd_before="${PWD}"
+            local cwd_before
+            cwd_before=$(pwd -P)
             # --print-paths outputs: repo_root, branch, mainline, cleaned_up, removed_path, pushed
             local result
             result=$(wt-core merge "$@" --print-paths)
@@ -190,7 +209,7 @@ wt() {
                 removed_path=$(printf '%s\n' "$result" | sed -n '5p')
                 pushed=$(printf '%s\n' "$result" | sed -n '6p')
                 if [[ "$cleaned_up" == "true" ]] && [[ -n "$removed_path" ]]; then
-                    if [[ "$cwd_before" == "${removed_path}"* ]]; then
+                    if wt__path_is_within "$cwd_before" "$removed_path"; then
                         cd "$repo_root" || true
                     fi
                 fi

--- a/bindings/zsh/wt.zsh
+++ b/bindings/zsh/wt.zsh
@@ -22,6 +22,17 @@ wt() {
                 esac
             done
 
+            # JSON is a caller-selected machine format. Do not append a
+            # path-only flag, which would otherwise change the JSON stream.
+            local want_json=false
+            for arg in "$@"; do
+                [[ "$arg" == "--json" ]] && want_json=true
+            done
+            if [[ "$want_json" == true ]]; then
+                wt-core add "$@"
+                return $?
+            fi
+
             local target
             target=$(wt-core add "$@" --print-cd-path 2>/dev/null)
             if [[ $? -eq 0 ]] && [[ -n "$target" ]]; then

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,8 +55,10 @@ pub enum Command {
         #[arg(long)]
         json: bool,
 
-        /// Print only the worktree path (for shell wrappers)
-        #[arg(long, conflicts_with = "json")]
+        /// Print only the worktree path (legacy shell-wrapper output)
+        ///
+        /// When combined with --json, JSON output takes precedence.
+        #[arg(long)]
         print_cd_path: bool,
     },
 
@@ -77,8 +79,10 @@ pub enum Command {
         #[arg(long)]
         json: bool,
 
-        /// Print only the worktree path (for shell wrappers)
-        #[arg(long, conflicts_with = "json")]
+        /// Print only the worktree path (legacy shell-wrapper output)
+        ///
+        /// When combined with --json, JSON output takes precedence.
+        #[arg(long)]
         print_cd_path: bool,
     },
 
@@ -99,8 +103,10 @@ pub enum Command {
         #[arg(long)]
         json: bool,
 
-        /// Print removed_path, repo_root, and branch (one per line) for shell wrappers
-        #[arg(long, conflicts_with = "json")]
+        /// Print removed_path, repo_root, and branch (one per line; legacy shell-wrapper output)
+        ///
+        /// When combined with --json, JSON output takes precedence.
+        #[arg(long)]
         print_paths: bool,
     },
 
@@ -129,8 +135,10 @@ pub enum Command {
         #[arg(long)]
         json: bool,
 
-        /// Print merge info (repo_root, branch, mainline, cleaned_up, removed_path, pushed — one per line) for shell wrappers
-        #[arg(long, conflicts_with = "json")]
+        /// Print merge info (repo_root, branch, mainline, cleaned_up, removed_path, pushed — one per line; legacy shell-wrapper output)
+        ///
+        /// When combined with --json, JSON output takes precedence.
+        #[arg(long)]
         print_paths: bool,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,6 +108,10 @@ pub enum Command {
         /// When combined with --json, JSON output takes precedence.
         #[arg(long)]
         print_paths: bool,
+
+        /// Write wrapper navigation metadata to a private side channel.
+        #[arg(long, hide = true, value_name = "PATH")]
+        navigation_file: Option<PathBuf>,
     },
 
     /// Merge a worktree's branch into a checked-out target and clean up
@@ -140,6 +144,10 @@ pub enum Command {
         /// When combined with --json, JSON output takes precedence.
         #[arg(long)]
         print_paths: bool,
+
+        /// Write wrapper navigation metadata to a private side channel.
+        #[arg(long, hide = true, value_name = "PATH")]
+        navigation_file: Option<PathBuf>,
     },
 
     /// Materialize an explicit detached checkout at a workspace path

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -130,10 +130,12 @@ pub fn run(cli: Cli) -> Result<()> {
 }
 
 fn nav_fmt(json: bool, cd_path: bool) -> NavigationFormat {
-    if cd_path {
-        NavigationFormat::CdPath
-    } else if json {
+    // JSON is the canonical machine format. The path flag remains accepted
+    // so wrappers can append it without making --json invocations invalid.
+    if json {
         NavigationFormat::Json
+    } else if cd_path {
+        NavigationFormat::CdPath
     } else {
         NavigationFormat::Human
     }
@@ -148,20 +150,24 @@ fn status_fmt(json: bool) -> StatusFormat {
 }
 
 fn remove_fmt(json: bool, print_paths: bool) -> RemoveFormat {
-    if print_paths {
-        RemoveFormat::PrintPaths
-    } else if json {
+    // Keep the same precedence as add/go: JSON is canonical, while the
+    // legacy line-oriented output remains available when requested alone.
+    if json {
         RemoveFormat::Json
+    } else if print_paths {
+        RemoveFormat::PrintPaths
     } else {
         RemoveFormat::Human
     }
 }
 
 fn merge_fmt(json: bool, print_paths: bool) -> MergeFormat {
-    if print_paths {
-        MergeFormat::PrintPaths
-    } else if json {
+    // Keep the same precedence as add/go: JSON is canonical, while the
+    // legacy line-oriented output remains available when requested alone.
+    if json {
         MergeFormat::Json
+    } else if print_paths {
+        MergeFormat::PrintPaths
     } else {
         MergeFormat::Human
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,7 @@ use crate::domain::{self, BranchName, WorktreeStatsStatus};
 use crate::error::{AppError, Result};
 use crate::git;
 use crate::output::{
-    find_current_worktree, print_json, JsonDoctorResponse, JsonListResponse,
+    find_current_worktree, print_json, write_navigation_file, JsonDoctorResponse, JsonListResponse,
     JsonMaterializeResponse, JsonMaterializeTimings, JsonMergeResponse, JsonPruneDryRunEntry,
     JsonPruneDryRunResponse, JsonPruneExecuteResponse, JsonPrunedEntry, JsonResponse,
     JsonSkippedEntry, MergeFormat, NavigationFormat, PruneFormat, RemoveFormat, StatusFormat,
@@ -53,11 +53,13 @@ pub fn run(cli: Cli) -> Result<()> {
             repo,
             json,
             print_paths,
+            navigation_file,
         } => cmd_remove(
             branch.as_deref().map(BranchName::new),
             force,
             repo,
             remove_fmt(json, print_paths),
+            navigation_file.as_deref(),
         ),
         Command::Merge {
             branch,
@@ -67,6 +69,7 @@ pub fn run(cli: Cli) -> Result<()> {
             repo,
             json,
             print_paths,
+            navigation_file,
         } => cmd_merge(
             branch.as_deref().map(BranchName::new),
             into,
@@ -74,6 +77,7 @@ pub fn run(cli: Cli) -> Result<()> {
             no_cleanup,
             repo,
             merge_fmt(json, print_paths),
+            navigation_file.as_deref(),
         ),
         Command::Materialize {
             repo_slug,
@@ -1058,6 +1062,7 @@ fn cmd_merge(
     no_cleanup: bool,
     repo: Option<PathBuf>,
     fmt: MergeFormat,
+    navigation_file: Option<&std::path::Path>,
 ) -> Result<()> {
     let repo = resolve_repo(repo)?;
 
@@ -1081,6 +1086,17 @@ fn cmd_merge(
         .as_ref()
         .map(|p| p.display().to_string())
         .unwrap_or_default();
+
+    if let Some(Err(error)) = navigation_file.map(|path| {
+        write_navigation_file(
+            path,
+            result.cleaned_up,
+            result.removed_path.as_deref(),
+            &result.repo_root,
+        )
+    }) {
+        eprintln!("warning: could not write navigation metadata: {error}");
+    }
 
     match fmt {
         MergeFormat::PrintPaths => {
@@ -1134,6 +1150,7 @@ fn cmd_remove(
     force: bool,
     repo: Option<PathBuf>,
     fmt: RemoveFormat,
+    navigation_file: Option<&std::path::Path>,
 ) -> Result<()> {
     let repo = resolve_repo(repo)?;
 
@@ -1147,6 +1164,12 @@ fn cmd_remove(
     let removed_str = result.removed_path.display().to_string();
     let root_str = result.repo_root.display().to_string();
     let branch_name = &result.branch;
+
+    if let Some(Err(error)) = navigation_file.map(|path| {
+        write_navigation_file(path, true, Some(&result.removed_path), &result.repo_root)
+    }) {
+        eprintln!("warning: could not write navigation metadata: {error}");
+    }
 
     match fmt {
         RemoveFormat::PrintPaths => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -5,6 +5,9 @@ use serde::Serialize;
 use crate::domain::{Worktree, WorktreeStatsStatus};
 
 /// Output format for commands that produce a navigable path (add, go).
+///
+/// JSON is selected before the legacy path-only mode when both flags are
+/// present; this keeps wrapper-added path flags compatible with machine calls.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NavigationFormat {
     Human,
@@ -24,7 +27,7 @@ pub enum StatusFormat {
 pub enum RemoveFormat {
     Human,
     Json,
-    /// `--print-paths`: prints removed_path, repo_root, and branch (one per line).
+    /// Legacy `--print-paths`: prints removed_path, repo_root, and branch (one per line).
     PrintPaths,
 }
 
@@ -335,7 +338,7 @@ pub struct JsonSkippedEntry {
 pub enum MergeFormat {
     Human,
     Json,
-    /// `--print-paths`: prints repo_root, branch, mainline, cleaned_up, removed_path, pushed (one per line).
+    /// Legacy `--print-paths`: prints repo_root, branch, mainline, cleaned_up, removed_path, pushed (one per line).
     PrintPaths,
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -394,6 +394,33 @@ pub struct JsonSetupResponse {
     pub gitignore_updated: bool,
 }
 
+/// Write the wrapper navigation side channel without involving JSON parsing.
+///
+/// The record is NUL-delimited as `action`, `removed_path`, and `repo_root`.
+/// Paths are written as their display representation, so shell bindings can
+/// read each field verbatim even when it contains JSON-significant characters.
+/// `action` is `reset` when the parent shell should leave the removed
+/// worktree, and `none` otherwise.
+pub fn write_navigation_file(
+    file: &Path,
+    reset: bool,
+    removed_path: Option<&Path>,
+    repo_root: &Path,
+) -> crate::error::Result<()> {
+    let action = if reset { "reset" } else { "none" };
+    let removed = removed_path
+        .map(|path| path.display().to_string())
+        .unwrap_or_default();
+    let record = format!("{action}\0{removed}\0{}\0", repo_root.display());
+    std::fs::write(file, record.as_bytes()).map_err(|error| {
+        crate::error::AppError::git(format!(
+            "could not write navigation metadata to {}: {error}",
+            file.display()
+        ))
+    })?;
+    Ok(())
+}
+
 /// Serialize a value as a compact single-line JSON object to stdout.
 pub fn print_json(value: &impl Serialize) -> crate::error::Result<()> {
     println!(

--- a/tests/bindings/bash_test.bash
+++ b/tests/bindings/bash_test.bash
@@ -120,9 +120,11 @@ json_add=$(wt add matrix-json --json)
 echo "$json_add" | grep -q '"cd_path"' \
     && pass "matrix add --json: command fields preserved" \
     || fail "matrix add --json: missing cd_path"
-echo "$json_add" | grep -Fq 'quote\\slash' \
-    && pass "matrix add --json: escaped path preserved" \
-    || fail "matrix add --json: escaped path was lost"
+matrix_add_path=$(printf '%s\n' "$json_add" | jq -er '.cd_path | strings')
+expected_matrix_path=$(find "$MATRIX_ROOT/.worktrees" -maxdepth 1 -type d -name 'matrix-json--*' -print -quit)
+[[ "$matrix_add_path" == "$expected_matrix_path" ]] \
+    && pass "matrix add --json: parsed escaped path preserved" \
+    || fail "matrix add --json: parsed path did not match Git path"
 [[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
     && pass "matrix add --json: cwd unchanged" \
     || fail "matrix add --json: cwd changed"
@@ -145,6 +147,7 @@ grep -q 'pnpm install --prefer-offline --frozen-lockfile' "$legacy_stderr" \
 wt remove matrix-diagnostics >/dev/null 2>&1
 
 wt add matrix-remove >/dev/null 2>&1
+expected_matrix_remove_path=$(find "$MATRIX_ROOT/.worktrees" -maxdepth 1 -type d -name 'matrix-remove--*' -print -quit)
 json_remove_file="$WORK/bash-remove.json"
 wt remove matrix-remove --json >"$json_remove_file"
 json_remove=$(cat "$json_remove_file")
@@ -154,9 +157,10 @@ json_remove=$(cat "$json_remove_file")
 echo "$json_remove" | grep -q '"removed_path"' \
     && pass "matrix remove --json: command fields preserved" \
     || fail "matrix remove --json: missing removed_path"
-echo "$json_remove" | grep -Fq 'quote\\slash' \
-    && pass "matrix remove --json: escaped path preserved" \
-    || fail "matrix remove --json: escaped path was lost"
+parsed_removed_path=$(printf '%s\n' "$json_remove" | jq -er '.removed_path | strings')
+[[ "$parsed_removed_path" == "$expected_matrix_remove_path" ]] \
+    && pass "matrix remove --json: parsed escaped path preserved" \
+    || fail "matrix remove --json: parsed path did not match Git path"
 [[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
     && pass "matrix remove --json: cwd reset to repository root" \
     || fail "matrix remove --json: cwd was not reset"

--- a/tests/bindings/bash_test.bash
+++ b/tests/bindings/bash_test.bash
@@ -96,4 +96,88 @@ wt remove feat-one 2>&1
     && pass "wt remove: worktree directory deleted" \
     || fail "wt remove: $WT_PATH still exists"
 
+# ── JSON/navigation matrix ───────────────────────────────────────────
+# Quotes and backslashes in the repository path must survive both the JSON
+# document and the wrapper's navigation side channel.
+MATRIX_REPO="$WORK/repo\"quote\\slash"
+git init "$MATRIX_REPO" >/dev/null 2>&1
+cd "$MATRIX_REPO"
+MATRIX_ROOT="$(pwd -P)"
+if ! wt__path_is_within "$MATRIX_ROOT/.worktrees/app-copy" "$MATRIX_ROOT/.worktrees/app"; then
+    pass "matrix containment: sibling prefix is not a descendant"
+else
+    fail "matrix containment: sibling prefix was treated as a descendant"
+fi
+git config user.name  "test"
+git config user.email "test@test.com"
+git commit --allow-empty -m "initial" >/dev/null 2>&1
+touch pnpm-workspace.yaml
+
+json_add=$(wt add matrix-json --json)
+[[ "$(printf '%s\n' "$json_add" | wc -l)" -eq 1 ]] \
+    && pass "matrix add --json: one raw stdout document" \
+    || fail "matrix add --json: expected one stdout line"
+echo "$json_add" | grep -q '"cd_path"' \
+    && pass "matrix add --json: command fields preserved" \
+    || fail "matrix add --json: missing cd_path"
+echo "$json_add" | grep -Fq 'quote\\slash' \
+    && pass "matrix add --json: escaped path preserved" \
+    || fail "matrix add --json: escaped path was lost"
+[[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
+    && pass "matrix add --json: cwd unchanged" \
+    || fail "matrix add --json: cwd changed"
+
+json_go=$(wt go matrix-json --json)
+[[ "$(printf '%s\n' "$json_go" | wc -l)" -eq 1 ]] \
+    && pass "matrix go --json: one raw stdout document" \
+    || fail "matrix go --json: expected one stdout line"
+echo "$json_go" | grep -q '"event":"switch"' \
+    && pass "matrix go --json: command fields preserved" \
+    || fail "matrix go --json: missing switch event"
+cd "$MATRIX_ROOT"
+wt remove matrix-json >/dev/null 2>&1
+
+legacy_stderr="$WORK/bash-add.stderr"
+wt add matrix-diagnostics >/dev/null 2>"$legacy_stderr"
+grep -q 'pnpm install --prefer-offline --frozen-lockfile' "$legacy_stderr" \
+    && pass "matrix add: successful stderr diagnostics preserved" \
+    || fail "matrix add: stderr diagnostics were discarded"
+wt remove matrix-diagnostics >/dev/null 2>&1
+
+wt add matrix-remove >/dev/null 2>&1
+json_remove_file="$WORK/bash-remove.json"
+wt remove matrix-remove --json >"$json_remove_file"
+json_remove=$(cat "$json_remove_file")
+[[ "$(printf '%s\n' "$json_remove" | wc -l)" -eq 1 ]] \
+    && pass "matrix remove --json: one raw stdout document" \
+    || fail "matrix remove --json: expected one stdout line"
+echo "$json_remove" | grep -q '"removed_path"' \
+    && pass "matrix remove --json: command fields preserved" \
+    || fail "matrix remove --json: missing removed_path"
+echo "$json_remove" | grep -Fq 'quote\\slash' \
+    && pass "matrix remove --json: escaped path preserved" \
+    || fail "matrix remove --json: escaped path was lost"
+[[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
+    && pass "matrix remove --json: cwd reset to repository root" \
+    || fail "matrix remove --json: cwd was not reset"
+
+wt add matrix-merge >/dev/null 2>&1
+printf 'merge\n' > merge.txt
+git add merge.txt
+git commit -m "merge" >/dev/null 2>&1
+json_merge_file="$WORK/bash-merge.json"
+wt merge matrix-merge --json >"$json_merge_file"
+json_merge=$(cat "$json_merge_file")
+[[ "$(printf '%s\n' "$json_merge" | wc -l)" -eq 1 ]] \
+    && pass "matrix merge --json: one raw stdout document" \
+    || fail "matrix merge --json: expected one stdout line"
+echo "$json_merge" | grep -q '"cleaned_up":true' \
+    && pass "matrix merge --json: command fields preserved" \
+    || fail "matrix merge --json: missing cleanup field"
+[[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
+    && pass "matrix merge --json: cwd reset to repository root" \
+    || fail "matrix merge --json: cwd was not reset"
+
+cd /tmp
+
 echo "All bash binding tests passed."

--- a/tests/bindings/bash_test.bash
+++ b/tests/bindings/bash_test.bash
@@ -33,6 +33,17 @@ wt add feat-one >/dev/null 2>&1
 
 WT_PATH="$(pwd -P)"
 
+# ── JSON output selection ────────────────────────────────────────────
+cd "$REPO_PATH"
+json_add=$(wt add feat-json --json)
+echo "$json_add" | grep -q '"cd_path"' \
+    && pass "wt add --json: returns one JSON document" \
+    || fail "wt add --json: expected JSON with cd_path"
+[[ "$(pwd -P)" == "$REPO_PATH" ]] \
+    && pass "wt add --json: cwd unchanged" \
+    || fail "wt add --json: cwd changed unexpectedly"
+wt remove feat-json >/dev/null 2>&1
+
 # ── wt list ──────────────────────────────────────────────────────────
 output=$(wt list 2>&1)
 echo "$output" | grep -q "feat-one" \

--- a/tests/bindings/fish_test.fish
+++ b/tests/bindings/fish_test.fish
@@ -130,4 +130,114 @@ else
     fail "wt remove: $WT_PATH still exists"
 end
 
+# ── JSON/navigation matrix ───────────────────────────────────────────
+set MATRIX_REPO "$WORK/repo\"quote\\slash"
+git init "$MATRIX_REPO" >/dev/null 2>&1
+cd "$MATRIX_REPO"
+set MATRIX_ROOT (pwd -P)
+if not wt__path_is_within "$MATRIX_ROOT/.worktrees/app-copy" "$MATRIX_ROOT/.worktrees/app"
+    pass "matrix containment: sibling prefix is not a descendant"
+else
+    fail "matrix containment: sibling prefix was treated as a descendant"
+end
+git config user.name  "test"
+git config user.email "test@test.com"
+git commit --allow-empty -m "initial" >/dev/null 2>&1
+touch pnpm-workspace.yaml
+
+set json_add (wt add matrix-json --json)
+if test (count $json_add) -eq 1
+    pass "matrix add --json: one raw stdout document"
+else
+    fail "matrix add --json: expected one stdout line"
+end
+if string match -q '*"cd_path"*' "$json_add"
+    pass "matrix add --json: command fields preserved"
+else
+    fail "matrix add --json: missing cd_path"
+end
+if string match -q '*quote\\slash*' "$json_add"
+    pass "matrix add --json: escaped path preserved"
+else
+    fail "matrix add --json: escaped path was lost"
+end
+if test (pwd -P) = "$MATRIX_ROOT"
+    pass "matrix add --json: cwd unchanged"
+else
+    fail "matrix add --json: cwd changed"
+end
+
+set json_go (wt go matrix-json --json)
+if test (count $json_go) -eq 1
+    pass "matrix go --json: one raw stdout document"
+else
+    fail "matrix go --json: expected one stdout line"
+end
+if string match -q '*"event":"switch"*' "$json_go"
+    pass "matrix go --json: command fields preserved"
+else
+    fail "matrix go --json: missing switch event"
+end
+cd "$MATRIX_ROOT"
+wt remove matrix-json >/dev/null 2>&1
+
+set legacy_stderr "$WORK/fish-add.stderr"
+wt add matrix-diagnostics >/dev/null 2>"$legacy_stderr"
+if grep -q 'pnpm install --prefer-offline --frozen-lockfile' "$legacy_stderr"
+    pass "matrix add: successful stderr diagnostics preserved"
+else
+    fail "matrix add: stderr diagnostics were discarded"
+end
+wt remove matrix-diagnostics >/dev/null 2>&1
+
+wt add matrix-remove >/dev/null 2>&1
+set json_remove_file "$WORK/fish-remove.json"
+wt remove matrix-remove --json >"$json_remove_file"
+set json_remove (cat "$json_remove_file")
+if test (count $json_remove) -eq 1
+    pass "matrix remove --json: one raw stdout document"
+else
+    fail "matrix remove --json: expected one stdout line"
+end
+if string match -q '*"removed_path"*' "$json_remove"
+    pass "matrix remove --json: command fields preserved"
+else
+    fail "matrix remove --json: missing removed_path"
+end
+if string match -q '*quote\\slash*' "$json_remove"
+    pass "matrix remove --json: escaped path preserved"
+else
+    fail "matrix remove --json: escaped path was lost"
+end
+if test (pwd -P) = "$MATRIX_ROOT"
+    pass "matrix remove --json: cwd reset to repository root"
+else
+    fail "matrix remove --json: cwd was not reset"
+end
+
+wt add matrix-merge >/dev/null 2>&1
+printf 'merge\n' > merge.txt
+git add merge.txt
+git commit -m "merge" >/dev/null 2>&1
+set json_merge_file "$WORK/fish-merge.json"
+wt merge matrix-merge --json >"$json_merge_file"
+set json_merge (cat "$json_merge_file")
+if test (count $json_merge) -eq 1
+    pass "matrix merge --json: one raw stdout document"
+else
+    fail "matrix merge --json: expected one stdout line"
+end
+if string match -q '*"cleaned_up":true*' "$json_merge"
+    pass "matrix merge --json: command fields preserved"
+else
+    fail "matrix merge --json: missing cleanup field"
+end
+if test (pwd -P) = "$MATRIX_ROOT"
+    pass "matrix merge --json: cwd reset to repository root"
+else
+    fail "matrix merge --json: cwd was not reset"
+end
+
+cd /tmp
+
 echo "All fish binding tests passed."

--- a/tests/bindings/fish_test.fish
+++ b/tests/bindings/fish_test.fish
@@ -42,6 +42,21 @@ end
 
 set WT_PATH (realpath "$PWD")
 
+# ── JSON output selection ────────────────────────────────────────────
+cd "$REPO_PATH"
+set json_add (wt add feat-json --json)
+if string match -q '*"cd_path"*' "$json_add"
+    pass "wt add --json: returns one JSON document"
+else
+    fail "wt add --json: expected JSON with cd_path"
+end
+if test (realpath "$PWD") = "$REPO_PATH"
+    pass "wt add --json: cwd unchanged"
+else
+    fail "wt add --json: cwd changed unexpectedly"
+end
+wt remove feat-json >/dev/null 2>&1
+
 # ── wt list ──────────────────────────────────────────────────────────
 set output (wt list 2>&1)
 if string match -q "*feat-one*" "$output"

--- a/tests/bindings/fish_test.fish
+++ b/tests/bindings/fish_test.fish
@@ -156,10 +156,19 @@ if string match -q '*"cd_path"*' "$json_add"
 else
     fail "matrix add --json: missing cd_path"
 end
-if string match -q '*quote\\slash*' "$json_add"
-    pass "matrix add --json: escaped path preserved"
+# Parse the JSON value and compare it with the path Git created. This checks
+# the decoded quote/backslash rather than counting JSON escape characters.
+set matrix_add_path (printf '%s\n' "$json_add" | jq -er '.cd_path | strings')
+set parse_rc $status
+set expected_matrix_path (realpath "$MATRIX_ROOT/.worktrees"/matrix-json--*)
+set expected_rc $status
+if test $parse_rc -ne 0 -o $expected_rc -ne 0
+    fail "matrix add --json: could not parse or locate worktree path"
+end
+if test "$matrix_add_path" = "$expected_matrix_path"
+    pass "matrix add --json: parsed escaped path preserved"
 else
-    fail "matrix add --json: escaped path was lost"
+    fail "matrix add --json: parsed path did not match Git path"
 end
 if test (pwd -P) = "$MATRIX_ROOT"
     pass "matrix add --json: cwd unchanged"
@@ -178,8 +187,46 @@ if string match -q '*"event":"switch"*' "$json_go"
 else
     fail "matrix go --json: missing switch event"
 end
+# Reproduce the sibling-prefix navigation case: the cwd begins with the
+# removed path text but is not inside that worktree. The wrapper must not cd.
+set sibling_path "$expected_matrix_path-copy"
+mkdir -p "$sibling_path"
+cd "$sibling_path"
+set json_remove_file "$WORK/fish-remove.json"
+wt remove matrix-json --json --repo "$MATRIX_ROOT" >"$json_remove_file"
+set remove_rc $status
+set json_remove (cat "$json_remove_file")
+if test $remove_rc -ne 0
+    fail "matrix remove --json: sibling-path removal failed"
+end
+if test (count $json_remove) -eq 1
+    pass "matrix remove --json: one raw stdout document"
+else
+    fail "matrix remove --json: expected one stdout line"
+end
+if string match -q '*"removed_path"*' "$json_remove"
+    pass "matrix remove --json: command fields preserved"
+else
+    fail "matrix remove --json: missing removed_path"
+end
+set parsed_removed_path (printf '%s\n' "$json_remove" | jq -er '.removed_path | strings')
+set parse_rc $status
+if test $parse_rc -eq 0
+    if test "$parsed_removed_path" = "$expected_matrix_path"
+        pass "matrix remove --json: parsed escaped path preserved"
+    else
+        fail "matrix remove --json: parsed path did not match Git path"
+    end
+else
+    fail "matrix remove --json: invalid JSON"
+end
+if test (pwd -P) = "$sibling_path"
+    pass "matrix remove --json: sibling cwd was not reset"
+else
+    fail "matrix remove --json: sibling cwd was reset unexpectedly"
+end
 cd "$MATRIX_ROOT"
-wt remove matrix-json >/dev/null 2>&1
+rm -rf -- "$sibling_path"
 
 set legacy_stderr "$WORK/fish-add.stderr"
 wt add matrix-diagnostics >/dev/null 2>"$legacy_stderr"
@@ -191,6 +238,7 @@ end
 wt remove matrix-diagnostics >/dev/null 2>&1
 
 wt add matrix-remove >/dev/null 2>&1
+set expected_matrix_remove_path (realpath "$MATRIX_ROOT/.worktrees"/matrix-remove--*)
 set json_remove_file "$WORK/fish-remove.json"
 wt remove matrix-remove --json >"$json_remove_file"
 set json_remove (cat "$json_remove_file")
@@ -204,10 +252,16 @@ if string match -q '*"removed_path"*' "$json_remove"
 else
     fail "matrix remove --json: missing removed_path"
 end
-if string match -q '*quote\\slash*' "$json_remove"
-    pass "matrix remove --json: escaped path preserved"
+set parsed_removed_path (printf '%s\n' "$json_remove" | jq -er '.removed_path | strings')
+set parse_rc $status
+if test $parse_rc -eq 0
+    if test "$parsed_removed_path" = "$expected_matrix_remove_path"
+        pass "matrix remove --json: parsed escaped path preserved"
+    else
+        fail "matrix remove --json: parsed path did not match Git path"
+    end
 else
-    fail "matrix remove --json: escaped path was lost"
+    fail "matrix remove --json: invalid JSON"
 end
 if test (pwd -P) = "$MATRIX_ROOT"
     pass "matrix remove --json: cwd reset to repository root"

--- a/tests/bindings/nu_test.nu
+++ b/tests/bindings/nu_test.nu
@@ -4,6 +4,9 @@
 
 source ../../bindings/nu/wt.nu
 
+let repo_root = (pwd | path expand)
+let binding_path = ($repo_root | path join "bindings/nu/wt.nu")
+
 def pass [msg: string] { print $"  ✓ ($msg)" }
 def fail [msg: string] { print $"  ✗ ($msg)"; exit 1 }
 
@@ -119,10 +122,12 @@ if ($matrix_add | str contains '"cd_path"') {
 } else {
     fail "matrix add --json: missing cd_path"
 }
-if ($matrix_add | str contains 'quote\\slash') {
-    pass "matrix add --json: escaped path preserved"
+let matrix_add_path = (($matrix_add | from json).cd_path)
+let expected_matrix_path = (^find ($matrix_root | path join ".worktrees") -maxdepth 1 -type d -name "matrix-json--*" -print | str trim)
+if $matrix_add_path == $expected_matrix_path {
+    pass "matrix add --json: parsed escaped path preserved"
 } else {
-    fail "matrix add --json: escaped path was lost"
+    fail "matrix add --json: parsed path did not match Git path"
 }
 if ($env.PWD | path expand) == $matrix_root {
     pass "matrix add --json: cwd unchanged"
@@ -149,6 +154,7 @@ if (open $nu_stderr | str contains "pnpm install --prefer-offline --frozen-lockf
 wt remove matrix-diagnostics | ignore
 
 wt add matrix-remove | ignore
+let expected_matrix_remove_path = (^find ($matrix_root | path join ".worktrees") -maxdepth 1 -type d -name "matrix-remove--*" -print | str trim)
 let matrix_remove_file = ($work | path join "nu-remove.json")
 wt remove matrix-remove --json | save --force $matrix_remove_file
 let matrix_remove = (open --raw $matrix_remove_file | decode utf-8)
@@ -157,10 +163,11 @@ if ($matrix_remove | str contains '"removed_path"') {
 } else {
     fail "matrix remove --json: missing removed_path"
 }
-if ($matrix_remove | str contains 'quote\\slash') {
-    pass "matrix remove --json: escaped path preserved"
+let parsed_removed_path = (($matrix_remove | from json).removed_path)
+if $parsed_removed_path == $expected_matrix_remove_path {
+    pass "matrix remove --json: parsed escaped path preserved"
 } else {
-    fail "matrix remove --json: escaped path was lost"
+    fail "matrix remove --json: parsed path did not match Git path"
 }
 if ($env.PWD | path expand) == $matrix_root {
     pass "matrix remove --json: cwd reset to repository root"
@@ -184,6 +191,26 @@ if ($env.PWD | path expand) == $matrix_root {
     pass "matrix merge --json: cwd reset to repository root"
 } else {
     fail "matrix merge --json: cwd was not reset"
+}
+
+# A failed JSON command must still fail when invoked from a child Nu script.
+# The binding re-raises wt-core's external-command error after its stderr has
+# already been rendered, rather than returning success from a catch block.
+let failure_repo = ($work | path join "repo")
+let remove_failure_script = $"source ($binding_path); wt remove missing --json --repo ($failure_repo)"
+let remove_failure = (^nu -c $remove_failure_script | complete)
+if $remove_failure.exit_code != 0 and ($remove_failure.stderr | str contains "no worktree found") {
+    pass "wt remove --json: failure script preserves status and diagnostics"
+} else {
+    fail $"wt remove --json: expected non-zero status and diagnostics, got ($remove_failure.exit_code)"
+}
+
+let merge_failure_script = $"source ($binding_path); wt merge missing --json --repo ($failure_repo)"
+let merge_failure = (^nu -c $merge_failure_script | complete)
+if $merge_failure.exit_code != 0 and ($merge_failure.stderr | str contains "no worktree found") {
+    pass "wt merge --json: failure script preserves status and diagnostics"
+} else {
+    fail $"wt merge --json: expected non-zero status and diagnostics, got ($merge_failure.exit_code)"
 }
 
 cd /tmp

--- a/tests/bindings/nu_test.nu
+++ b/tests/bindings/nu_test.nu
@@ -42,6 +42,21 @@ if ($env.PWD | str contains ".worktrees") and ($env.PWD | str contains "feat-one
 
 let wt_path = $env.PWD
 
+# ── JSON output selection ────────────────────────────────────────────
+cd $"($work)/repo"
+let json_add = (wt add feat-json --json)
+if ($json_add.cd_path? != null) {
+    pass "wt add --json: returns one JSON document"
+} else {
+    fail "wt add --json: expected JSON with cd_path"
+}
+if $env.PWD == ($"($work)/repo" | path expand) {
+    pass "wt add --json: cwd unchanged"
+} else {
+    fail "wt add --json: cwd changed unexpectedly"
+}
+wt remove feat-json | ignore
+
 # ── wt list ──────────────────────────────────────────────────────────
 let output = (wt list | str join "\n")
 if ($output | str contains "feat-one") {

--- a/tests/bindings/nu_test.nu
+++ b/tests/bindings/nu_test.nu
@@ -45,10 +45,10 @@ let wt_path = $env.PWD
 # ── JSON output selection ────────────────────────────────────────────
 cd $"($work)/repo"
 let json_add = (wt add feat-json --json)
-if ($json_add.cd_path? != null) {
-    pass "wt add --json: returns one JSON document"
+if ($json_add | str contains '"cd_path"') {
+    pass "wt add --json: returns raw JSON stdout"
 } else {
-    fail "wt add --json: expected JSON with cd_path"
+    fail "wt add --json: expected raw JSON with cd_path"
 }
 if $env.PWD == ($"($work)/repo" | path expand) {
     pass "wt add --json: cwd unchanged"
@@ -95,6 +95,95 @@ if not ($wt_path | path exists) {
     pass "wt remove: worktree directory deleted"
 } else {
     fail $"wt remove: ($wt_path) still exists"
+}
+
+# ── JSON/navigation matrix ───────────────────────────────────────────
+# Use a repository path containing JSON-significant characters.
+let matrix_repo = ($work | path join 'repo"quote\slash')
+^git init $matrix_repo o+e>| ignore
+cd $matrix_repo
+let matrix_root = ($env.PWD | path expand)
+if not (path-is-within ($matrix_root | path join ".worktrees/app-copy") ($matrix_root | path join ".worktrees/app")) {
+    pass "matrix containment: sibling prefix is not a descendant"
+} else {
+    fail "matrix containment: sibling prefix was treated as a descendant"
+}
+^git config user.name "test"
+^git config user.email "test@test.com"
+^git commit --allow-empty -m "initial" o+e>| ignore
+^touch ($matrix_repo | path join "pnpm-workspace.yaml")
+
+let matrix_add = (wt add matrix-json --json)
+if ($matrix_add | str contains '"cd_path"') {
+    pass "matrix add --json: raw JSON stdout"
+} else {
+    fail "matrix add --json: missing cd_path"
+}
+if ($matrix_add | str contains 'quote\\slash') {
+    pass "matrix add --json: escaped path preserved"
+} else {
+    fail "matrix add --json: escaped path was lost"
+}
+if ($env.PWD | path expand) == $matrix_root {
+    pass "matrix add --json: cwd unchanged"
+} else {
+    fail "matrix add --json: cwd changed"
+}
+
+let matrix_go = (wt go matrix-json --json)
+if ($matrix_go | str contains '"event":"switch"') {
+    pass "matrix go --json: command fields preserved"
+} else {
+    fail "matrix go --json: missing switch event"
+}
+cd $matrix_root
+wt remove matrix-json | ignore
+
+let nu_stderr = ($work | path join "nu-add.stderr")
+let _ = (wt add matrix-diagnostics err> $nu_stderr)
+if (open $nu_stderr | str contains "pnpm install --prefer-offline --frozen-lockfile") {
+    pass "matrix add: successful stderr diagnostics preserved"
+} else {
+    fail "matrix add: stderr diagnostics were discarded"
+}
+wt remove matrix-diagnostics | ignore
+
+wt add matrix-remove | ignore
+let matrix_remove_file = ($work | path join "nu-remove.json")
+wt remove matrix-remove --json | save --force $matrix_remove_file
+let matrix_remove = (open --raw $matrix_remove_file | decode utf-8)
+if ($matrix_remove | str contains '"removed_path"') {
+    pass "matrix remove --json: command fields preserved"
+} else {
+    fail "matrix remove --json: missing removed_path"
+}
+if ($matrix_remove | str contains 'quote\\slash') {
+    pass "matrix remove --json: escaped path preserved"
+} else {
+    fail "matrix remove --json: escaped path was lost"
+}
+if ($env.PWD | path expand) == $matrix_root {
+    pass "matrix remove --json: cwd reset to repository root"
+} else {
+    fail "matrix remove --json: cwd was not reset"
+}
+
+wt add matrix-merge | ignore
+"merge" | save --force merge.txt
+^git add merge.txt
+^git commit -m "merge" o+e>| ignore
+let matrix_merge_file = ($work | path join "nu-merge.json")
+wt merge matrix-merge --json | save --force $matrix_merge_file
+let matrix_merge = (open --raw $matrix_merge_file | decode utf-8)
+if ($matrix_merge | str contains '"cleaned_up":true') {
+    pass "matrix merge --json: command fields preserved"
+} else {
+    fail "matrix merge --json: missing cleanup field"
+}
+if ($env.PWD | path expand) == $matrix_root {
+    pass "matrix merge --json: cwd reset to repository root"
+} else {
+    fail "matrix merge --json: cwd was not reset"
 }
 
 cd /tmp

--- a/tests/bindings/zsh_test.zsh
+++ b/tests/bindings/zsh_test.zsh
@@ -94,4 +94,86 @@ wt remove feat-one 2>&1
     && pass "wt remove: worktree directory deleted" \
     || fail "wt remove: $WT_PATH still exists"
 
+# ── JSON/navigation matrix ───────────────────────────────────────────
+MATRIX_REPO="$WORK/repo\"quote\\slash"
+git init "$MATRIX_REPO" >/dev/null 2>&1
+cd "$MATRIX_REPO"
+MATRIX_ROOT="$(pwd -P)"
+if ! wt__path_is_within "$MATRIX_ROOT/.worktrees/app-copy" "$MATRIX_ROOT/.worktrees/app"; then
+    pass "matrix containment: sibling prefix is not a descendant"
+else
+    fail "matrix containment: sibling prefix was treated as a descendant"
+fi
+git config user.name  "test"
+git config user.email "test@test.com"
+git commit --allow-empty -m "initial" >/dev/null 2>&1
+touch pnpm-workspace.yaml
+
+json_add=$(wt add matrix-json --json)
+[[ "$(printf '%s\n' "$json_add" | wc -l)" -eq 1 ]] \
+    && pass "matrix add --json: one raw stdout document" \
+    || fail "matrix add --json: expected one stdout line"
+echo "$json_add" | grep -q '"cd_path"' \
+    && pass "matrix add --json: command fields preserved" \
+    || fail "matrix add --json: missing cd_path"
+echo "$json_add" | grep -Fq 'quote\\slash' \
+    && pass "matrix add --json: escaped path preserved" \
+    || fail "matrix add --json: escaped path was lost"
+[[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
+    && pass "matrix add --json: cwd unchanged" \
+    || fail "matrix add --json: cwd changed"
+
+json_go=$(wt go matrix-json --json)
+[[ "$(printf '%s\n' "$json_go" | wc -l)" -eq 1 ]] \
+    && pass "matrix go --json: one raw stdout document" \
+    || fail "matrix go --json: expected one stdout line"
+echo "$json_go" | grep -q '"event":"switch"' \
+    && pass "matrix go --json: command fields preserved" \
+    || fail "matrix go --json: missing switch event"
+cd "$MATRIX_ROOT"
+wt remove matrix-json >/dev/null 2>&1
+
+legacy_stderr="$WORK/zsh-add.stderr"
+wt add matrix-diagnostics >/dev/null 2>"$legacy_stderr"
+grep -q 'pnpm install --prefer-offline --frozen-lockfile' "$legacy_stderr" \
+    && pass "matrix add: successful stderr diagnostics preserved" \
+    || fail "matrix add: stderr diagnostics were discarded"
+wt remove matrix-diagnostics >/dev/null 2>&1
+
+wt add matrix-remove >/dev/null 2>&1
+json_remove_file="$WORK/zsh-remove.json"
+wt remove matrix-remove --json >"$json_remove_file"
+json_remove=$(<"$json_remove_file")
+[[ "$(printf '%s\n' "$json_remove" | wc -l)" -eq 1 ]] \
+    && pass "matrix remove --json: one raw stdout document" \
+    || fail "matrix remove --json: expected one stdout line"
+echo "$json_remove" | grep -q '"removed_path"' \
+    && pass "matrix remove --json: command fields preserved" \
+    || fail "matrix remove --json: missing removed_path"
+echo "$json_remove" | grep -Fq 'quote\\slash' \
+    && pass "matrix remove --json: escaped path preserved" \
+    || fail "matrix remove --json: escaped path was lost"
+[[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
+    && pass "matrix remove --json: cwd reset to repository root" \
+    || fail "matrix remove --json: cwd was not reset"
+
+wt add matrix-merge >/dev/null 2>&1
+printf 'merge\n' > merge.txt
+git add merge.txt
+git commit -m "merge" >/dev/null 2>&1
+json_merge_file="$WORK/zsh-merge.json"
+wt merge matrix-merge --json >"$json_merge_file"
+json_merge=$(<"$json_merge_file")
+[[ "$(printf '%s\n' "$json_merge" | wc -l)" -eq 1 ]] \
+    && pass "matrix merge --json: one raw stdout document" \
+    || fail "matrix merge --json: expected one stdout line"
+echo "$json_merge" | grep -q '"cleaned_up":true' \
+    && pass "matrix merge --json: command fields preserved" \
+    || fail "matrix merge --json: missing cleanup field"
+[[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
+    && pass "matrix merge --json: cwd reset to repository root" \
+    || fail "matrix merge --json: cwd was not reset"
+
+cd /tmp
+
 echo "All zsh binding tests passed."

--- a/tests/bindings/zsh_test.zsh
+++ b/tests/bindings/zsh_test.zsh
@@ -116,9 +116,11 @@ json_add=$(wt add matrix-json --json)
 echo "$json_add" | grep -q '"cd_path"' \
     && pass "matrix add --json: command fields preserved" \
     || fail "matrix add --json: missing cd_path"
-echo "$json_add" | grep -Fq 'quote\\slash' \
-    && pass "matrix add --json: escaped path preserved" \
-    || fail "matrix add --json: escaped path was lost"
+matrix_add_path=$(printf '%s\n' "$json_add" | jq -er '.cd_path | strings')
+expected_matrix_path=$(find "$MATRIX_ROOT/.worktrees" -maxdepth 1 -type d -name 'matrix-json--*' -print -quit)
+[[ "$matrix_add_path" == "$expected_matrix_path" ]] \
+    && pass "matrix add --json: parsed escaped path preserved" \
+    || fail "matrix add --json: parsed path did not match Git path"
 [[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
     && pass "matrix add --json: cwd unchanged" \
     || fail "matrix add --json: cwd changed"
@@ -141,6 +143,7 @@ grep -q 'pnpm install --prefer-offline --frozen-lockfile' "$legacy_stderr" \
 wt remove matrix-diagnostics >/dev/null 2>&1
 
 wt add matrix-remove >/dev/null 2>&1
+expected_matrix_remove_path=$(find "$MATRIX_ROOT/.worktrees" -maxdepth 1 -type d -name 'matrix-remove--*' -print -quit)
 json_remove_file="$WORK/zsh-remove.json"
 wt remove matrix-remove --json >"$json_remove_file"
 json_remove=$(<"$json_remove_file")
@@ -150,9 +153,10 @@ json_remove=$(<"$json_remove_file")
 echo "$json_remove" | grep -q '"removed_path"' \
     && pass "matrix remove --json: command fields preserved" \
     || fail "matrix remove --json: missing removed_path"
-echo "$json_remove" | grep -Fq 'quote\\slash' \
-    && pass "matrix remove --json: escaped path preserved" \
-    || fail "matrix remove --json: escaped path was lost"
+parsed_removed_path=$(printf '%s\n' "$json_remove" | jq -er '.removed_path | strings')
+[[ "$parsed_removed_path" == "$expected_matrix_remove_path" ]] \
+    && pass "matrix remove --json: parsed escaped path preserved" \
+    || fail "matrix remove --json: parsed path did not match Git path"
 [[ "$(pwd -P)" == "$MATRIX_ROOT" ]] \
     && pass "matrix remove --json: cwd reset to repository root" \
     || fail "matrix remove --json: cwd was not reset"

--- a/tests/bindings/zsh_test.zsh
+++ b/tests/bindings/zsh_test.zsh
@@ -32,6 +32,17 @@ wt add feat-one >/dev/null 2>&1
 
 WT_PATH="$(pwd -P)"
 
+# ── JSON output selection ────────────────────────────────────────────
+cd "$REPO_PATH"
+json_add=$(wt add feat-json --json)
+echo "$json_add" | grep -q '"cd_path"' \
+    && pass "wt add --json: returns one JSON document" \
+    || fail "wt add --json: expected JSON with cd_path"
+[[ "$(pwd -P)" == "$REPO_PATH" ]] \
+    && pass "wt add --json: cwd unchanged" \
+    || fail "wt add --json: cwd changed unexpectedly"
+wt remove feat-json >/dev/null 2>&1
+
 # ── wt list ──────────────────────────────────────────────────────────
 output=$(wt list 2>&1)
 echo "$output" | grep -q "feat-one" \

--- a/tests/cli_add_remove.rs
+++ b/tests/cli_add_remove.rs
@@ -90,6 +90,33 @@ fn add_print_cd_path_returns_bare_path() {
 }
 
 #[test]
+fn add_json_takes_precedence_over_print_cd_path() {
+    let repo = fixtures::TestRepo::new();
+
+    let output = wt_core()
+        .args([
+            "add",
+            "feature/json-precedence",
+            "--repo",
+            &repo.path().display().to_string(),
+            "--print-cd-path",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("invalid utf8");
+    assert_eq!(stdout.lines().count(), 1, "expected one JSON document");
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("invalid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["branch"], "feature/json-precedence");
+    assert!(json["cd_path"].as_str().is_some());
+}
+
+#[test]
 fn add_fails_when_branch_exists() {
     let repo = fixtures::TestRepo::new();
 
@@ -293,24 +320,36 @@ fn remove_print_paths_returns_three_lines() {
 }
 
 #[test]
-fn remove_print_paths_conflicts_with_json() {
+fn remove_json_takes_precedence_over_print_paths() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
 
     wt_core()
+        .args(["add", "json-precedence-rm", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let output = wt_core()
         .args([
             "remove",
-            "any-branch",
+            "json-precedence-rm",
             "--repo",
             &repo_str,
             "--print-paths",
             "--json",
         ])
         .assert()
-        .failure()
-        .stderr(predicates::prelude::predicate::str::contains(
-            "cannot be used with",
-        ));
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("invalid utf8");
+    assert_eq!(stdout.lines().count(), 1, "expected one JSON document");
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("invalid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["branch"], "json-precedence-rm");
+    assert!(json["removed_path"].as_str().is_some());
 }
 
 // ── Interactive picker fallback tests ───────────────────────────────

--- a/tests/cli_add_remove.rs
+++ b/tests/cli_add_remove.rs
@@ -267,6 +267,42 @@ fn remove_json_includes_removed_path() {
 }
 
 #[test]
+fn remove_json_writes_nul_delimited_navigation_metadata() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "navigation-protocol", "--repo", &repo_str])
+        .assert()
+        .success();
+    let removed_path = fixtures::find_worktree_dir(&repo.path(), "navigation-protocol");
+    let navigation_file = tempfile::NamedTempFile::new().expect("navigation file");
+
+    wt_core()
+        .args([
+            "remove",
+            "navigation-protocol",
+            "--repo",
+            &repo_str,
+            "--json",
+            "--navigation-file",
+            &navigation_file.path().display().to_string(),
+        ])
+        .assert()
+        .success();
+
+    let expected = format!(
+        "reset\0{}\0{}\0",
+        removed_path.display(),
+        repo.path().display()
+    );
+    assert_eq!(
+        std::fs::read(navigation_file.path()).expect("read navigation file"),
+        expected.as_bytes()
+    );
+}
+
+#[test]
 fn remove_print_paths_returns_three_lines() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();

--- a/tests/cli_go.rs
+++ b/tests/cli_go.rs
@@ -142,6 +142,39 @@ fn go_json_emits_single_line_for_machine_parsing() {
 }
 
 #[test]
+fn go_json_takes_precedence_over_print_cd_path() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "go-json-precedence", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let output = wt_core()
+        .args([
+            "go",
+            "go-json-precedence",
+            "--repo",
+            &repo_str,
+            "--print-cd-path",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("invalid utf8");
+    assert_eq!(stdout.lines().count(), 1, "expected one JSON document");
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("invalid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["branch"], "go-json-precedence");
+    assert!(json["cd_path"].as_str().is_some());
+}
+
+#[test]
 fn go_fails_for_nonexistent_branch() {
     let repo = fixtures::TestRepo::new();
 

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -592,22 +592,40 @@ fn merge_print_paths_into_reports_destination_branch() {
 }
 
 #[test]
-fn merge_print_paths_conflicts_with_json() {
+fn merge_json_takes_precedence_over_print_paths() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
 
     wt_core()
+        .args(["add", "feature/json-precedence-merge", "--repo", &repo_str])
+        .assert()
+        .success();
+
+    let wt_dir = find_worktree_dir(&repo.path(), "feature-json-precedence-merge");
+    commit_file(&wt_dir, "precedence.txt", "precedence", "precedence commit");
+
+    let output = wt_core()
         .args([
             "merge",
-            "any-branch",
+            "feature/json-precedence-merge",
             "--repo",
             &repo_str,
             "--print-paths",
             "--json",
         ])
         .assert()
-        .failure()
-        .stderr(predicate::str::contains("cannot be used with"));
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).expect("invalid utf8");
+    assert_eq!(stdout.lines().count(), 1, "expected one JSON document");
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("invalid json");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["branch"], "feature/json-precedence-merge");
+    assert_eq!(json["cleaned_up"], true);
+    assert!(json["removed_path"].as_str().is_some());
 }
 
 // ── Mainline detection ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Make `--json` authoritative for `add`, `go`, `remove`, and `merge` when combined with legacy path selectors.
- Keep legacy `--print-cd-path` / `--print-paths` compatibility for existing scripts.
- Use a private NUL-delimited navigation side channel so shell bindings can safely reset cwd without contaminating JSON stdout.
- Preserve stderr diagnostics and failure statuses across Bash, Zsh, Fish, and Nushell bindings, with path-component-safe cwd checks.

## Validation matrix
| Area | Result |
|---|---|
| Rust unit/integration suite (`cargo test`) | PASS — 221 tests |
| Diff whitespace (`git diff --check`) | PASS |
| Bash binding integration matrix | PASS |
| Nushell binding integration matrix | PASS |
| Zsh/Fish binding integration matrix | Not run locally — runtimes unavailable |

Closes #74
