### PR TITLE
feat: add merge topology preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ wt go [<branch>] [-i]                  Switch to an existing worktree
 wt list [--stats]                      List all worktrees
 wt remove [<branch>] [--force]         Remove a worktree and its local branch
 wt merge [<branch>] [--into <branch>]  Merge a branch and clean up
+wt merge [<branch>] --inspect         Inspect merge topology without mutation
 wt diff [<branch>] [--dry-run]         Open difftool for branch or dirty changes
 wt materialize --sha <sha> ...         Create an explicit detached checkout
 wt prune [--execute] [--force]         Remove worktrees integrated into mainline
@@ -124,7 +125,23 @@ wt merge feature/auth --into rc  # merge into checked-out branch rc
 wt merge feature/auth --into release/1.0  # destination may be linked
 wt merge --push                  # push target branch to origin after merge
 wt merge --no-cleanup            # keep worktree and branch after merge
+wt merge feature/auth --inspect  # report topology without changing the repo
 ```
+
+Before a merge, wt-core reports the destination's configured upstream and
+commit counts. Synchronized destinations are ready to merge; destinations
+that are ahead are called out prominently because a subsequent push includes
+those local commits. Destinations behind or diverged from their upstream are
+refused before Git's content merge starts, so update or reconcile the target
+first. A configured upstream whose remote-tracking ref is unavailable is also
+refused rather than treated as an untracked destination. A source that appears
+in a standard Git revert record is reported as previously merged then reverted.
+
+`--inspect` performs the same read-only preflight and never fetches, prunes
+worktree metadata, merges, pushes, or cleans up. With `--json`, the
+`preflight` object contains `upstream`, `ahead`, `behind`, `topology`, source
+history, and any structured refusal reason. Topology refusals are distinct
+from `content_conflict` refusals.
 
 ### `wt diff`
 
@@ -203,6 +220,7 @@ Example: branch `feature/auth` → `.worktrees/feature-auth--a1b2c3d4/`
 | `--print-cd-path` | Bare absolute path on stdout (for wrappers)  |
 | `--print-paths`   | Version 1 merge metadata on stdout (for wrappers) |
 | `--print-paths-v2` | Version 2 merge metadata, including destination path (for wrappers) |
+| `--inspect` | Read-only merge topology preflight (use with `--json` for facts) |
 
 `--json` emits one compact JSON object per line so machine consumers can parse stdout line-by-line.
 

--- a/bindings/bash/wt.bash
+++ b/bindings/bash/wt.bash
@@ -171,6 +171,13 @@ wt() {
                 return $rc
             fi
 
+            for arg in "$@"; do
+                if [ "$arg" = "--inspect" ]; then
+                    wt-core merge "$@"
+                    return $?
+                fi
+            done
+
             local cwd_before
             cwd_before=$(pwd)
             # --print-paths-v2 preserves the six legacy fields and appends

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -150,6 +150,13 @@ function wt --description "Git worktree manager"
                 return $rc
             end
 
+            for arg in $argv
+                if test "$arg" = "--inspect"
+                    wt-core merge $argv
+                    return $status
+                end
+            end
+
             set -l cwd_before (pwd)
             # --print-paths-v2 preserves the six legacy fields and appends
             # destination_path as field seven.

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -133,6 +133,7 @@ export def --env "wt remove" [
 export def --env "wt merge" [
     branch?: string  # Branch name (defaults to current worktree)
     --into: string   # Merge into a branch checked out in any worktree
+    --inspect        # Inspect topology without mutating the repository
     --push           # Push mainline to origin after merge
     --no-cleanup     # Keep worktree and branch after merge
     --repo: path     # Repository path (defaults to cwd)
@@ -143,10 +144,14 @@ export def --env "wt merge" [
     mut args = ["merge"]
     if $branch != null { $args = ($args | append $branch) }
     if $into != null { $args = ($args | append ["--into" $into]) }
+    if $inspect { $args = ($args | append "--inspect") }
     if $push { $args = ($args | append "--push") }
     if $no_cleanup { $args = ($args | append "--no-cleanup") }
 
-    if $json {
+    if $inspect and not $json {
+        let full_args = (build-args $args $repo false false)
+        ^wt-core ...$full_args
+    } else if $json {
         let full_args = (build-args $args $repo true false)
         let result = (^wt-core ...$full_args | from json)
 

--- a/bindings/zsh/wt.zsh
+++ b/bindings/zsh/wt.zsh
@@ -165,6 +165,13 @@ wt() {
                 return $rc
             fi
 
+            for arg in "$@"; do
+                if [[ "$arg" == "--inspect" ]]; then
+                    wt-core merge "$@"
+                    return $?
+                fi
+            done
+
             local cwd_before="${PWD}"
             # --print-paths-v2 preserves the six legacy fields and appends
             # destination_path as field seven.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,13 @@ pub enum Command {
         #[arg(long, value_name = "BRANCH")]
         into: Option<String>,
 
+        /// Inspect merge topology without merging, cleaning up, or pushing
+        #[arg(
+            long,
+            conflicts_with_all = ["push", "no_cleanup", "print_paths", "print_paths_v2"]
+        )]
+        inspect: bool,
+
         /// Push the target branch to origin after successful merge
         #[arg(long)]
         push: bool,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -7,9 +7,10 @@ use crate::error::{AppError, Result};
 use crate::git;
 use crate::output::{
     find_current_worktree, print_json, JsonDoctorResponse, JsonListResponse,
-    JsonMaterializeResponse, JsonMaterializeTimings, JsonMergeResponse, JsonPruneDryRunEntry,
-    JsonPruneDryRunResponse, JsonPruneExecuteResponse, JsonPrunedEntry, JsonResponse,
-    JsonSkippedEntry, MergeFormat, NavigationFormat, PruneFormat, RemoveFormat, StatusFormat,
+    JsonMaterializeResponse, JsonMaterializeTimings, JsonMergePreflight, JsonMergeRefusal,
+    JsonMergeResponse, JsonPruneDryRunEntry, JsonPruneDryRunResponse, JsonPruneExecuteResponse,
+    JsonPrunedEntry, JsonResponse, JsonSkippedEntry, MergeFormat, NavigationFormat, PruneFormat,
+    RemoveFormat, StatusFormat,
 };
 use crate::worktree;
 use unicode_width::UnicodeWidthStr;
@@ -62,6 +63,7 @@ pub fn run(cli: Cli) -> Result<()> {
         Command::Merge {
             branch,
             into,
+            inspect,
             push,
             no_cleanup,
             repo,
@@ -71,6 +73,7 @@ pub fn run(cli: Cli) -> Result<()> {
         } => cmd_merge(
             branch.as_deref().map(BranchName::new),
             into,
+            inspect,
             push,
             no_cleanup,
             repo,
@@ -1051,6 +1054,7 @@ fn resolve_diff_branch(repo: &domain::RepoRoot) -> Result<BranchName> {
 fn cmd_merge(
     branch: Option<BranchName>,
     into: Option<String>,
+    inspect: bool,
     push: bool,
     no_cleanup: bool,
     repo: Option<PathBuf>,
@@ -1059,24 +1063,48 @@ fn cmd_merge(
     let repo = resolve_repo(repo)?;
 
     let resolved_branch = match branch {
-        Some(b) => Some(b),
+        Some(branch) => Some(branch),
         None => resolve_action_branch(&repo, fmt == MergeFormat::Json, "merge")?,
     };
+    let preflight = worktree::merge_preflight(&repo, resolved_branch.as_ref(), into.as_deref())?;
 
-    let result = worktree::merge(
-        &repo,
-        resolved_branch.as_ref(),
-        into.as_deref(),
-        push,
-        no_cleanup,
-    )?;
+    if inspect {
+        return print_merge_inspection(&repo, &preflight, fmt);
+    }
+
+    if fmt == MergeFormat::Human {
+        print_merge_preflight(&preflight);
+    }
+
+    if let Some(refusal) = &preflight.refusal {
+        let error = AppError::conflict(refusal.message.clone());
+        return report_merge_failure(&repo, &preflight, fmt, error, None);
+    }
+
+    let preflight_for_error = preflight.clone();
+    let result = match worktree::merge_with_preflight(&repo, preflight, push, no_cleanup) {
+        Ok(result) => result,
+        Err(error) => {
+            return report_merge_failure(
+                &repo,
+                &preflight_for_error,
+                fmt,
+                error,
+                Some(JsonMergeRefusal {
+                    kind: "content".to_string(),
+                    reason: "content_conflict".to_string(),
+                    message: Some("destination content conflicts with the source".to_string()),
+                }),
+            )
+        }
+    };
 
     let root_str = result.repo_root.display().to_string();
     let branch_name = &result.branch;
     let removed_str = result
         .removed_path
         .as_ref()
-        .map(|p| p.display().to_string())
+        .map(|path| path.display().to_string())
         .unwrap_or_default();
 
     match fmt {
@@ -1118,6 +1146,9 @@ fn cmd_merge(
                     None
                 },
                 pushed: result.pushed,
+                preflight: Some(JsonMergePreflight::from_preflight(&result.preflight)),
+                refusal: None,
+                inspect: false,
             })?;
         }
         MergeFormat::Human => {
@@ -1134,10 +1165,167 @@ fn cmd_merge(
             }
         }
     }
-    for w in &result.warnings {
-        eprintln!("warning: {w}");
+    for warning in &result.warnings {
+        eprintln!("warning: {warning}");
     }
     Ok(())
+}
+
+fn print_merge_preflight(preflight: &worktree::MergePreflight) {
+    println!(
+        "Merge preflight: destination '{}' at {}",
+        preflight.destination,
+        preflight.destination_path.display()
+    );
+    match (&preflight.upstream, preflight.ahead, preflight.behind) {
+        (Some(upstream), Some(ahead), Some(behind)) => {
+            println!("  Destination upstream: {upstream}");
+            println!(
+                "  Topology: {} (ahead {ahead}, behind {behind})",
+                merge_topology_label(preflight.topology)
+            );
+            if preflight.topology == worktree::MergeTopology::Ahead {
+                println!(
+                    "  WARNING: destination is AHEAD of upstream by {ahead} commit{}; merge/push will preserve those local commits",
+                    if ahead == 1 { "" } else { "s" }
+                );
+            }
+        }
+        (Some(upstream), None, None) => {
+            println!("  Destination upstream: {upstream} (unavailable locally)");
+            println!(
+                "  Topology: {} (ahead/behind counts unavailable)",
+                merge_topology_label(preflight.topology)
+            );
+        }
+        (None, _, _) => {
+            println!("  Destination upstream: none");
+            println!("  Topology: no upstream (ahead/behind counts unavailable)");
+        }
+        _ => {
+            println!("  Destination upstream: unavailable");
+            println!(
+                "  Topology: {} (ahead/behind counts unavailable)",
+                merge_topology_label(preflight.topology)
+            );
+        }
+    }
+
+    print_source_history(preflight);
+    match &preflight.refusal {
+        Some(refusal) => println!("  REFUSED ({}): {}", refusal.kind, refusal.message),
+        None => println!("  Result: ready for content merge"),
+    }
+}
+
+fn print_source_history(preflight: &worktree::MergePreflight) {
+    match preflight.source_history {
+        worktree::SourceHistory::NotMerged => {}
+        worktree::SourceHistory::AlreadyMerged => println!(
+            "  Source history: source '{}' is already merged into the destination",
+            preflight.source
+        ),
+        worktree::SourceHistory::MergedThenReverted => {
+            let commit = preflight
+                .reverted_commit
+                .as_deref()
+                .unwrap_or("an earlier source commit");
+            println!(
+                "  WARNING: source '{}' was previously merged then reverted (revert of {commit}); merging again may intentionally reintroduce reverted changes",
+                preflight.source
+            );
+        }
+    }
+}
+
+fn merge_topology_label(topology: worktree::MergeTopology) -> &'static str {
+    match topology {
+        worktree::MergeTopology::NoUpstream => "no upstream",
+        worktree::MergeTopology::UpstreamUnavailable => "upstream unavailable",
+        worktree::MergeTopology::Synchronized => "synchronized",
+        worktree::MergeTopology::Ahead => "ahead",
+        worktree::MergeTopology::Behind => "behind",
+        worktree::MergeTopology::Diverged => "diverged",
+    }
+}
+
+fn print_merge_inspection(
+    repo: &domain::RepoRoot,
+    preflight: &worktree::MergePreflight,
+    fmt: MergeFormat,
+) -> Result<()> {
+    match fmt {
+        MergeFormat::Json => print_json(&JsonMergeResponse {
+            ok: true,
+            event: None,
+            message: format!(
+                "inspected merge of '{}' into {}",
+                preflight.source, preflight.destination
+            ),
+            branch: preflight.source.clone(),
+            mainline: preflight.destination.clone(),
+            destination_path: preflight.destination_path.display().to_string(),
+            repo_root: repo.display().to_string(),
+            cleaned_up: false,
+            removed_path: None,
+            pushed: false,
+            preflight: Some(JsonMergePreflight::from_preflight(preflight)),
+            refusal: preflight.refusal.as_ref().map(|refusal| JsonMergeRefusal {
+                kind: refusal.kind.clone(),
+                reason: refusal.reason.clone(),
+                message: Some(refusal.message.clone()),
+            }),
+            inspect: true,
+        }),
+        MergeFormat::Human => {
+            println!(
+                "Inspecting merge of '{}' (no repository mutation)",
+                preflight.source
+            );
+            print_merge_preflight(preflight);
+            Ok(())
+        }
+        MergeFormat::PrintPaths | MergeFormat::PrintPathsV2 => Err(AppError::usage(
+            "--inspect cannot be used with path output formats".to_string(),
+        )),
+    }
+}
+
+fn report_merge_failure(
+    repo: &domain::RepoRoot,
+    preflight: &worktree::MergePreflight,
+    fmt: MergeFormat,
+    error: AppError,
+    refusal: Option<JsonMergeRefusal>,
+) -> Result<()> {
+    if fmt == MergeFormat::Json {
+        let json_refusal = refusal.or_else(|| {
+            preflight
+                .refusal
+                .as_ref()
+                .map(|preflight_refusal| JsonMergeRefusal {
+                    kind: preflight_refusal.kind.clone(),
+                    reason: preflight_refusal.reason.clone(),
+                    message: Some(preflight_refusal.message.clone()),
+                })
+        });
+        print_json(&JsonMergeResponse {
+            ok: false,
+            event: None,
+            message: error.message.clone(),
+            branch: preflight.source.clone(),
+            mainline: preflight.destination.clone(),
+            destination_path: preflight.destination_path.display().to_string(),
+            repo_root: repo.display().to_string(),
+            cleaned_up: false,
+            removed_path: None,
+            pushed: false,
+            preflight: Some(JsonMergePreflight::from_preflight(preflight)),
+            refusal: json_refusal,
+            inspect: false,
+        })?;
+    }
+    Err(error)
 }
 
 fn cmd_remove(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -763,10 +763,12 @@ fn pick_worktree(_worktrees: &[domain::Worktree]) -> Result<BranchName> {
 ///
 /// `is_json` — whether the output format is machine-only (JSON).
 /// `action`  — verb shown in picker prompt and error messages (e.g. "remove", "merge").
+/// `readonly` — avoid pruning worktree metadata for inspection.
 fn resolve_action_branch(
     repo: &domain::RepoRoot,
     is_json: bool,
     action: &str,
+    readonly: bool,
 ) -> Result<Option<BranchName>> {
     if is_json {
         return Ok(None);
@@ -776,7 +778,11 @@ fn resolve_action_branch(
         return Ok(None);
     }
 
-    let worktrees = git::list_worktrees(repo)?;
+    let worktrees = if readonly {
+        git::list_worktrees_readonly(repo)?
+    } else {
+        git::list_worktrees(repo)?
+    };
     let candidates: Vec<_> = worktrees.iter().filter(|wt| !wt.is_main).collect();
 
     if candidates.is_empty() {
@@ -1064,9 +1070,10 @@ fn cmd_merge(
 
     let resolved_branch = match branch {
         Some(branch) => Some(branch),
-        None => resolve_action_branch(&repo, fmt == MergeFormat::Json, "merge")?,
+        None => resolve_action_branch(&repo, fmt == MergeFormat::Json, "merge", inspect)?,
     };
-    let preflight = worktree::merge_preflight(&repo, resolved_branch.as_ref(), into.as_deref())?;
+    let preflight =
+        worktree::merge_preflight(&repo, resolved_branch.as_ref(), into.as_deref(), inspect)?;
 
     if inspect {
         return print_merge_inspection(&repo, &preflight, fmt);
@@ -1084,18 +1091,26 @@ fn cmd_merge(
     let preflight_for_error = preflight.clone();
     let result = match worktree::merge_with_preflight(&repo, preflight, push, no_cleanup) {
         Ok(result) => result,
-        Err(error) => {
+        Err(failure) => {
+            let refusal = match failure.kind {
+                worktree::MergeFailureKind::ContentConflict => JsonMergeRefusal {
+                    kind: "content".to_string(),
+                    reason: "content_conflict".to_string(),
+                    message: Some("destination content conflicts with the source".to_string()),
+                },
+                worktree::MergeFailureKind::GitFailure => JsonMergeRefusal {
+                    kind: "git".to_string(),
+                    reason: "git_error".to_string(),
+                    message: Some(failure.error.message.clone()),
+                },
+            };
             return report_merge_failure(
                 &repo,
                 &preflight_for_error,
                 fmt,
-                error,
-                Some(JsonMergeRefusal {
-                    kind: "content".to_string(),
-                    reason: "content_conflict".to_string(),
-                    message: Some("destination content conflicts with the source".to_string()),
-                }),
-            )
+                failure.error,
+                Some(refusal),
+            );
         }
     };
 
@@ -1338,7 +1353,7 @@ fn cmd_remove(
 
     let resolved_branch = match branch {
         Some(b) => Some(b),
-        None => resolve_action_branch(&repo, fmt == RemoveFormat::Json, "remove")?,
+        None => resolve_action_branch(&repo, fmt == RemoveFormat::Json, "remove", false)?,
     };
 
     let result = worktree::remove(&repo, resolved_branch.as_ref(), force)?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1161,6 +1161,7 @@ fn cmd_merge(
                     None
                 },
                 pushed: result.pushed,
+                warnings: result.warnings.clone(),
                 preflight: Some(JsonMergePreflight::from_preflight(&result.preflight)),
                 refusal: None,
                 inspect: false,
@@ -1284,6 +1285,7 @@ fn print_merge_inspection(
             cleaned_up: false,
             removed_path: None,
             pushed: false,
+            warnings: Vec::new(),
             preflight: Some(JsonMergePreflight::from_preflight(preflight)),
             refusal: preflight.refusal.as_ref().map(|refusal| JsonMergeRefusal {
                 kind: refusal.kind.clone(),
@@ -1335,6 +1337,7 @@ fn report_merge_failure(
             cleaned_up: false,
             removed_path: None,
             pushed: false,
+            warnings: Vec::new(),
             preflight: Some(JsonMergePreflight::from_preflight(preflight)),
             refusal: json_refusal,
             inspect: false,

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command as Cmd;
@@ -658,9 +659,328 @@ pub fn merge_in_progress(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Return whether a path is a usable Git worktree.
-pub fn worktree_is_valid(path: &Path) -> bool {
-    git_success(&["rev-parse", "--is-inside-work-tree"], path)
+/// Resolve a path returned by `git rev-parse` relative to its command cwd.
+fn canonical_git_path(cwd: &Path, argument: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(git(&["rev-parse", argument], cwd)?);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    };
+    path.canonicalize().map_err(|error| {
+        AppError::conflict(format!(
+            "cannot canonicalize Git metadata path '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+/// Reject aliases that could make a registered path resolve somewhere else.
+fn has_symlink_component(path: &Path) -> bool {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => cwd.join(path),
+            Err(_) => return true,
+        }
+    };
+
+    let mut current = PathBuf::new();
+    for component in absolute.components() {
+        current.push(component.as_os_str());
+        if fs::symlink_metadata(&current)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Resolve a path stored in a worktree admin file.
+fn resolve_admin_link(admin_dir: &Path, link: &str) -> PathBuf {
+    let link = PathBuf::from(link);
+    if link.is_absolute() {
+        link
+    } else {
+        admin_dir.join(link)
+    }
+}
+
+/// Find the one main-repository admin entry registered for `worktree`.
+fn registered_worktree_admin(common_dir: &Path, worktree: &Path) -> Result<PathBuf> {
+    let admin_root = common_dir.join("worktrees");
+    let canonical_admin_root = admin_root.canonicalize().map_err(|error| {
+        AppError::conflict(format!(
+            "cannot canonicalize Git worktree admin directory '{}': {error}",
+            admin_root.display()
+        ))
+    })?;
+    let worktree_git = worktree.join(".git").canonicalize().map_err(|error| {
+        AppError::conflict(format!(
+            "cannot canonicalize worktree Git link '{}': {error}",
+            worktree.join(".git").display()
+        ))
+    })?;
+
+    let mut matches = Vec::new();
+    for entry in fs::read_dir(&canonical_admin_root).map_err(|error| {
+        AppError::conflict(format!(
+            "cannot inspect Git worktree admin directory '{}': {error}",
+            canonical_admin_root.display()
+        ))
+    })? {
+        let entry = entry.map_err(|error| {
+            AppError::conflict(format!("cannot inspect Git worktree admin entry: {error}"))
+        })?;
+        let admin_dir = entry.path();
+        if !admin_dir.is_dir() {
+            continue;
+        }
+        let canonical_admin = admin_dir.canonicalize().map_err(|error| {
+            AppError::conflict(format!(
+                "cannot canonicalize Git worktree admin entry '{}': {error}",
+                admin_dir.display()
+            ))
+        })?;
+        if canonical_admin.parent() != Some(canonical_admin_root.as_path()) {
+            continue;
+        }
+
+        let link = match fs::read_to_string(canonical_admin.join("gitdir")) {
+            Ok(link) => link,
+            Err(_) => continue,
+        };
+        let target = resolve_admin_link(&canonical_admin, link.trim());
+        let Ok(target) = target.canonicalize() else {
+            continue;
+        };
+        if target == worktree_git {
+            matches.push(canonical_admin);
+        }
+    }
+
+    match matches.as_slice() {
+        [admin] => Ok(admin.clone()),
+        [] => Err(AppError::conflict(format!(
+            "worktree '{}' has no matching main-repository admin entry",
+            worktree.display()
+        ))),
+        _ => Err(AppError::conflict(format!(
+            "worktree '{}' has multiple matching main-repository admin entries",
+            worktree.display()
+        ))),
+    }
+}
+
+/// Verify that a listed worktree is the exact worktree registered by `repo`.
+///
+/// `git worktree list` reports branch and path metadata from the owning
+/// repository even when the directory at that path has been replaced. Before
+/// merge code uses a path, compare both Git's canonical common directory and
+/// the per-worktree admin linkage. This prevents an unrelated, nested, or
+/// symlink-aliased repository from receiving a merge or cleanup operation.
+pub fn validate_worktree_identity(repo: &RepoRoot, worktree: &Worktree) -> Result<()> {
+    let path = &worktree.path;
+    if has_symlink_component(path) {
+        return Err(AppError::conflict(format!(
+            "worktree path '{}' contains a symlink component",
+            path.display()
+        )));
+    }
+
+    let canonical_repo = repo.as_ref().canonicalize().map_err(|error| {
+        AppError::conflict(format!(
+            "cannot canonicalize owning repository '{}': {error}",
+            repo.display()
+        ))
+    })?;
+    let canonical_path = path.canonicalize().map_err(|_| {
+        AppError::conflict(format!("worktree path '{}' is unavailable", path.display()))
+    })?;
+    if !worktree.is_main && canonical_path == canonical_repo {
+        return Err(AppError::conflict(format!(
+            "linked worktree '{}' resolves to the owning repository root",
+            path.display()
+        )));
+    }
+    if worktree.is_main && canonical_path != canonical_repo {
+        return Err(AppError::conflict(format!(
+            "main worktree '{}' is not the owning repository root '{}'",
+            path.display(),
+            canonical_repo.display()
+        )));
+    }
+
+    let common_dir = canonical_git_path(repo.as_ref(), "--git-common-dir")?;
+    let worktree_common = canonical_git_path(path, "--git-common-dir")?;
+    if worktree_common != common_dir {
+        return Err(AppError::conflict(format!(
+            "Git common directory '{}' does not match owning repository '{}'",
+            worktree_common.display(),
+            common_dir.display()
+        )));
+    }
+
+    let worktree_git_file = path.join(".git");
+    match worktree.is_main {
+        true => {
+            let worktree_git_dir = canonical_git_path(path, "--git-dir")?;
+            if worktree_git_dir != common_dir {
+                return Err(AppError::conflict(format!(
+                    "main worktree Git directory '{}' does not match owning repository '{}'",
+                    worktree_git_dir.display(),
+                    common_dir.display()
+                )));
+            }
+        }
+        false => {
+            let metadata = fs::symlink_metadata(&worktree_git_file).map_err(|error| {
+                AppError::conflict(format!(
+                    "linked worktree Git link '{}' is unavailable: {error}",
+                    worktree_git_file.display()
+                ))
+            })?;
+            if !metadata.file_type().is_file() {
+                return Err(AppError::conflict(format!(
+                    "linked worktree '{}' does not have a regular .git link",
+                    path.display()
+                )));
+            }
+
+            let admin_dir = registered_worktree_admin(&common_dir, path)?;
+            let actual_git_dir = canonical_git_path(path, "--git-dir")?;
+            if actual_git_dir != admin_dir {
+                return Err(AppError::conflict(format!(
+                    "Git directory '{}' is not the registered admin entry '{}'",
+                    actual_git_dir.display(),
+                    admin_dir.display()
+                )));
+            }
+
+            let link = fs::read_to_string(&worktree_git_file).map_err(|error| {
+                AppError::conflict(format!(
+                    "cannot read linked worktree Git link '{}': {error}",
+                    worktree_git_file.display()
+                ))
+            })?;
+            let link = link.strip_prefix("gitdir:").map(str::trim).ok_or_else(|| {
+                AppError::conflict(format!(
+                    "linked worktree Git link '{}' has an invalid format",
+                    worktree_git_file.display()
+                ))
+            })?;
+            let linked_admin = resolve_admin_link(path, link)
+                .canonicalize()
+                .map_err(|error| {
+                    AppError::conflict(format!(
+                        "cannot canonicalize linked worktree admin path '{}': {error}",
+                        link
+                    ))
+                })?;
+            if linked_admin != admin_dir {
+                return Err(AppError::conflict(format!(
+                    "linked worktree Git link '{}' does not point to registered admin entry '{}'",
+                    linked_admin.display(),
+                    admin_dir.display()
+                )));
+            }
+
+            let admin_link = fs::read_to_string(admin_dir.join("gitdir")).map_err(|error| {
+                AppError::conflict(format!(
+                    "cannot read worktree admin link '{}': {error}",
+                    admin_dir.join("gitdir").display()
+                ))
+            })?;
+            let registered_path = resolve_admin_link(&admin_dir, admin_link.trim())
+                .canonicalize()
+                .map_err(|error| {
+                    AppError::conflict(format!(
+                        "cannot canonicalize worktree admin link '{}': {error}",
+                        admin_link.trim()
+                    ))
+                })?;
+            if registered_path
+                != worktree_git_file.canonicalize().map_err(|error| {
+                    AppError::conflict(format!(
+                        "cannot canonicalize worktree Git link '{}': {error}",
+                        worktree_git_file.display()
+                    ))
+                })?
+            {
+                return Err(AppError::conflict(format!(
+                    "worktree admin entry '{}' is not linked back to '{}'",
+                    admin_dir.display(),
+                    worktree_git_file.display()
+                )));
+            }
+
+            match fs::read_to_string(admin_dir.join("commondir")) {
+                Ok(commondir) => {
+                    let admin_common = resolve_admin_link(&admin_dir, commondir.trim())
+                        .canonicalize()
+                        .map_err(|error| {
+                            AppError::conflict(format!(
+                                "cannot canonicalize worktree admin common directory '{}': {error}",
+                                commondir.trim()
+                            ))
+                        })?;
+                    if admin_common != common_dir {
+                        return Err(AppError::conflict(format!(
+                            "worktree admin common directory '{}' does not match owning repository '{}'",
+                            admin_common.display(),
+                            common_dir.display()
+                        )));
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(AppError::conflict(format!(
+                        "cannot read worktree admin common directory '{}': {error}",
+                        admin_dir.join("commondir").display()
+                    )));
+                }
+            }
+
+            let admin_head = fs::read_to_string(admin_dir.join("HEAD")).map_err(|error| {
+                AppError::conflict(format!(
+                    "cannot read worktree admin HEAD '{}': {error}",
+                    admin_dir.join("HEAD").display()
+                ))
+            })?;
+            let admin_branch = admin_head
+                .trim()
+                .strip_prefix("ref: refs/heads/")
+                .map(str::to_string);
+            let actual_branch = git(&["symbolic-ref", "--quiet", "--short", "HEAD"], path).ok();
+            if admin_branch != worktree.branch || actual_branch != worktree.branch {
+                return Err(AppError::conflict(format!(
+                    "worktree branch metadata does not match registered branch '{}'",
+                    worktree.branch.as_deref().unwrap_or("(detached)")
+                )));
+            }
+        }
+    }
+
+    let actual_branch = git(&["symbolic-ref", "--quiet", "--short", "HEAD"], path).ok();
+    if actual_branch != worktree.branch {
+        return Err(AppError::conflict(format!(
+            "worktree branch '{}' does not match the registered branch '{}'",
+            actual_branch.as_deref().unwrap_or("(detached)"),
+            worktree.branch.as_deref().unwrap_or("(detached)")
+        )));
+    }
+    let actual_head = git(&["rev-parse", "--verify", "HEAD"], path)?;
+    if !worktree.commit.is_empty() && !actual_head.starts_with(&worktree.commit) {
+        return Err(AppError::conflict(format!(
+            "worktree HEAD '{}' does not match registered HEAD '{}'",
+            actual_head, worktree.commit
+        )));
+    }
+
+    Ok(())
 }
 
 /// Return whether Git left unmerged index entries in a worktree.

--- a/src/git.rs
+++ b/src/git.rs
@@ -98,7 +98,14 @@ pub fn repo_root(start: &Path) -> Result<RepoRoot> {
 pub fn list_worktrees(repo: &RepoRoot) -> Result<Vec<Worktree>> {
     // Prune stale worktrees first (matches current behavior expectation).
     let _ = git(&["worktree", "prune"], repo.as_ref());
+    list_worktrees_readonly(repo)
+}
 
+/// List worktrees without pruning Git's worktree metadata.
+///
+/// Merge preflight and `--inspect` use this variant so inspection never
+/// changes repository state, including stale-worktree administrative files.
+pub fn list_worktrees_readonly(repo: &RepoRoot) -> Result<Vec<Worktree>> {
     let raw = git(&["worktree", "list", "--porcelain"], repo.as_ref())?;
     parse_worktree_porcelain(&raw, repo)
 }
@@ -301,6 +308,17 @@ fn resolve_origin_head(repo: &RepoRoot) -> Option<String> {
 /// 3. Local branch named `master`
 /// 4. The main worktree's branch (first entry from `git worktree list`)
 pub fn resolve_mainline(repo: &RepoRoot) -> Result<String> {
+    resolve_mainline_with_worktree_listing(repo, true)
+}
+
+/// Resolve the mainline without pruning worktree metadata.
+///
+/// This is used by merge preflight because inspection must be read-only.
+pub fn resolve_mainline_readonly(repo: &RepoRoot) -> Result<String> {
+    resolve_mainline_with_worktree_listing(repo, false)
+}
+
+fn resolve_mainline_with_worktree_listing(repo: &RepoRoot, prune: bool) -> Result<String> {
     // 1. Try origin/HEAD — prefer the local branch name if it exists,
     //    otherwise use the full remote ref so git commands can resolve it
     //    even when there is no local tracking branch.
@@ -321,7 +339,11 @@ pub fn resolve_mainline(repo: &RepoRoot) -> Result<String> {
     }
 
     // 4. Fall back to main worktree's branch
-    let worktrees = list_worktrees(repo)?;
+    let worktrees = if prune {
+        list_worktrees(repo)?
+    } else {
+        list_worktrees_readonly(repo)?
+    };
     worktrees
         .iter()
         .find(|wt| wt.is_main)
@@ -331,6 +353,127 @@ pub fn resolve_mainline(repo: &RepoRoot) -> Result<String> {
                 "could not determine mainline branch; use --mainline to specify".to_string(),
             )
         })
+}
+
+/// Return the configured upstream ref for a checked-out branch.
+///
+/// `for-each-ref` reads branch configuration without requiring the upstream
+/// object to exist. This keeps a configured-but-stale remote visible to
+/// callers instead of misreporting it as a branch with no upstream.
+pub fn branch_upstream(path: &Path, branch: &str) -> Result<Option<String>> {
+    let branch_ref = format!("refs/heads/{branch}");
+    let output = git(
+        &["for-each-ref", "--format=%(upstream:short)", &branch_ref],
+        path,
+    )?;
+    Ok((!output.is_empty()).then_some(output))
+}
+
+/// Return ahead and behind commit counts for a branch and its upstream.
+///
+/// The first value is commits the branch is behind; the second is commits it
+/// is ahead, matching Git's `--left-right --count` ordering. `None` means the
+/// configured upstream ref is unavailable locally; this is distinct from a
+/// branch with no configured upstream.
+pub fn upstream_counts(path: &Path, upstream: &str, branch: &str) -> Result<Option<(u32, u32)>> {
+    if !git_success(&["rev-parse", "--verify", upstream], path) {
+        return Ok(None);
+    }
+
+    let range = format!("{upstream}...{branch}");
+    let output = git(&["rev-list", "--left-right", "--count", &range], path)?;
+    let mut fields = output.split_whitespace();
+    let behind = fields
+        .next()
+        .and_then(|value| value.parse::<u32>().ok())
+        .ok_or_else(|| AppError::git("failed to parse upstream behind count".to_string()))?;
+    let ahead = fields
+        .next()
+        .and_then(|value| value.parse::<u32>().ok())
+        .ok_or_else(|| AppError::git("failed to parse upstream ahead count".to_string()))?;
+    Ok(Some((ahead, behind)))
+}
+
+/// Find a standard Git revert commit that refers to source history.
+///
+/// Git records the reverted object in the body as `This reverts commit ...`.
+/// A marker alone is not enough: the reverted object must be in the
+/// destination history, and either the object itself or (for a reverted merge)
+/// its second parent must be reachable from `source`. This avoids warning for
+/// a revert message that merely names an unrelated object.
+pub fn reverted_source_commit(
+    path: &Path,
+    source: &str,
+    destination: &str,
+) -> Result<Option<String>> {
+    let log = git(&["log", "--format=%H%x00%P%x00%B%x1e", destination], path)?;
+    let source_was_merged =
+        git_success(&["merge-base", "--is-ancestor", source, destination], path);
+    let common_base = git(&["merge-base", source, destination], path).ok();
+
+    for record in log.split('\x1e') {
+        let mut fields = record.splitn(3, '\0');
+        let Some(_revert_commit) = fields.next() else {
+            continue;
+        };
+        let Some(_revert_parents) = fields.next() else {
+            continue;
+        };
+        let Some(message) = fields.next() else {
+            continue;
+        };
+        let Some(marker) = message.find("This reverts commit ") else {
+            continue;
+        };
+        let start = marker + "This reverts commit ".len();
+        let Some(reverted) = message[start..]
+            .split(|character: char| !character.is_ascii_hexdigit())
+            .next()
+            .filter(|value| value.len() == 40)
+        else {
+            continue;
+        };
+
+        if !git_success(
+            &["merge-base", "--is-ancestor", reverted, destination],
+            path,
+        ) {
+            continue;
+        }
+
+        let reverted_parents = match git(&["show", "-s", "--format=%P", reverted], path) {
+            Ok(parents) => parents,
+            Err(_) => continue,
+        };
+        let parents: Vec<&str> = reverted_parents.split_whitespace().collect();
+        let source_history_commit = parents
+            .get(1)
+            .copied()
+            .filter(|second_parent| {
+                git_success(
+                    &["merge-base", "--is-ancestor", second_parent, source],
+                    path,
+                )
+            })
+            .unwrap_or(reverted);
+        let is_shared_base = common_base.as_deref().is_some_and(|base| {
+            git_success(
+                &["merge-base", "--is-ancestor", source_history_commit, base],
+                path,
+            )
+        });
+        if !source_was_merged && is_shared_base {
+            continue;
+        }
+        if git_success(
+            &["merge-base", "--is-ancestor", source_history_commit, source],
+            path,
+        ) {
+            return Ok(Some(reverted.to_string()));
+        }
+    }
+
+    Ok(None)
 }
 
 /// Compute commit and diff stats for `branch` against `base`.

--- a/src/git.rs
+++ b/src/git.rs
@@ -775,14 +775,42 @@ fn registered_worktree_admin(common_dir: &Path, worktree: &Path) -> Result<PathB
     }
 }
 
-/// Verify that a listed worktree is the exact worktree registered by `repo`.
+/// Stable registration identity for a worktree.
+///
+/// The main worktree uses the repository's common Git directory as its admin
+/// directory. A linked worktree uses its unique entry below
+/// `<common-dir>/worktrees`. The path is captured before a merge and compared
+/// later; path, branch, and common-directory checks alone cannot distinguish a
+/// replacement worktree registered during a hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeIdentity {
+    Main { admin_dir: PathBuf },
+    Linked { admin_dir: PathBuf },
+}
+
+impl WorktreeIdentity {
+    pub fn admin_dir(&self) -> &Path {
+        match self {
+            Self::Main { admin_dir } | Self::Linked { admin_dir } => admin_dir,
+        }
+    }
+
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Main { .. } => "main",
+            Self::Linked { .. } => "linked",
+        }
+    }
+}
+
+/// Resolve and validate the exact worktree registration owned by `repo`.
 ///
 /// `git worktree list` reports branch and path metadata from the owning
 /// repository even when the directory at that path has been replaced. Before
 /// merge code uses a path, compare both Git's canonical common directory and
 /// the per-worktree admin linkage. This prevents an unrelated, nested, or
 /// symlink-aliased repository from receiving a merge or cleanup operation.
-pub fn validate_worktree_identity(repo: &RepoRoot, worktree: &Worktree) -> Result<()> {
+pub fn capture_worktree_identity(repo: &RepoRoot, worktree: &Worktree) -> Result<WorktreeIdentity> {
     let path = &worktree.path;
     if has_symlink_component(path) {
         return Err(AppError::conflict(format!(
@@ -825,7 +853,7 @@ pub fn validate_worktree_identity(repo: &RepoRoot, worktree: &Worktree) -> Resul
     }
 
     let worktree_git_file = path.join(".git");
-    match worktree.is_main {
+    let identity = match worktree.is_main {
         true => {
             let worktree_git_dir = canonical_git_path(path, "--git-dir")?;
             if worktree_git_dir != common_dir {
@@ -834,6 +862,9 @@ pub fn validate_worktree_identity(repo: &RepoRoot, worktree: &Worktree) -> Resul
                     worktree_git_dir.display(),
                     common_dir.display()
                 )));
+            }
+            WorktreeIdentity::Main {
+                admin_dir: common_dir.clone(),
             }
         }
         false => {
@@ -961,8 +992,9 @@ pub fn validate_worktree_identity(repo: &RepoRoot, worktree: &Worktree) -> Resul
                     worktree.branch.as_deref().unwrap_or("(detached)")
                 )));
             }
+            WorktreeIdentity::Linked { admin_dir }
         }
-    }
+    };
 
     let actual_branch = git(&["symbolic-ref", "--quiet", "--short", "HEAD"], path).ok();
     if actual_branch != worktree.branch {
@@ -980,7 +1012,7 @@ pub fn validate_worktree_identity(repo: &RepoRoot, worktree: &Worktree) -> Resul
         )));
     }
 
-    Ok(())
+    Ok(identity)
 }
 
 /// Return whether Git left unmerged index entries in a worktree.

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command as Cmd;
 use std::process::Stdio;
@@ -277,6 +278,21 @@ pub fn cherry(repo: &RepoRoot, mainline: &str, branch: &str) -> bool {
     }
 }
 
+/// Return whether the source and destination have equivalent content.
+///
+/// `git cherry` detects rebased and cherry-picked integrations, while an
+/// exact tree comparison covers a squash merge whose combined commit is not
+/// equivalent to any one source commit. This is deliberately conservative:
+/// it never treats a branch as integrated merely because a commit message or
+/// object name appears in the destination log.
+pub fn patch_equivalent(repo: &RepoRoot, destination: &str, source: &str) -> bool {
+    cherry(repo, destination, source)
+        || git_success(
+            &["diff", "--quiet", destination, source, "--"],
+            repo.as_ref(),
+        )
+}
+
 /// Try to resolve `refs/remotes/origin/HEAD` to a usable branch name.
 ///
 /// Returns the local branch name if it exists, otherwise the full remote
@@ -394,13 +410,70 @@ pub fn upstream_counts(path: &Path, upstream: &str, branch: &str) -> Result<Opti
     Ok(Some((ahead, behind)))
 }
 
+/// Compute a stable patch id for a revision range.
+///
+/// The caller can reverse the range endpoints when it needs to compare an
+/// inverse patch. An empty diff has no patch id because it cannot prove that
+/// any content was reverted.
+fn diff_patch_id(path: &Path, from: &str, to: &str) -> Option<String> {
+    let mut diff = Cmd::new("git");
+    diff.args(["diff", "--binary", "--no-ext-diff", from, to, "--"])
+        .current_dir(path)
+        .stdout(Stdio::piped());
+    for var in GIT_ENV_OVERRIDES {
+        diff.env_remove(var);
+    }
+    let diff_output = diff.output().ok()?;
+    if !diff_output.status.success() || diff_output.stdout.is_empty() {
+        return None;
+    }
+
+    let mut patch_id = Cmd::new("git");
+    patch_id.args(["patch-id", "--stable"]).current_dir(path);
+    for var in GIT_ENV_OVERRIDES {
+        patch_id.env_remove(var);
+    }
+    let mut child = patch_id
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    child.stdin.take()?.write_all(&diff_output.stdout).ok()?;
+    let output = child.wait_with_output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    output
+        .stdout
+        .split(|byte| byte.is_ascii_whitespace())
+        .find(|field| !field.is_empty())
+        .map(|field| String::from_utf8_lossy(field).into_owned())
+}
+
+/// Confirm that a revert commit actually reverses the referenced commit.
+///
+/// Git's standard revert message is user-controlled, so the message alone is
+/// not evidence. Compare the referenced commit's forward patch with the
+/// revert commit's reverse patch; an empty or unrelated commit is rejected.
+fn revert_reverses_commit(path: &Path, revert_commit: &str, reverted: &str) -> bool {
+    let reverted_parent = format!("{reverted}^1");
+    let revert_parent = format!("{revert_commit}^1");
+    diff_patch_id(path, &reverted_parent, reverted).is_some_and(|original| {
+        diff_patch_id(path, revert_commit, &revert_parent)
+            .is_some_and(|inverse| original == inverse)
+    })
+}
+
 /// Find a standard Git revert commit that refers to source history.
 ///
 /// Git records the reverted object in the body as `This reverts commit ...`.
 /// A marker alone is not enough: the reverted object must be in the
-/// destination history, and either the object itself or (for a reverted merge)
-/// its second parent must be reachable from `source`. This avoids warning for
-/// a revert message that merely names an unrelated object.
+/// destination history, the revert commit must actually reverse the object's
+/// tree diff, and either the object itself or (for a reverted merge) its second
+/// parent must be reachable from `source`. This avoids warning for a revert
+/// message that merely names an unrelated object.
 pub fn reverted_source_commit(
     path: &Path,
     source: &str,
@@ -413,7 +486,7 @@ pub fn reverted_source_commit(
 
     for record in log.split('\x1e') {
         let mut fields = record.splitn(3, '\0');
-        let Some(_revert_commit) = fields.next() else {
+        let Some(revert_commit) = fields.next() else {
             continue;
         };
         let Some(_revert_parents) = fields.next() else {
@@ -437,7 +510,8 @@ pub fn reverted_source_commit(
         if !git_success(
             &["merge-base", "--is-ancestor", reverted, destination],
             path,
-        ) {
+        ) || !revert_reverses_commit(path, revert_commit, reverted)
+        {
             continue;
         }
 
@@ -581,6 +655,23 @@ pub fn operation_state(path: &Path) -> Result<Option<&'static str>> {
 pub fn merge_in_progress(path: &Path) -> bool {
     git_path(path, "MERGE_HEAD")
         .map(|marker| marker.exists())
+        .unwrap_or(false)
+}
+
+/// Return whether a path is a usable Git worktree.
+pub fn worktree_is_valid(path: &Path) -> bool {
+    git_success(&["rev-parse", "--is-inside-work-tree"], path)
+}
+
+/// Return whether Git left unmerged index entries in a worktree.
+///
+/// A failed hook can leave `MERGE_HEAD` and a staged merge without any
+/// unmerged entries, so the index is the authoritative signal for a content
+/// conflict. This keeps hook and other Git failures out of the
+/// `content_conflict` JSON category.
+pub fn has_unmerged_entries(path: &Path) -> bool {
+    git(&["ls-files", "--unmerged"], path)
+        .map(|output| !output.is_empty())
         .unwrap_or(false)
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -452,6 +452,9 @@ pub struct JsonMergeResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub removed_path: Option<String>,
     pub pushed: bool,
+    /// Partial-success diagnostics, such as an identity change after commit.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preflight: Option<JsonMergePreflight>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/output.rs
+++ b/src/output.rs
@@ -341,6 +341,101 @@ pub enum MergeFormat {
     PrintPathsV2,
 }
 
+/// Machine-readable refusal details for a merge preflight or content merge.
+#[derive(Debug, Serialize)]
+pub struct JsonMergeRefusal {
+    pub kind: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// Facts collected before a merge mutates the destination.
+#[derive(Debug, Serialize)]
+pub struct JsonMergePreflight {
+    pub source: String,
+    pub destination: String,
+    pub destination_path: String,
+    pub upstream: Option<String>,
+    /// Alias kept explicit for consumers that name the destination side.
+    pub destination_upstream: Option<String>,
+    pub ahead: Option<u32>,
+    pub behind: Option<u32>,
+    pub topology: String,
+    pub source_history: String,
+    pub source_was_merged: bool,
+    pub source_was_reverted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reverted_commit: Option<String>,
+    pub allowed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal_message: Option<String>,
+}
+
+impl JsonMergePreflight {
+    pub fn from_preflight(preflight: &crate::worktree::MergePreflight) -> Self {
+        let (refusal_kind, refusal_reason, refusal_message) = preflight
+            .refusal
+            .as_ref()
+            .map(|refusal| {
+                (
+                    Some(refusal.kind.clone()),
+                    Some(refusal.reason.clone()),
+                    Some(refusal.message.clone()),
+                )
+            })
+            .unwrap_or((None, None, None));
+
+        Self {
+            source: preflight.source.clone(),
+            destination: preflight.destination.clone(),
+            destination_path: preflight.destination_path.display().to_string(),
+            upstream: preflight.upstream.clone(),
+            destination_upstream: preflight.upstream.clone(),
+            ahead: preflight.ahead,
+            behind: preflight.behind,
+            topology: merge_topology_name(preflight.topology),
+            source_history: source_history_name(preflight.source_history),
+            source_was_merged: preflight.source_was_merged,
+            source_was_reverted: preflight.source_was_reverted,
+            reverted_commit: preflight.reverted_commit.clone(),
+            allowed: preflight.allowed,
+            refusal_kind,
+            refusal_reason,
+            refusal_message,
+        }
+    }
+}
+
+fn merge_topology_name(topology: crate::worktree::MergeTopology) -> String {
+    match topology {
+        crate::worktree::MergeTopology::NoUpstream => "no_upstream",
+        crate::worktree::MergeTopology::UpstreamUnavailable => "upstream_unavailable",
+        crate::worktree::MergeTopology::Synchronized => "synchronized",
+        crate::worktree::MergeTopology::Ahead => "ahead",
+        crate::worktree::MergeTopology::Behind => "behind",
+        crate::worktree::MergeTopology::Diverged => "diverged",
+    }
+    .to_string()
+}
+
+fn source_history_name(history: crate::worktree::SourceHistory) -> String {
+    match history {
+        crate::worktree::SourceHistory::NotMerged => "not_merged",
+        crate::worktree::SourceHistory::AlreadyMerged => "already_merged",
+        crate::worktree::SourceHistory::MergedThenReverted => "merged_then_reverted",
+    }
+    .to_string()
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
+}
+
 /// JSON response for the merge command.
 #[derive(Debug, Serialize)]
 pub struct JsonMergeResponse {
@@ -357,6 +452,13 @@ pub struct JsonMergeResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub removed_path: Option<String>,
     pub pushed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preflight: Option<JsonMergePreflight>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<JsonMergeRefusal>,
+    /// True when this response came from `merge --inspect`.
+    #[serde(skip_serializing_if = "is_false")]
+    pub inspect: bool,
 }
 
 /// JSON response for the materialize command.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -678,6 +678,20 @@ pub struct MergeResult {
     pub warnings: Vec<String>,
 }
 
+/// Category for a Git failure while attempting the content merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeFailureKind {
+    ContentConflict,
+    GitFailure,
+}
+
+/// A merge attempt failure with enough context for human and JSON output.
+#[derive(Debug)]
+pub struct MergeFailure {
+    pub kind: MergeFailureKind,
+    pub error: AppError,
+}
+
 #[derive(Debug)]
 struct MergeDestination {
     branch: String,
@@ -800,13 +814,37 @@ fn topology_refusal(
     }
 }
 
+/// Validate a worktree record before using it for a merge.
+///
+/// Normal merges prune stale Git metadata before this check. Keeping the
+/// explicit validation here also handles locked or otherwise unusable records
+/// without falling through to a low-level "No such file" Git error.
+fn validate_merge_worktree(wt: &Worktree, role: &str) -> Result<()> {
+    if !git::worktree_is_valid(&wt.path) {
+        let branch = wt.branch.as_deref().unwrap_or("(detached)");
+        return Err(AppError::conflict(format!(
+            "stale {role} worktree metadata for branch '{branch}' at {}; run `git worktree prune`",
+            wt.path.display()
+        )));
+    }
+    Ok(())
+}
+
 /// Inspect the merge topology without changing repository state.
+///
+/// `readonly` is true for `--inspect`. Normal merges deliberately prune
+/// stale worktree metadata before selecting either side of the merge.
 pub fn merge_preflight(
     repo: &RepoRoot,
     branch: Option<&BranchName>,
     into: Option<&str>,
+    readonly: bool,
 ) -> Result<MergePreflight> {
-    let worktrees = git::list_worktrees_readonly(repo)?;
+    let worktrees = if readonly {
+        git::list_worktrees_readonly(repo)?
+    } else {
+        git::list_worktrees(repo)?
+    };
 
     let target_branch = match branch {
         Some(branch) => branch.clone(),
@@ -824,8 +862,19 @@ pub fn merge_preflight(
             "refusing to merge the main worktree".to_string(),
         ));
     }
+    validate_merge_worktree(source_wt, "source")?;
 
     let destination = resolve_merge_destination(repo, &worktrees, into)?;
+    let destination_wt = worktrees
+        .iter()
+        .find(|wt| wt.path == destination.path)
+        .ok_or_else(|| {
+            AppError::invariant(format!(
+                "destination worktree '{}' disappeared during merge preflight",
+                destination.path.display()
+            ))
+        })?;
+    validate_merge_worktree(destination_wt, "destination")?;
     if target_branch.as_str() == destination.branch {
         return Err(AppError::invariant(
             "refusing to merge a branch into itself".to_string(),
@@ -844,6 +893,8 @@ pub fn merge_preflight(
     };
     let topology = topology(upstream.as_deref(), ahead, behind);
     let source_was_merged = git::is_ancestor(repo, target_branch.as_str(), &destination.branch);
+    let source_patch_equivalent =
+        git::patch_equivalent(repo, &destination.branch, target_branch.as_str());
     let reverted_commit = git::reverted_source_commit(
         &destination.path,
         target_branch.as_str(),
@@ -852,7 +903,10 @@ pub fn merge_preflight(
     let source_was_reverted = reverted_commit.is_some();
     let source_history = if source_was_reverted {
         SourceHistory::MergedThenReverted
-    } else if source_was_merged {
+    } else if source_was_merged || source_patch_equivalent {
+        // Keep the existing `already_merged` output for both ancestry and a
+        // proven equivalent tree/patch. Do not report a known squash or rebase
+        // integration as `not_merged` merely because commit IDs differ.
         SourceHistory::AlreadyMerged
     } else {
         SourceHistory::NotMerged
@@ -900,15 +954,40 @@ fn abort_created_merge(path: &Path) {
     }
 }
 
+fn classify_merge_failure(
+    path: &Path,
+    target_branch: &BranchName,
+    error: AppError,
+) -> MergeFailure {
+    let kind = match git::has_unmerged_entries(path) {
+        true => MergeFailureKind::ContentConflict,
+        false => MergeFailureKind::GitFailure,
+    };
+    let error = match kind {
+        MergeFailureKind::ContentConflict => AppError::conflict(format!(
+            "content merge conflicts with '{}' — merge aborted; use `git merge` directly to handle conflicts\n{error}",
+            target_branch
+        )),
+        MergeFailureKind::GitFailure => AppError {
+            code: error.code,
+            message: format!("merge of '{}' failed and was aborted\n{error}", target_branch),
+        },
+    };
+    MergeFailure { kind, error }
+}
+
 /// Run a merge using an already collected preflight.
 pub fn merge_with_preflight(
     repo: &RepoRoot,
     preflight: MergePreflight,
     push: bool,
     no_cleanup: bool,
-) -> Result<MergeResult> {
+) -> std::result::Result<MergeResult, MergeFailure> {
     if let Some(refusal) = &preflight.refusal {
-        return Err(AppError::conflict(refusal.message.clone()));
+        return Err(MergeFailure {
+            kind: MergeFailureKind::GitFailure,
+            error: AppError::conflict(refusal.message.clone()),
+        });
     }
 
     let destination_path = preflight.destination_path.clone();
@@ -918,12 +997,11 @@ pub fn merge_with_preflight(
     // Attempt the merge from the selected destination worktree's context.
     if let Err(error) = git::merge_no_ff(&destination_path, target_branch.as_str()) {
         // The preflight established that any merge state now belongs to this
-        // invocation. Do not abort unrelated failures that created no state.
+        // invocation. Abort it after classifying the failure so a hook or
+        // other Git failure is not mislabeled as a content conflict.
+        let failure = classify_merge_failure(&destination_path, &target_branch, error);
         abort_created_merge(&destination_path);
-        return Err(AppError::conflict(format!(
-            "content merge conflicts with '{}' — merge aborted; use `git merge` directly to handle conflicts\n{error}",
-            target_branch
-        )));
+        return Err(failure);
     }
 
     let mut warnings = Vec::new();

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -614,6 +614,53 @@ pub fn doctor(repo: &RepoRoot) -> Result<Vec<Diagnostic>> {
     Ok(diags)
 }
 
+/// How the destination branch relates to its configured upstream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeTopology {
+    NoUpstream,
+    UpstreamUnavailable,
+    Synchronized,
+    Ahead,
+    Behind,
+    Diverged,
+}
+
+/// History relationship between the source branch and destination history.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceHistory {
+    NotMerged,
+    AlreadyMerged,
+    MergedThenReverted,
+}
+
+/// A refusal identified before Git's content merge starts.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MergeRefusal {
+    pub kind: String,
+    pub reason: String,
+    pub message: String,
+}
+
+/// Read-only facts and policy decision for a merge.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MergePreflight {
+    pub source: String,
+    pub destination: String,
+    pub destination_path: PathBuf,
+    pub upstream: Option<String>,
+    pub ahead: Option<u32>,
+    pub behind: Option<u32>,
+    pub topology: MergeTopology,
+    pub source_history: SourceHistory,
+    pub source_was_merged: bool,
+    pub source_was_reverted: bool,
+    pub reverted_commit: Option<String>,
+    pub allowed: bool,
+    pub refusal: Option<MergeRefusal>,
+}
+
 /// Result of a successful `merge` operation.
 pub struct MergeResult {
     pub branch: BranchName,
@@ -625,6 +672,8 @@ pub struct MergeResult {
     /// Path of the removed worktree (only set when `cleaned_up` is true).
     pub removed_path: Option<PathBuf>,
     pub pushed: bool,
+    /// Facts gathered before the merge mutation.
+    pub preflight: MergePreflight,
     /// Non-fatal warnings (e.g. cleanup or push failure after merge).
     pub warnings: Vec<String>,
 }
@@ -648,7 +697,7 @@ fn resolve_merge_destination(
     let mainline = into
         .map(str::to_string)
         .map(Ok)
-        .unwrap_or_else(|| git::resolve_mainline(repo))?;
+        .unwrap_or_else(|| git::resolve_mainline_readonly(repo))?;
 
     if into.is_none() {
         let main = worktrees
@@ -703,38 +752,66 @@ fn resolve_merge_destination(
     }
 }
 
-/// Abort the merge marker created by this invocation, if any.
-fn abort_created_merge(path: &Path) {
-    if git::merge_in_progress(path) {
-        git::merge_abort(path);
+fn topology(upstream: Option<&str>, ahead: Option<u32>, behind: Option<u32>) -> MergeTopology {
+    match (upstream, ahead, behind) {
+        (None, None, None) => MergeTopology::NoUpstream,
+        (Some(_), None, None) => MergeTopology::UpstreamUnavailable,
+        (Some(_), Some(0), Some(0)) => MergeTopology::Synchronized,
+        (Some(_), Some(ahead), Some(0)) if ahead > 0 => MergeTopology::Ahead,
+        (Some(_), Some(0), Some(behind)) if behind > 0 => MergeTopology::Behind,
+        (Some(_), Some(ahead), Some(behind)) if ahead > 0 && behind > 0 => MergeTopology::Diverged,
+        _ => MergeTopology::UpstreamUnavailable,
     }
 }
 
-/// Merge a worktree's branch into the selected destination.
-///
-/// 1. Resolve the source branch (argument, cwd inference, or picker)
-/// 2. Resolve the destination worktree (`--into` or detected mainline)
-/// 3. Refuse self-merges and source merges from the main worktree
-/// 4. Refuse destinations with an existing Git operation in progress
-/// 5. Run `git merge --no-ff <branch>` from the destination worktree
-/// 6. On conflict: abort only a merge state created by this invocation
-/// 7. On success: optionally remove only the source worktree+branch, optionally push
-pub fn merge(
+fn topology_refusal(
+    destination: &str,
+    upstream: Option<&str>,
+    topology: MergeTopology,
+    ahead: Option<u32>,
+    behind: Option<u32>,
+) -> Option<MergeRefusal> {
+    let upstream = upstream?;
+    let (ahead, behind) = (ahead.unwrap_or(0), behind.unwrap_or(0));
+    match topology {
+        MergeTopology::UpstreamUnavailable => Some(MergeRefusal {
+            kind: "topology".to_string(),
+            reason: "destination_upstream_unavailable".to_string(),
+            message: format!(
+                "merge preflight refused: destination '{destination}' tracks upstream '{upstream}', but that configured ref is unavailable locally; restore the upstream before merging"
+            ),
+        }),
+        MergeTopology::Diverged => Some(MergeRefusal {
+            kind: "topology".to_string(),
+            reason: "destination_diverged_from_upstream".to_string(),
+            message: format!(
+                "merge preflight refused: destination '{destination}' has diverged from upstream '{upstream}' (ahead {ahead}, behind {behind}); reconcile the destination with its upstream before merging"
+            ),
+        }),
+        MergeTopology::Behind => Some(MergeRefusal {
+            kind: "topology".to_string(),
+            reason: "destination_behind_upstream".to_string(),
+            message: format!(
+                "merge preflight refused: destination '{destination}' is behind upstream '{upstream}' by {behind} commit{}; update the destination before merging",
+                if behind == 1 { "" } else { "s" }
+            ),
+        }),
+        _ => None,
+    }
+}
+
+/// Inspect the merge topology without changing repository state.
+pub fn merge_preflight(
     repo: &RepoRoot,
     branch: Option<&BranchName>,
     into: Option<&str>,
-    push: bool,
-    no_cleanup: bool,
-) -> Result<MergeResult> {
-    let worktrees = git::list_worktrees(repo)?;
+) -> Result<MergePreflight> {
+    let worktrees = git::list_worktrees_readonly(repo)?;
 
-    // Resolve which branch to merge (same cwd-inference as `remove`).
     let target_branch = match branch {
-        Some(b) => b.clone(),
+        Some(branch) => branch.clone(),
         None => resolve_branch_from_cwd(&worktrees)?,
     };
-
-    // Find the source worktree entry.
     let source_wt = worktrees
         .iter()
         .find(|wt| wt.branch.as_deref() == Some(target_branch.as_str()))
@@ -742,7 +819,6 @@ pub fn merge(
             AppError::usage(format!("no worktree found for branch '{target_branch}'"))
         })?;
 
-    // Never merge the main worktree into itself.
     if source_wt.is_main {
         return Err(AppError::invariant(
             "refusing to merge the main worktree".to_string(),
@@ -756,24 +832,96 @@ pub fn merge(
         ));
     }
 
-    // Never inspect or mutate an operation that was started before this
-    // invocation. In particular, `git merge --abort` below must not erase a
-    // user's existing merge, rebase, cherry-pick, or revert state.
-    if let Some(state) = git::operation_state(&destination.path)? {
-        return Err(AppError::conflict(format!(
-            "destination worktree '{}' has an in-progress {state}; finish or abort it before merging",
-            destination.path.display()
-        )));
+    let upstream = git::branch_upstream(&destination.path, &destination.branch)?;
+    let (ahead, behind) = match upstream.as_deref() {
+        Some(upstream) => {
+            match git::upstream_counts(&destination.path, upstream, &destination.branch)? {
+                Some((ahead, behind)) => (Some(ahead), Some(behind)),
+                None => (None, None),
+            }
+        }
+        None => (None, None),
+    };
+    let topology = topology(upstream.as_deref(), ahead, behind);
+    let source_was_merged = git::is_ancestor(repo, target_branch.as_str(), &destination.branch);
+    let reverted_commit = git::reverted_source_commit(
+        &destination.path,
+        target_branch.as_str(),
+        &destination.branch,
+    )?;
+    let source_was_reverted = reverted_commit.is_some();
+    let source_history = if source_was_reverted {
+        SourceHistory::MergedThenReverted
+    } else if source_was_merged {
+        SourceHistory::AlreadyMerged
+    } else {
+        SourceHistory::NotMerged
+    };
+
+    let refusal = match git::operation_state(&destination.path)? {
+        Some(state) => Some(MergeRefusal {
+            kind: "state".to_string(),
+            reason: "destination_operation_in_progress".to_string(),
+            message: format!(
+                "destination worktree '{}' has an in-progress {state}; finish or abort it before merging",
+                destination.path.display()
+            ),
+        }),
+        None => topology_refusal(
+            &destination.branch,
+            upstream.as_deref(),
+            topology,
+            ahead,
+            behind,
+        ),
+    };
+
+    Ok(MergePreflight {
+        source: target_branch.to_string(),
+        destination: destination.branch,
+        destination_path: destination.path,
+        upstream,
+        ahead,
+        behind,
+        topology,
+        source_history,
+        source_was_merged,
+        source_was_reverted,
+        reverted_commit,
+        allowed: refusal.is_none(),
+        refusal,
+    })
+}
+
+/// Abort the merge marker created by this invocation, if any.
+fn abort_created_merge(path: &Path) {
+    if git::merge_in_progress(path) {
+        git::merge_abort(path);
+    }
+}
+
+/// Run a merge using an already collected preflight.
+pub fn merge_with_preflight(
+    repo: &RepoRoot,
+    preflight: MergePreflight,
+    push: bool,
+    no_cleanup: bool,
+) -> Result<MergeResult> {
+    if let Some(refusal) = &preflight.refusal {
+        return Err(AppError::conflict(refusal.message.clone()));
     }
 
+    let destination_path = preflight.destination_path.clone();
+    let target_branch = BranchName::new(&preflight.source);
+    let destination_branch = preflight.destination.clone();
+
     // Attempt the merge from the selected destination worktree's context.
-    if let Err(e) = git::merge_no_ff(&destination.path, target_branch.as_str()) {
-        // The preflight above established that any merge state now belongs to
-        // this invocation. Do not abort unrelated failures that created no
-        // merge state.
-        abort_created_merge(&destination.path);
+    if let Err(error) = git::merge_no_ff(&destination_path, target_branch.as_str()) {
+        // The preflight established that any merge state now belongs to this
+        // invocation. Do not abort unrelated failures that created no state.
+        abort_created_merge(&destination_path);
         return Err(AppError::conflict(format!(
-            "merge conflicts with '{}' — merge aborted; use `git merge` directly to handle conflicts\n{e}",
+            "content merge conflicts with '{}' — merge aborted; use `git merge` directly to handle conflicts\n{error}",
             target_branch
         )));
     }
@@ -786,15 +934,15 @@ pub fn merge(
     let (cleaned_up, removed_path) = if no_cleanup {
         (false, None)
     } else {
-        match remove_with_branch_context(repo, Some(&target_branch), false, &destination.path) {
+        match remove_with_branch_context(repo, Some(&target_branch), false, &destination_path) {
             Ok(result) => {
-                if let Some(w) = result.warning {
-                    warnings.push(w);
+                if let Some(warning) = result.warning {
+                    warnings.push(warning);
                 }
                 (true, Some(result.removed_path))
             }
-            Err(e) => {
-                warnings.push(format!("merge succeeded but cleanup failed: {e}"));
+            Err(error) => {
+                warnings.push(format!("merge succeeded but cleanup failed: {error}"));
                 (false, None)
             }
         }
@@ -802,10 +950,10 @@ pub fn merge(
 
     // Push the selected destination branch to origin if requested.
     let pushed = if push {
-        match git::push(&destination.path, &destination.branch) {
+        match git::push(&destination_path, &destination_branch) {
             Ok(()) => true,
-            Err(e) => {
-                warnings.push(format!("merge succeeded but push failed: {e}"));
+            Err(error) => {
+                warnings.push(format!("merge succeeded but push failed: {error}"));
                 false
             }
         }
@@ -815,12 +963,13 @@ pub fn merge(
 
     Ok(MergeResult {
         branch: target_branch,
-        mainline: destination.branch,
-        destination_path: destination.path,
+        mainline: destination_branch,
+        destination_path,
         repo_root: repo.to_path_buf(),
         cleaned_up,
         removed_path,
         pushed,
+        preflight,
         warnings,
     })
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -345,6 +345,34 @@ fn remove_with_branch_context(
     })
 }
 
+/// Remove the exact source worktree captured by merge preflight.
+///
+/// Unlike the user-facing remove path, merge cleanup must not prune and then
+/// rediscover a worktree by branch name. Requiring both paths and identities
+/// prevents cleanup from deleting a replacement repository or branch.
+fn remove_exact_merge_source(repo: &RepoRoot, preflight: &MergePreflight) -> Result<RemoveResult> {
+    let (source, _) = validate_preflight_worktrees(repo, preflight, "source", "destination")?;
+    let removed_path = source.path.clone();
+    let target_branch = BranchName::new(&preflight.source);
+
+    git::remove_worktree(repo, &removed_path, false)?;
+
+    // The source was removed above, so validate the destination separately
+    // immediately before deleting the merged source branch in its context.
+    let destination = validate_preflight_destination(repo, preflight, "destination")?;
+
+    let warning = git::delete_branch_at(&destination.path, &target_branch, false)
+        .err()
+        .map(|e| format!("worktree removed but branch deletion failed: {e}"));
+
+    Ok(RemoveResult {
+        removed_path,
+        branch: target_branch,
+        repo_root: repo.to_path_buf(),
+        warning,
+    })
+}
+
 /// How a branch was detected as integrated into mainline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -647,6 +675,11 @@ pub struct MergeRefusal {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct MergePreflight {
     pub source: String,
+    /// Exact source path captured from the owning repository's worktree list.
+    /// It is skipped by serde because the established JSON contract only
+    /// exposes the destination path.
+    #[serde(skip)]
+    pub(crate) source_path: PathBuf,
     pub destination: String,
     pub destination_path: PathBuf,
     pub upstream: Option<String>,
@@ -817,17 +850,82 @@ fn topology_refusal(
 /// Validate a worktree record before using it for a merge.
 ///
 /// Normal merges prune stale Git metadata before this check. Keeping the
-/// explicit validation here also handles locked or otherwise unusable records
-/// without falling through to a low-level "No such file" Git error.
-fn validate_merge_worktree(wt: &Worktree, role: &str) -> Result<()> {
-    if !git::worktree_is_valid(&wt.path) {
+/// explicit identity validation here also handles locked or otherwise
+/// replaced records without falling through to a low-level Git mutation.
+fn validate_merge_worktree(repo: &RepoRoot, wt: &Worktree, role: &str) -> Result<()> {
+    git::validate_worktree_identity(repo, wt).map_err(|error| {
         let branch = wt.branch.as_deref().unwrap_or("(detached)");
-        return Err(AppError::conflict(format!(
-            "stale {role} worktree metadata for branch '{branch}' at {}; run `git worktree prune`",
+        AppError::conflict(format!(
+            "stale {role} worktree metadata for branch '{branch}' at {}: {error}",
             wt.path.display()
-        )));
-    }
-    Ok(())
+        ))
+    })
+}
+
+/// Re-read both sides of a merge and require the paths and branch metadata to
+/// still be the exact records used by preflight. This is intentionally
+/// read-only so cleanup never selects a replacement by branch name alone.
+fn validate_preflight_worktrees(
+    repo: &RepoRoot,
+    preflight: &MergePreflight,
+    source_role: &str,
+    destination_role: &str,
+) -> Result<(Worktree, Worktree)> {
+    let worktrees = git::list_worktrees_readonly(repo)?;
+    let source = worktrees
+        .iter()
+        .find(|wt| {
+            wt.path == preflight.source_path
+                && wt.branch.as_deref() == Some(preflight.source.as_str())
+        })
+        .ok_or_else(|| {
+            AppError::conflict(format!(
+                "stale {source_role} worktree metadata for branch '{}' at {}: path or branch no longer matches the preflight record",
+                preflight.source,
+                preflight.source_path.display()
+            ))
+        })?;
+    let destination = worktrees
+        .iter()
+        .find(|wt| {
+            wt.path == preflight.destination_path
+                && wt.branch.as_deref() == Some(preflight.destination.as_str())
+        })
+        .ok_or_else(|| {
+            AppError::conflict(format!(
+                "stale {destination_role} worktree metadata for branch '{}' at {}: path or branch no longer matches the preflight record",
+                preflight.destination,
+                preflight.destination_path.display()
+            ))
+        })?;
+
+    validate_merge_worktree(repo, source, source_role)?;
+    validate_merge_worktree(repo, destination, destination_role)?;
+    Ok((source.clone(), destination.clone()))
+}
+
+/// Re-read and validate the exact destination record after source cleanup.
+fn validate_preflight_destination(
+    repo: &RepoRoot,
+    preflight: &MergePreflight,
+    role: &str,
+) -> Result<Worktree> {
+    let worktrees = git::list_worktrees_readonly(repo)?;
+    let destination = worktrees
+        .iter()
+        .find(|wt| {
+            wt.path == preflight.destination_path
+                && wt.branch.as_deref() == Some(preflight.destination.as_str())
+        })
+        .ok_or_else(|| {
+            AppError::conflict(format!(
+                "stale {role} worktree metadata for branch '{}' at {}: path or branch no longer matches the preflight record",
+                preflight.destination,
+                preflight.destination_path.display()
+            ))
+        })?;
+    validate_merge_worktree(repo, destination, role)?;
+    Ok(destination.clone())
 }
 
 /// Inspect the merge topology without changing repository state.
@@ -862,7 +960,7 @@ pub fn merge_preflight(
             "refusing to merge the main worktree".to_string(),
         ));
     }
-    validate_merge_worktree(source_wt, "source")?;
+    validate_merge_worktree(repo, source_wt, "source")?;
 
     let destination = resolve_merge_destination(repo, &worktrees, into)?;
     let destination_wt = worktrees
@@ -874,7 +972,7 @@ pub fn merge_preflight(
                 destination.path.display()
             ))
         })?;
-    validate_merge_worktree(destination_wt, "destination")?;
+    validate_merge_worktree(repo, destination_wt, "destination")?;
     if target_branch.as_str() == destination.branch {
         return Err(AppError::invariant(
             "refusing to merge a branch into itself".to_string(),
@@ -932,6 +1030,7 @@ pub fn merge_preflight(
 
     Ok(MergePreflight {
         source: target_branch.to_string(),
+        source_path: source_wt.path.clone(),
         destination: destination.branch,
         destination_path: destination.path,
         upstream,
@@ -990,6 +1089,15 @@ pub fn merge_with_preflight(
         });
     }
 
+    // Revalidate immediately before the first mutation. Preflight paths are
+    // not trusted across the gap between inspection and merge execution.
+    if let Err(error) = validate_preflight_worktrees(repo, &preflight, "source", "destination") {
+        return Err(MergeFailure {
+            kind: MergeFailureKind::GitFailure,
+            error,
+        });
+    }
+
     let destination_path = preflight.destination_path.clone();
     let target_branch = BranchName::new(&preflight.source);
     let destination_branch = preflight.destination.clone();
@@ -1012,7 +1120,7 @@ pub fn merge_with_preflight(
     let (cleaned_up, removed_path) = if no_cleanup {
         (false, None)
     } else {
-        match remove_with_branch_context(repo, Some(&target_branch), false, &destination_path) {
+        match remove_exact_merge_source(repo, &preflight) {
             Ok(result) => {
                 if let Some(warning) = result.warning {
                     warnings.push(warning);
@@ -1026,12 +1134,20 @@ pub fn merge_with_preflight(
         }
     };
 
-    // Push the selected destination branch to origin if requested.
+    // Push the selected destination branch to origin if requested. The
+    // destination may have changed while cleanup ran, so verify it again
+    // before allowing a remote mutation.
     let pushed = if push {
-        match git::push(&destination_path, &destination_branch) {
-            Ok(()) => true,
+        match validate_preflight_destination(repo, &preflight, "destination") {
+            Ok(_) => match git::push(&destination_path, &destination_branch) {
+                Ok(()) => true,
+                Err(error) => {
+                    warnings.push(format!("merge succeeded but push failed: {error}"));
+                    false
+                }
+            },
             Err(error) => {
-                warnings.push(format!("merge succeeded but push failed: {error}"));
+                warnings.push(format!("merge succeeded but push refused: {error}"));
                 false
             }
         }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -680,8 +680,14 @@ pub struct MergePreflight {
     /// exposes the destination path.
     #[serde(skip)]
     pub(crate) source_path: PathBuf,
+    /// Stable Git registration identity captured before any merge mutation.
+    #[serde(skip)]
+    pub(crate) source_identity: git::WorktreeIdentity,
     pub destination: String,
     pub destination_path: PathBuf,
+    /// Stable Git registration identity captured before any merge mutation.
+    #[serde(skip)]
+    pub(crate) destination_identity: git::WorktreeIdentity,
     pub upstream: Option<String>,
     pub ahead: Option<u32>,
     pub behind: Option<u32>,
@@ -847,13 +853,18 @@ fn topology_refusal(
     }
 }
 
-/// Validate a worktree record before using it for a merge.
+/// Validate a worktree record before using it for a merge and capture its
+/// stable Git registration identity.
 ///
 /// Normal merges prune stale Git metadata before this check. Keeping the
 /// explicit identity validation here also handles locked or otherwise
 /// replaced records without falling through to a low-level Git mutation.
-fn validate_merge_worktree(repo: &RepoRoot, wt: &Worktree, role: &str) -> Result<()> {
-    git::validate_worktree_identity(repo, wt).map_err(|error| {
+fn validate_merge_worktree(
+    repo: &RepoRoot,
+    wt: &Worktree,
+    role: &str,
+) -> Result<git::WorktreeIdentity> {
+    git::capture_worktree_identity(repo, wt).map_err(|error| {
         let branch = wt.branch.as_deref().unwrap_or("(detached)");
         AppError::conflict(format!(
             "stale {role} worktree metadata for branch '{branch}' at {}: {error}",
@@ -862,9 +873,27 @@ fn validate_merge_worktree(repo: &RepoRoot, wt: &Worktree, role: &str) -> Result
     })
 }
 
-/// Re-read both sides of a merge and require the paths and branch metadata to
-/// still be the exact records used by preflight. This is intentionally
-/// read-only so cleanup never selects a replacement by branch name alone.
+fn identity_changed(
+    role: &str,
+    branch: &str,
+    path: &Path,
+    expected: &git::WorktreeIdentity,
+    actual: &git::WorktreeIdentity,
+) -> AppError {
+    AppError::conflict(format!(
+        "worktree identity changed for {role} branch '{branch}' at {}: preflight {} Git admin directory '{}' is now {} Git admin directory '{}'; refusing to use the replacement",
+        path.display(),
+        expected.kind(),
+        expected.admin_dir().display(),
+        actual.kind(),
+        actual.admin_dir().display()
+    ))
+}
+
+/// Re-read both sides of a merge and require the paths, branch metadata, and
+/// stable Git registration identities to still be the exact records used by
+/// preflight. This is intentionally read-only so cleanup never selects a
+/// replacement by branch name alone.
 fn validate_preflight_worktrees(
     repo: &RepoRoot,
     preflight: &MergePreflight,
@@ -899,8 +928,26 @@ fn validate_preflight_worktrees(
             ))
         })?;
 
-    validate_merge_worktree(repo, source, source_role)?;
-    validate_merge_worktree(repo, destination, destination_role)?;
+    let source_identity = validate_merge_worktree(repo, source, source_role)?;
+    if source_identity != preflight.source_identity {
+        return Err(identity_changed(
+            source_role,
+            &preflight.source,
+            &preflight.source_path,
+            &preflight.source_identity,
+            &source_identity,
+        ));
+    }
+    let destination_identity = validate_merge_worktree(repo, destination, destination_role)?;
+    if destination_identity != preflight.destination_identity {
+        return Err(identity_changed(
+            destination_role,
+            &preflight.destination,
+            &preflight.destination_path,
+            &preflight.destination_identity,
+            &destination_identity,
+        ));
+    }
     Ok((source.clone(), destination.clone()))
 }
 
@@ -924,7 +971,16 @@ fn validate_preflight_destination(
                 preflight.destination_path.display()
             ))
         })?;
-    validate_merge_worktree(repo, destination, role)?;
+    let identity = validate_merge_worktree(repo, destination, role)?;
+    if identity != preflight.destination_identity {
+        return Err(identity_changed(
+            role,
+            &preflight.destination,
+            &preflight.destination_path,
+            &preflight.destination_identity,
+            &identity,
+        ));
+    }
     Ok(destination.clone())
 }
 
@@ -960,7 +1016,7 @@ pub fn merge_preflight(
             "refusing to merge the main worktree".to_string(),
         ));
     }
-    validate_merge_worktree(repo, source_wt, "source")?;
+    let source_identity = validate_merge_worktree(repo, source_wt, "source")?;
 
     let destination = resolve_merge_destination(repo, &worktrees, into)?;
     let destination_wt = worktrees
@@ -972,7 +1028,7 @@ pub fn merge_preflight(
                 destination.path.display()
             ))
         })?;
-    validate_merge_worktree(repo, destination_wt, "destination")?;
+    let destination_identity = validate_merge_worktree(repo, destination_wt, "destination")?;
     if target_branch.as_str() == destination.branch {
         return Err(AppError::invariant(
             "refusing to merge a branch into itself".to_string(),
@@ -1031,8 +1087,10 @@ pub fn merge_preflight(
     Ok(MergePreflight {
         source: target_branch.to_string(),
         source_path: source_wt.path.clone(),
+        source_identity,
         destination: destination.branch,
         destination_path: destination.path,
+        destination_identity,
         upstream,
         ahead,
         behind,
@@ -1073,6 +1131,16 @@ fn classify_merge_failure(
         },
     };
     MergeFailure { kind, error }
+}
+
+fn partial_success_warning(action: &str, replacement_action: &str, error: &AppError) -> String {
+    if error.message.contains("worktree identity changed") {
+        format!(
+            "partial success: merge succeeded; {action} skipped because {error}. The merge commit was preserved; the replacement was not {replacement_action}. Inspect the original worktree and recover manually before retrying."
+        )
+    } else {
+        format!("merge succeeded but {action} failed: {error}")
+    }
 }
 
 /// Run a merge using an already collected preflight.
@@ -1128,7 +1196,7 @@ pub fn merge_with_preflight(
                 (true, Some(result.removed_path))
             }
             Err(error) => {
-                warnings.push(format!("merge succeeded but cleanup failed: {error}"));
+                warnings.push(partial_success_warning("cleanup", "removed", &error));
                 (false, None)
             }
         }
@@ -1147,7 +1215,11 @@ pub fn merge_with_preflight(
                 }
             },
             Err(error) => {
-                warnings.push(format!("merge succeeded but push refused: {error}"));
+                warnings.push(partial_success_warning(
+                    "destination push",
+                    "pushed",
+                    &error,
+                ));
                 false
             }
         }

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -822,8 +822,11 @@ fn merge_into_linked_worktree_dirty_destination_fails_and_aborts_there() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("merge conflicts"))
-        .stderr(predicate::str::contains("merge aborted"));
+        .stderr(predicate::str::contains(
+            "merge of 'feature/linked-dirty' failed",
+        ))
+        .stderr(predicate::str::contains("merge conflicts").not())
+        .stderr(predicate::str::contains("failed and was aborted"));
 
     let destination_status = git_status(&destination);
     assert!(
@@ -1513,6 +1516,255 @@ fn merge_inspect_reports_linked_destination_topology() {
     );
 }
 
+#[test]
+fn merge_normal_rejects_locked_stale_source_before_preflight() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/stale-source", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-stale-source");
+    lock_worktree_metadata(&repo.path(), &source);
+    std::fs::remove_dir_all(&source).expect("remove stale source");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/stale-source",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(5)
+        .stderr(predicate::str::contains("stale source worktree metadata"))
+        .stderr(predicate::str::contains("No such file or directory").not());
+
+    assert_branch_exists(&repo.path(), "feature/stale-source");
+    assert_eq!(
+        worktree_admin_snapshot(&repo.path()).len(),
+        1,
+        "locked stale source metadata must be retained for explicit repair"
+    );
+}
+
+#[test]
+fn merge_normal_rejects_locked_stale_destination_before_content_merge() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/stale-destination");
+    lock_worktree_metadata(&repo.path(), &destination);
+    std::fs::remove_dir_all(&destination).expect("remove stale destination");
+
+    wt_core()
+        .args(["add", "feature/stale-destination", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-stale-destination");
+    commit_file(&source, "stale-destination.txt", "source", "source");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/stale-destination",
+            "--into",
+            "release/stale-destination",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(5)
+        .stderr(predicate::str::contains(
+            "stale destination worktree metadata",
+        ))
+        .stderr(predicate::str::contains("No such file or directory").not());
+
+    assert_branch_exists(&repo.path(), "feature/stale-destination");
+    assert_branch_exists(&repo.path(), "release/stale-destination");
+}
+
+#[test]
+fn merge_inspect_does_not_prune_locked_stale_metadata() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/inspect-stale", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-inspect-stale");
+    lock_worktree_metadata(&repo.path(), &source);
+    std::fs::remove_dir_all(&source).expect("remove stale source");
+    let admin_before = worktree_admin_snapshot(&repo.path());
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/inspect-stale",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(5)
+        .stderr(predicate::str::contains("stale source worktree metadata"));
+
+    assert_eq!(
+        worktree_admin_snapshot(&repo.path()),
+        admin_before,
+        "inspect must not prune stale worktree metadata"
+    );
+}
+
+#[test]
+fn merge_inspect_detects_squash_integration_by_equivalent_tree() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/squashed-history", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-squashed-history");
+    commit_file(&source, "squash-one.txt", "one", "one");
+    commit_file(&source, "squash-two.txt", "two", "two");
+    run_git(
+        &["merge", "--squash", "feature/squashed-history"],
+        &repo.path(),
+    );
+    run_git(&["commit", "-m", "squashed feature"], &repo.path());
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/squashed-history",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["preflight"]["source_history"], "already_merged");
+    assert_eq!(json["preflight"]["source_was_merged"], false);
+    assert!(source.exists(), "inspect must preserve the source worktree");
+}
+
+#[test]
+fn merge_inspect_rejects_forged_revert_marker_without_tree_change() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/forged-revert", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-forged-revert");
+    commit_file(&source, "forged.txt", "source", "source");
+    let source_head = git_rev_parse(&source, "HEAD");
+    run_git(
+        &["merge", "--ff-only", "feature/forged-revert"],
+        &repo.path(),
+    );
+    run_git(
+        &[
+            "commit",
+            "--allow-empty",
+            "-m",
+            &format!("Forged marker\n\nThis reverts commit {source_head}."),
+        ],
+        &repo.path(),
+    );
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/forged-revert",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["preflight"]["source_history"], "already_merged");
+    assert_eq!(json["preflight"]["source_was_merged"], true);
+    assert_eq!(json["preflight"]["source_was_reverted"], false);
+    assert!(json["preflight"]["reverted_commit"].is_null());
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_json_distinguishes_pre_merge_hook_failure_from_content_conflict() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/hook-failure", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-hook-failure");
+    commit_file(&source, "hook.txt", "source", "source");
+
+    let hook = repo.path().join(".git/hooks/pre-merge-commit");
+    std::fs::write(
+        &hook,
+        "#!/bin/sh\necho pre-merge hook failed >&2\nexit 42\n",
+    )
+    .expect("write hook");
+    let mut permissions = std::fs::metadata(&hook)
+        .expect("hook metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&hook, permissions).expect("chmod hook");
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/hook-failure",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["refusal"]["kind"], "git");
+    assert_eq!(json["refusal"]["reason"], "git_error");
+    assert!(json["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("merge of 'feature/hook-failure' failed")));
+    assert!(json["message"]
+        .as_str()
+        .is_some_and(|message| !message.contains("content merge conflicts")));
+    assert_branch_exists(&repo.path(), "feature/hook-failure");
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /// Run a git command and return its raw output, allowing expected failures.
@@ -1580,6 +1832,25 @@ fn worktree_admin_snapshot(repo: &std::path::Path) -> Vec<(String, String)> {
     }
     snapshot.sort();
     snapshot
+}
+
+/// Mark a worktree admin entry locked so Git's prune cannot silently remove
+/// the stale record during a normal merge preflight.
+fn lock_worktree_metadata(repo: &std::path::Path, worktree: &std::path::Path) {
+    let admin_dir = repo.join(".git/worktrees");
+    let worktree_prefix = worktree.display().to_string();
+    for entry in std::fs::read_dir(&admin_dir)
+        .expect("worktree admin directory")
+        .flatten()
+    {
+        let path = entry.path();
+        let gitdir = std::fs::read_to_string(path.join("gitdir")).unwrap_or_default();
+        if gitdir.trim().starts_with(&worktree_prefix) {
+            std::fs::write(path.join("locked"), "repair test").expect("lock worktree");
+            return;
+        }
+    }
+    panic!("no worktree admin entry for {}", worktree.display());
 }
 
 /// Get the git log as one-line entries.

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -1053,6 +1053,466 @@ fn merge_refuses_preexisting_destination_merge_without_aborting_it() {
     );
 }
 
+// ── Merge topology preflight tests ─────────────────────────────────
+
+#[test]
+fn merge_json_distinguishes_content_conflict_from_topology_refusal() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/json-conflict", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-json-conflict");
+    commit_file(&source, "shared.txt", "source", "source conflict");
+    commit_file(
+        &repo.path(),
+        "shared.txt",
+        "destination",
+        "destination conflict",
+    );
+    let destination_before = git_rev_parse(&repo.path(), "HEAD");
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/json-conflict",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(5)
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["preflight"]["topology"], "no_upstream");
+    assert_eq!(json["refusal"]["kind"], "content");
+    assert_eq!(json["refusal"]["reason"], "content_conflict");
+    assert_eq!(git_rev_parse(&repo.path(), "HEAD"), destination_before);
+    assert!(source.exists(), "content conflict must preserve the source");
+}
+
+#[test]
+fn merge_inspect_reports_synchronized_topology_without_mutation() {
+    let (repo, _upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/inspect", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-inspect");
+    commit_file(&source, "inspect.txt", "inspect", "inspect");
+    let main_before = git_rev_parse(&repo.path(), "main");
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/inspect",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["inspect"], true);
+    assert_eq!(json["preflight"]["upstream"], "origin/main");
+    assert_eq!(json["preflight"]["ahead"], 0);
+    assert_eq!(json["preflight"]["behind"], 0);
+    assert_eq!(json["preflight"]["topology"], "synchronized");
+    assert_eq!(json["preflight"]["allowed"], true);
+    assert_eq!(git_rev_parse(&repo.path(), "main"), main_before);
+    assert!(
+        source.exists(),
+        "inspect must not clean up the source worktree"
+    );
+}
+
+#[test]
+fn merge_inspect_reports_absent_upstream_without_inventing_remote_state() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/no-upstream", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-no-upstream");
+    commit_file(
+        &source,
+        "no-upstream.txt",
+        "source",
+        "source without upstream",
+    );
+    let status_before = git_status(&repo.path());
+    let worktree_admin_before = worktree_admin_snapshot(&repo.path());
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/no-upstream",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert!(json["preflight"]["upstream"].is_null());
+    assert_eq!(json["preflight"]["ahead"], serde_json::Value::Null);
+    assert_eq!(json["preflight"]["behind"], serde_json::Value::Null);
+    assert_eq!(json["preflight"]["topology"], "no_upstream");
+    assert_eq!(json["preflight"]["allowed"], true);
+    assert_eq!(git_status(&repo.path()), status_before);
+    assert_eq!(worktree_admin_snapshot(&repo.path()), worktree_admin_before);
+    assert!(
+        source.exists(),
+        "inspect must not clean up the source worktree"
+    );
+}
+
+#[test]
+fn merge_inspect_refuses_configured_upstream_missing_remote_ref() {
+    let (repo, _upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+    run_git(
+        &["update-ref", "-d", "refs/remotes/origin/main"],
+        &repo.path(),
+    );
+
+    wt_core()
+        .args(["add", "feature/stale-upstream", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-stale-upstream");
+    commit_file(&source, "stale.txt", "source", "source with stale upstream");
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/stale-upstream",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["preflight"]["upstream"], "origin/main");
+    assert_eq!(json["preflight"]["topology"], "upstream_unavailable");
+    assert_eq!(json["preflight"]["allowed"], false);
+    assert_eq!(json["refusal"]["kind"], "topology");
+    assert_eq!(
+        json["refusal"]["reason"],
+        "destination_upstream_unavailable"
+    );
+    assert!(
+        source.exists(),
+        "inspect must not clean up the source worktree"
+    );
+}
+
+#[test]
+fn merge_reports_ahead_destination_before_merging() {
+    let (repo, _upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+
+    commit_file(
+        &repo.path(),
+        "local.txt",
+        "local",
+        "local destination commit",
+    );
+    wt_core()
+        .args(["add", "feature/ahead", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-ahead");
+    commit_file(&source, "ahead.txt", "ahead", "ahead source");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/ahead",
+            "--no-cleanup",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("AHEAD"))
+        .stdout(predicate::str::contains("ahead 1, behind 0"));
+}
+
+#[test]
+fn merge_inspect_reports_behind_destination() {
+    let (repo, _upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+
+    // Move origin/main forward, then leave the checked-out destination one
+    // commit behind it. Preflight must report this without fetching.
+    commit_file(
+        &repo.path(),
+        "remote.txt",
+        "remote",
+        "remote destination commit",
+    );
+    run_git(&["push", "origin", "main"], &repo.path());
+    run_git(&["reset", "--hard", "HEAD~1"], &repo.path());
+
+    wt_core()
+        .args(["add", "feature/behind", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-behind");
+    commit_file(&source, "behind.txt", "behind", "behind source");
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/behind",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["preflight"]["topology"], "behind");
+    assert_eq!(json["preflight"]["ahead"], 0);
+    assert_eq!(json["preflight"]["behind"], 1);
+    assert_eq!(json["preflight"]["allowed"], false);
+    assert_eq!(json["refusal"]["reason"], "destination_behind_upstream");
+    assert!(
+        source.exists(),
+        "inspect must not clean up the source worktree"
+    );
+}
+
+#[test]
+fn merge_rejects_diverged_destination_before_mutation_with_json_reason() {
+    let (repo, _upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/diverged-topology", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-diverged-topology");
+    commit_file(&source, "source.txt", "source", "source");
+
+    run_git(&["checkout", "-b", "remote-simulation"], &repo.path());
+    commit_file(&repo.path(), "remote.txt", "remote", "remote");
+    let remote_head = git_rev_parse(&repo.path(), "HEAD");
+    run_git(&["checkout", "main"], &repo.path());
+    run_git(&["branch", "-D", "remote-simulation"], &repo.path());
+    run_git(
+        &["update-ref", "refs/remotes/origin/main", &remote_head],
+        &repo.path(),
+    );
+    commit_file(&repo.path(), "local.txt", "local", "local");
+    let main_before = git_rev_parse(&repo.path(), "main");
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/diverged-topology",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(5)
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["preflight"]["topology"], "diverged");
+    assert_eq!(json["preflight"]["ahead"], 1);
+    assert_eq!(json["preflight"]["behind"], 1);
+    assert_eq!(json["preflight"]["allowed"], false);
+    assert_eq!(json["refusal"]["kind"], "topology");
+    assert_eq!(
+        json["refusal"]["reason"],
+        "destination_diverged_from_upstream"
+    );
+    assert_eq!(git_rev_parse(&repo.path(), "main"), main_before);
+    assert!(source.exists(), "topology refusal must preserve the source");
+}
+
+#[test]
+fn merge_inspect_explains_merged_then_reverted_source() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/reverted", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-reverted");
+    commit_file(&source, "reverted.txt", "reverted", "reverted source");
+    run_git(
+        &[
+            "merge",
+            "--no-ff",
+            "feature/reverted",
+            "-m",
+            "Merge branch 'feature/reverted'",
+        ],
+        &repo.path(),
+    );
+    run_git(&["revert", "-m", "1", "HEAD", "--no-edit"], &repo.path());
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/reverted",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["preflight"]["source_history"], "merged_then_reverted");
+    assert_eq!(json["preflight"]["source_was_merged"], true);
+    assert_eq!(json["preflight"]["source_was_reverted"], true);
+    assert!(
+        json["preflight"]["reverted_commit"]
+            .as_str()
+            .is_some_and(|sha| sha.len() == 40),
+        "reverted commit should be exposed"
+    );
+    assert!(
+        source.exists(),
+        "inspect must not clean up the source worktree"
+    );
+}
+
+#[test]
+fn merge_inspect_ignores_revert_marker_for_unmerged_source() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/unmerged-revert", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-unmerged-revert");
+    commit_file(&source, "unmerged.txt", "source", "unmerged source");
+    let shared_base = git_rev_parse(&repo.path(), "main");
+    let message =
+        format!("Revert a shared base, not the source\n\nThis reverts commit {shared_base}.");
+    run_git(&["commit", "--allow-empty", "-m", &message], &repo.path());
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/unmerged-revert",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["preflight"]["source_history"], "not_merged");
+    assert_eq!(json["preflight"]["source_was_merged"], false);
+    assert_eq!(json["preflight"]["source_was_reverted"], false);
+    assert!(json["preflight"]["reverted_commit"].is_null());
+    assert!(
+        source.exists(),
+        "inspect must not clean up the source worktree"
+    );
+}
+
+#[test]
+fn merge_inspect_reports_linked_destination_topology() {
+    let (repo, _upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/inspect");
+    run_git(&["push", "-u", "origin", "release/inspect"], &repo.path());
+
+    wt_core()
+        .args(["add", "feature/linked-inspect", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-linked-inspect");
+    commit_file(&source, "linked-inspect.txt", "linked", "linked inspect");
+    let destination_before = git_rev_parse(&destination, "HEAD");
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/linked-inspect",
+            "--into",
+            "release/inspect",
+            "--inspect",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["preflight"]["destination"], "release/inspect");
+    assert_eq!(
+        json["preflight"]["destination_path"],
+        destination.display().to_string()
+    );
+    assert_eq!(json["preflight"]["topology"], "synchronized");
+    assert_eq!(git_rev_parse(&destination, "HEAD"), destination_before);
+    assert!(
+        source.exists(),
+        "linked inspect must not clean up the source"
+    );
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /// Run a git command and return its raw output, allowing expected failures.
@@ -1079,6 +1539,47 @@ fn git_path(cwd: &std::path::Path, marker: &str) -> std::path::PathBuf {
     } else {
         cwd.join(path)
     }
+}
+
+/// Resolve a revision to its full commit ID.
+fn git_rev_parse(repo: &std::path::Path, revision: &str) -> String {
+    let mut cmd = StdCommand::new("git");
+    cmd.args(["rev-parse", revision]).current_dir(repo);
+    for var in GIT_ENV_OVERRIDES {
+        cmd.env_remove(var);
+    }
+    let output = cmd.output().expect("git rev-parse failed");
+    assert!(
+        output.status.success(),
+        "git rev-parse {revision} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("invalid utf8")
+        .trim()
+        .to_string()
+}
+
+/// Snapshot Git's per-worktree administrative entries without pruning them.
+fn worktree_admin_snapshot(repo: &std::path::Path) -> Vec<(String, String)> {
+    let admin_dir = repo.join(".git/worktrees");
+    let Ok(entries) = std::fs::read_dir(admin_dir) else {
+        return Vec::new();
+    };
+
+    let mut snapshot = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        let gitdir = std::fs::read_to_string(path.join("gitdir")).unwrap_or_default();
+        let head = std::fs::read_to_string(path.join("HEAD")).unwrap_or_default();
+        snapshot.push((name, format!("{gitdir}\0{head}")));
+    }
+    snapshot.sort();
+    snapshot
 }
 
 /// Get the git log as one-line entries.

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -1960,7 +1960,276 @@ fn merge_json_distinguishes_pre_merge_hook_failure_from_content_conflict() {
     assert_branch_exists(&repo.path(), "feature/hook-failure");
 }
 
+#[cfg(unix)]
+#[test]
+fn merge_source_identity_race_skips_cleanup_after_commit() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/source-identity-race", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-source-identity-race");
+    commit_file(&source, "source-race.txt", "source", "source race");
+
+    install_identity_replacement_hook(
+        &repo,
+        "pre-merge-commit",
+        &source,
+        "feature/source-identity-race",
+        "replacement-source-identity",
+    );
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/source-identity-race",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["cleaned_up"], false);
+    assert_eq!(json["pushed"], false);
+    assert!(json["warnings"]
+        .as_array()
+        .is_some_and(|warnings| warnings.iter().any(|warning| {
+            warning
+                .as_str()
+                .is_some_and(|message| message.contains("identity changed"))
+        })));
+    assert!(source.exists(), "replacement source must remain untouched");
+    assert_branch_exists(&repo.path(), "feature/source-identity-race");
+    assert!(
+        git_log_oneline(&repo.path(), "main")
+            .contains("Merge branch 'feature/source-identity-race'"),
+        "successful merge must remain committed"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_linked_destination_identity_race_skips_cleanup_and_push() {
+    let (repo, upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/destination-identity-race");
+    run_git(
+        &["push", "-u", "origin", "release/destination-identity-race"],
+        &repo.path(),
+    );
+
+    wt_core()
+        .args([
+            "add",
+            "feature/destination-identity-race",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-destination-identity-race");
+    commit_file(
+        &source,
+        "destination-race.txt",
+        "source",
+        "destination race",
+    );
+
+    install_identity_replacement_hook(
+        &repo,
+        "post-merge",
+        &destination,
+        "release/destination-identity-race",
+        "replacement-destination-identity",
+    );
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/destination-identity-race",
+            "--into",
+            "release/destination-identity-race",
+            "--push",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid json");
+
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["cleaned_up"], false);
+    assert_eq!(json["pushed"], false);
+    assert!(json["warnings"].as_array().is_some_and(|warnings| {
+        warnings.iter().any(|warning| {
+            warning
+                .as_str()
+                .is_some_and(|message| message.contains("identity changed"))
+        })
+    }));
+    assert!(
+        destination.exists(),
+        "replacement destination must remain untouched"
+    );
+    assert!(
+        source.exists(),
+        "cleanup must stop when destination identity changed"
+    );
+    assert_branch_exists(&repo.path(), "feature/destination-identity-race");
+    assert!(
+        !git_log_oneline(upstream.path(), "release/destination-identity-race")
+            .contains("Merge branch 'feature/destination-identity-race'")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_source_identity_control_keeps_cleanup_with_non_replacing_hook() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args([
+            "add",
+            "feature/source-identity-control",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-source-identity-control");
+    commit_file(&source, "source-control.txt", "source", "source control");
+    install_hook(&repo, "pre-merge-commit", "#!/bin/sh\nexit 0\n");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/source-identity-control",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("identity changed").not());
+
+    assert!(
+        !source.exists(),
+        "stable source identity should be cleaned up"
+    );
+    assert_branch_deleted(&repo.path(), "feature/source-identity-control");
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_linked_destination_identity_control_keeps_push_with_non_replacing_hook() {
+    let (repo, upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/destination-identity-control");
+    run_git(
+        &[
+            "push",
+            "-u",
+            "origin",
+            "release/destination-identity-control",
+        ],
+        &repo.path(),
+    );
+
+    wt_core()
+        .args([
+            "add",
+            "feature/destination-identity-control",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-destination-identity-control");
+    commit_file(
+        &source,
+        "destination-control.txt",
+        "source",
+        "destination control",
+    );
+    install_hook(&repo, "post-merge", "#!/bin/sh\nexit 0\n");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/destination-identity-control",
+            "--into",
+            "release/destination-identity-control",
+            "--push",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("identity changed").not());
+
+    assert!(
+        !source.exists(),
+        "stable source identity should be cleaned up"
+    );
+    assert_branch_deleted(&repo.path(), "feature/destination-identity-control");
+    assert!(
+        git_log_oneline(upstream.path(), "release/destination-identity-control")
+            .contains("Merge branch 'feature/destination-identity-control'")
+    );
+    assert!(destination.exists(), "linked destination must remain");
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+fn install_hook(repo: &fixtures::TestRepo, name: &str, script: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let hook = repo.path().join(".git/hooks").join(name);
+    std::fs::write(&hook, script).expect("write hook");
+    let mut permissions = std::fs::metadata(&hook)
+        .expect("hook metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&hook, permissions).expect("chmod hook");
+}
+
+#[cfg(unix)]
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(unix)]
+fn install_identity_replacement_hook(
+    repo: &fixtures::TestRepo,
+    hook_name: &str,
+    target: &std::path::Path,
+    branch: &str,
+    replacement_name: &str,
+) {
+    let repo_path = repo.path().display().to_string();
+    let target_path = target.display().to_string();
+    let script = format!(
+        "#!/bin/sh\nset -eu\nunset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX\nrepo={}\ntarget={}\nreplacement=\"$target.{}\"\ngit -C \"$repo\" worktree remove --force \"$target\"\ngit -C \"$repo\" worktree add \"$replacement\" {}\nadmin=$(git -C \"$replacement\" rev-parse --git-dir)\nmv \"$replacement\" \"$target\"\nprintf '%s\\n' \"$target/.git\" > \"$admin/gitdir\"\n",
+        shell_quote(&repo_path),
+        shell_quote(&target_path),
+        replacement_name,
+        shell_quote(branch),
+    );
+    install_hook(repo, hook_name, &script);
+}
 
 /// Run a git command and return its raw output, allowing expected failures.
 fn git_allow_failure(args: &[&str], cwd: &std::path::Path) -> std::process::Output {

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -792,6 +792,201 @@ fn merge_into_linked_worktree_succeeds_and_cleans_only_source() {
 }
 
 #[test]
+fn merge_rejects_replaced_linked_destination_before_mutation_or_cleanup() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/stale");
+
+    wt_core()
+        .args(["add", "feature/stale", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-stale");
+    commit_file(&source, "source.txt", "source", "source");
+    let main_before = git_rev_parse(&repo.path(), "main");
+    let destination_branch_before = git_rev_parse(&repo.path(), "release/stale");
+    let admin_before = worktree_admin_snapshot(&repo.path());
+
+    let unrelated = fixtures::TestRepo::new();
+    run_git(&["checkout", "-b", "release/stale"], &unrelated.path());
+    commit_file(
+        &unrelated.path(),
+        "unrelated-release.txt",
+        "unrelated release",
+        "unrelated release",
+    );
+    run_git(&["checkout", "-b", "feature/stale"], &unrelated.path());
+    commit_file(
+        &unrelated.path(),
+        "unrelated-feature.txt",
+        "unrelated feature",
+        "unrelated feature",
+    );
+    run_git(&["checkout", "release/stale"], &unrelated.path());
+
+    std::fs::remove_dir_all(&destination).expect("remove registered destination");
+    let unrelated_path = unrelated.path();
+    std::fs::rename(&unrelated_path, &destination).expect("replace destination");
+    let unrelated_before = git_rev_parse(&destination, "HEAD");
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/stale",
+            "--into",
+            "release/stale",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .code(5)
+        .stderr(predicate::str::contains(
+            "stale destination worktree metadata",
+        ))
+        .stderr(predicate::str::contains("common directory"));
+
+    assert_eq!(git_rev_parse(&repo.path(), "main"), main_before);
+    assert_eq!(
+        git_rev_parse(&repo.path(), "release/stale"),
+        destination_branch_before
+    );
+    assert_eq!(git_rev_parse(&destination, "HEAD"), unrelated_before);
+    assert_branch_exists(&repo.path(), "feature/stale");
+    assert!(source.exists(), "source must not be cleaned up");
+    assert_eq!(worktree_admin_snapshot(&repo.path()), admin_before);
+}
+
+#[test]
+fn merge_rejects_replaced_source_before_mutation_or_cleanup() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/stale-source", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-stale-source");
+    commit_file(&source, "source.txt", "source", "source");
+    let main_before = git_rev_parse(&repo.path(), "main");
+    let source_branch_before = git_rev_parse(&repo.path(), "feature/stale-source");
+    let admin_before = worktree_admin_snapshot(&repo.path());
+
+    let unrelated = fixtures::TestRepo::new();
+    run_git(
+        &["checkout", "-b", "feature/stale-source"],
+        &unrelated.path(),
+    );
+    commit_file(&unrelated.path(), "unrelated.txt", "unrelated", "unrelated");
+    std::fs::remove_dir_all(&source).expect("remove registered source");
+    let unrelated_path = unrelated.path();
+    std::fs::rename(&unrelated_path, &source).expect("replace source");
+    let unrelated_before = git_rev_parse(&source, "HEAD");
+
+    wt_core()
+        .args(["merge", "feature/stale-source", "--repo", &repo_str])
+        .assert()
+        .failure()
+        .code(5)
+        .stderr(predicate::str::contains("stale source worktree metadata"))
+        .stderr(predicate::str::contains("common directory"));
+
+    assert_eq!(git_rev_parse(&repo.path(), "main"), main_before);
+    assert_eq!(
+        git_rev_parse(&repo.path(), "feature/stale-source"),
+        source_branch_before
+    );
+    assert_eq!(git_rev_parse(&source, "HEAD"), unrelated_before);
+    assert!(source.exists(), "replacement source must not be removed");
+    assert_eq!(worktree_admin_snapshot(&repo.path()), admin_before);
+}
+
+#[test]
+fn merge_inspect_rejects_symlinked_destination_without_pruning_metadata() {
+    #[cfg(not(unix))]
+    return;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+
+        let repo = fixtures::TestRepo::new();
+        let repo_str = repo.path().display().to_string();
+        let destination = add_linked_destination(&repo, "release/symlink");
+
+        wt_core()
+            .args(["add", "feature/symlink", "--repo", &repo_str])
+            .assert()
+            .success();
+        let source = find_worktree_dir(&repo.path(), "feature-symlink");
+        commit_file(&source, "source.txt", "source", "source");
+        let admin_before = worktree_admin_snapshot(&repo.path());
+
+        let unrelated = fixtures::TestRepo::new();
+        let unrelated_path = unrelated.path();
+        std::fs::remove_dir_all(&destination).expect("remove registered destination");
+        symlink(&unrelated_path, &destination).expect("replace destination with symlink");
+
+        wt_core()
+            .args([
+                "merge",
+                "feature/symlink",
+                "--into",
+                "release/symlink",
+                "--inspect",
+                "--repo",
+                &repo_str,
+            ])
+            .assert()
+            .failure()
+            .code(5)
+            .stderr(predicate::str::contains(
+                "stale destination worktree metadata",
+            ))
+            .stderr(predicate::str::contains("symlink"));
+
+        assert!(source.exists(), "inspect must preserve the source");
+        assert!(destination.is_symlink(), "replacement symlink must remain");
+        assert_eq!(worktree_admin_snapshot(&repo.path()), admin_before);
+    }
+}
+
+#[test]
+fn merge_rejects_same_repository_branch_spoof_before_cleanup() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+
+    wt_core()
+        .args(["add", "feature/spoof", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-spoof");
+    commit_file(&source, "source.txt", "source", "source");
+
+    wt_core()
+        .args(["add", "feature/other", "--repo", &repo_str])
+        .assert()
+        .success();
+    let replacement = find_worktree_dir(&repo.path(), "feature-other");
+    lock_worktree_metadata(&repo.path(), &replacement);
+    let admin_before = worktree_admin_snapshot(&repo.path());
+    std::fs::remove_dir_all(&source).expect("remove registered source");
+    std::fs::rename(&replacement, &source).expect("move another worktree into source path");
+
+    wt_core()
+        .args(["merge", "feature/spoof", "--repo", &repo_str])
+        .assert()
+        .failure()
+        .code(5)
+        .stderr(predicate::str::contains("stale source worktree metadata"))
+        .stderr(predicate::str::contains("registered admin entry"));
+
+    assert_branch_exists(&repo.path(), "feature/spoof");
+    assert!(source.exists(), "spoofed source must not be removed");
+    assert_eq!(worktree_admin_snapshot(&repo.path()), admin_before);
+}
+
+#[test]
 fn merge_into_linked_worktree_dirty_destination_fails_and_aborts_there() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();


### PR DESCRIPTION
## Summary
- Add destination topology preflight before merge mutation, reporting upstream and ahead/behind counts.
- Refuse behind, diverged, and unavailable-upstream destinations with actionable topology reasons; surface ahead destinations prominently.
- Add `wt merge --inspect` for human and JSON inspection without repository mutation.
- Detect already-merged and merged-then-reverted source history, and distinguish topology refusals from content conflicts in diagnostics and JSON.
- Preserve linked-worktree recovery behavior while carrying preflight facts through success and failure responses.

## Topology / inspect / recovery
- Synchronized, ahead, behind, diverged, no-upstream, and unavailable-upstream states are represented explicitly.
- Inspection uses read-only worktree discovery and does not prune metadata or clean up the source worktree.
- Merge failures retain preflight context; topology refusals are reported separately from content-conflict and Git failures.
- Source cleanup and linked-destination push remain conditional on the merge succeeding and identity checks passing.

## Race-safety validation
- Source and linked-destination identities are captured and revalidated before destructive cleanup or push.
- Identity-replacement tests verify cleanup/push are skipped when a worktree is replaced during the operation.
- Control tests verify cleanup and push still occur when identities remain stable.

## Validation
- `git diff --check feat/issue-69-linked-merge-target...HEAD` passed.
- The branch was clean at publication; tests were not rerun during this publication-only step.

Stacked on #77

Closes #71
