### PR TITLE
feat: add resumable merge lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "dialoguer",
+ "libc",
  "predicates",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,5 @@ windows-sys = { version = "0.61", features = [
     "Win32_Security",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
+    "Win32_Storage_FileSystem",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,14 @@ assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_System_IO",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
     "Win32_Storage_FileSystem",

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ wt list [--stats]                      List all worktrees
 wt remove [<branch>] [--force]         Remove a worktree and its local branch
                                       [--keep-branch] preserves the branch
 wt merge [<branch>] [--into <branch>]  Merge a branch and clean up
+wt merge --status                     Show a paused managed merge
+wt merge --continue                   Finish a resolved managed merge
+wt merge --abort                      Abort a managed merge safely
 wt merge [<branch>] --inspect         Inspect merge topology without mutation
 wt diff [<branch>] [--dry-run]         Open difftool for branch or dirty changes
 wt materialize --sha <sha> ...         Create an explicit detached checkout
@@ -166,8 +169,9 @@ wt remove feature/auth --keep-branch  # remove worktree, preserve local branch
 Merges a worktree's branch into the auto-detected mainline using
 `--no-ff`, then removes the source worktree and branch by default. Use
 `--into` to merge into a different branch that is already checked out in the
-main or a linked worktree. The merge and conflict abort run in the destination
-worktree, and conflicts cause an automatic `merge --abort` to keep it clean.
+main or a linked worktree. The merge and conflict lifecycle runs in the
+destination worktree; conflicts remain there for resolution or an explicit
+`wt merge --abort`.
 
 ```
 wt merge                         # merge current worktree's branch
@@ -193,6 +197,34 @@ worktree metadata, merges, pushes, or cleans up. With `--json`, the
 `preflight` object contains `upstream`, `ahead`, `behind`, `topology`, source
 history, and any structured refusal reason. Topology refusals are distinct
 from `content_conflict` refusals.
+
+A content conflict is intentionally left in the destination worktree. The
+source worktree and branch are not cleaned up, and wt-core records the
+operation under Git's common directory at
+`git rev-parse --git-path wt-core/merge-operation.json`. The record is written
+atomically and includes the schema version, exact source/destination worktree
+registrations, merge commit identity, push intent, and cleanup policy. Resolve
+and stage every path, then continue through Git's normal merge commit and hook
+path:
+
+```bash
+wt merge --status              # unresolved paths and pending actions
+wt merge --continue            # commit, then perform the original push/cleanup
+wt merge --abort               # git merge --abort, then clear matching state
+```
+
+`--status --json` reports `state`, `unresolved_paths`, `pending_actions`, and
+`recovery` (when state is stale, interrupted, or corrupt). A continuation hook
+failure preserves the merge and state for retry. Cleanup and push failures are
+reported as warnings and leave committed operation state so `--continue` can
+retry them; pushes never force-update a remote. If worktree registration
+identity, branch heads, or Git's merge marker no longer match the record,
+wt-core refuses mutation and prints recovery guidance rather than selecting a
+replacement by branch name.
+
+The Bash, Zsh, Fish, and Nushell bindings pass `--status` and `--abort`
+through without applying legacy navigation parsing. `--continue` retains the
+normal merge navigation behavior, including JSON output.
 
 ### `wt diff`
 

--- a/README.md
+++ b/README.md
@@ -201,9 +201,11 @@ from `content_conflict` refusals.
 A content conflict is intentionally left in the destination worktree. The
 source worktree and branch are not cleaned up, and wt-core records the
 operation under Git's common directory at
-`git rev-parse --git-path wt-core/merge-operation.json`. The record is written
-atomically and includes the schema version, exact source/destination worktree
-registrations, merge commit identity, push intent, and cleanup policy. Resolve
+`git rev-parse --git-path wt-core/merge-operation.json`. The record is written atomically and includes the schema version, exact
+source/destination worktree registrations, captured source and destination
+heads, merge commit identity, typed lifecycle progress, push intent, and cleanup
+policy. Its directory is private and its state/temp records are owner-only;
+insecure existing records are refused. Resolve
 and stage every path, then continue through Git's normal merge commit and hook
 path:
 
@@ -222,9 +224,9 @@ identity, branch heads, or Git's merge marker no longer match the record,
 wt-core refuses mutation and prints recovery guidance rather than selecting a
 replacement by branch name.
 
-The Bash, Zsh, Fish, and Nushell bindings pass `--status` and `--abort`
-through without applying legacy navigation parsing. `--continue` retains the
-normal merge navigation behavior, including JSON output.
+The Bash, Zsh, Fish, and Nushell bindings pass `--status`, `--continue`, and
+`--abort` through without applying legacy navigation or path-only parsing.
+JSON output remains available for all three lifecycle commands.
 
 ### `wt diff`
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ identity, branch heads, or Git's merge marker no longer match the record,
 wt-core refuses mutation and prints recovery guidance rather than selecting a
 replacement by branch name.
 
+Only one mutating merge lifecycle may own a repository at a time. An
+OS-backed lock is held from preflight through Git subprocess finalization and
+all durable journal/cleanup updates; its lock state is released safely by the
+OS after process death. A live owner makes a new merge, `--continue`, or
+`--abort` fail with recovery guidance, while `--status` remains read-only.
+Journal updates also compare the operation identity and generation before
+replacement or deletion, so a stale process cannot overwrite a newer journal.
+
 The Bash, Zsh, Fish, and Nushell bindings pass `--status`, `--continue`, and
 `--abort` through without applying legacy navigation or path-only parsing.
 JSON output remains available for all three lifecycle commands.

--- a/bindings/bash/wt.bash
+++ b/bindings/bash/wt.bash
@@ -166,6 +166,17 @@ wt() {
                 esac
             done
 
+            # Status and abort are lifecycle reports, not the legacy
+            # navigation protocol. --continue uses the normal merge protocol.
+            for arg in "$@"; do
+                case "$arg" in
+                    --status|--abort)
+                        wt-core merge "$@"
+                        return $?
+                        ;;
+                esac
+            done
+
             # Detect if the caller explicitly asked for --json
             local want_json=false
             for arg in "$@"; do

--- a/bindings/bash/wt.bash
+++ b/bindings/bash/wt.bash
@@ -166,11 +166,11 @@ wt() {
                 esac
             done
 
-            # Status and abort are lifecycle reports, not the legacy
-            # navigation protocol. --continue uses the normal merge protocol.
+            # Status, continue, and abort are lifecycle reports, not the
+            # legacy navigation protocol or path-only output protocol.
             for arg in "$@"; do
                 case "$arg" in
-                    --status|--abort)
+                    --status|--continue|--abort)
                         wt-core merge "$@"
                         return $?
                         ;;

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -192,10 +192,10 @@ function wt --description "Git worktree manager"
                 end
             end
 
-            # Status and abort are lifecycle reports, not the legacy
-            # navigation protocol. --continue uses the normal merge protocol.
+            # Status, continue, and abort are lifecycle reports, not the
+            # legacy navigation protocol or path-only output protocol.
             for arg in $argv
-                if test "$arg" = "--status" -o "$arg" = "--abort"
+                if test "$arg" = "--status" -o "$arg" = "--continue" -o "$arg" = "--abort"
                     wt-core merge $argv
                     return $status
                 end

--- a/bindings/fish/wt.fish
+++ b/bindings/fish/wt.fish
@@ -192,6 +192,15 @@ function wt --description "Git worktree manager"
                 end
             end
 
+            # Status and abort are lifecycle reports, not the legacy
+            # navigation protocol. --continue uses the normal merge protocol.
+            for arg in $argv
+                if test "$arg" = "--status" -o "$arg" = "--abort"
+                    wt-core merge $argv
+                    return $status
+                end
+            end
+
             # Detect if the caller explicitly asked for --json
             set -l want_json false
             for arg in $argv

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -232,6 +232,9 @@ export def --env "wt merge" [
     branch?: string  # Branch name (defaults to current worktree)
     --into: string   # Merge into a branch checked out in any worktree
     --inspect        # Inspect topology without mutating the repository
+    --status         # Show the managed conflicted-merge operation
+    --continue      # Continue after resolving conflicts
+    --abort          # Abort and restore the managed merge
     --push           # Push mainline to origin after merge
     --no-cleanup     # Keep worktree and branch after merge
     --repo: path     # Repository path (defaults to cwd)
@@ -243,10 +246,22 @@ export def --env "wt merge" [
     if $branch != null { $args = ($args | append $branch) }
     if $into != null { $args = ($args | append ["--into" $into]) }
     if $inspect { $args = ($args | append "--inspect") }
+    if $status { $args = ($args | append "--status") }
+    if $continue { $args = ($args | append "--continue") }
+    if $abort { $args = ($args | append "--abort") }
     if $push { $args = ($args | append "--push") }
     if $no_cleanup { $args = ($args | append "--no-cleanup") }
 
-    if $inspect {
+    if $status or $abort {
+        # Lifecycle reports have no navigation or path-only protocol. Keep
+        # stdout JSON-native when requested and preserve the core exit status.
+        let full_args = (build-args $args $repo $json false)
+        if $json {
+            run-core $full_args
+        } else {
+            ^wt-core ...$full_args
+        }
+    } else if $inspect {
         # Inspection is a read-only protocol. Do not add navigation metadata or
         # move cwd; the core command never prunes or mutates in this mode.
         let full_args = (build-args $args $repo $json false)
@@ -267,7 +282,7 @@ export def --env "wt merge" [
                 | path dirname
             } catch { |err| error make $err }
         }
-        if $branch == null {
+        if $branch == null and not $continue {
             let inferred_branch = try { ^git branch --show-current | str trim } catch { "" }
             if $inferred_branch != "" {
                 $args = ($args | append $inferred_branch)
@@ -312,7 +327,7 @@ export def --env "wt merge" [
                 | path dirname
             } catch { |err| error make $err }
         }
-        if $branch == null {
+        if $branch == null and not $continue {
             let inferred_branch = try { ^git branch --show-current | str trim } catch { "" }
             if $inferred_branch != "" {
                 $args = ($args | append $inferred_branch)

--- a/bindings/nu/wt.nu
+++ b/bindings/nu/wt.nu
@@ -252,7 +252,7 @@ export def --env "wt merge" [
     if $push { $args = ($args | append "--push") }
     if $no_cleanup { $args = ($args | append "--no-cleanup") }
 
-    if $status or $abort {
+    if $status or $continue or $abort {
         # Lifecycle reports have no navigation or path-only protocol. Keep
         # stdout JSON-native when requested and preserve the core exit status.
         let full_args = (build-args $args $repo $json false)

--- a/bindings/zsh/wt.zsh
+++ b/bindings/zsh/wt.zsh
@@ -174,6 +174,17 @@ wt() {
                 esac
             done
 
+            # Status and abort are lifecycle reports, not the legacy
+            # navigation protocol. --continue uses the normal merge protocol.
+            for arg in "$@"; do
+                case "$arg" in
+                    --status|--abort)
+                        wt-core merge "$@"
+                        return $?
+                        ;;
+                esac
+            done
+
             # Detect if the caller explicitly asked for --json
             local want_json=false
             for arg in "$@"; do

--- a/bindings/zsh/wt.zsh
+++ b/bindings/zsh/wt.zsh
@@ -174,11 +174,11 @@ wt() {
                 esac
             done
 
-            # Status and abort are lifecycle reports, not the legacy
-            # navigation protocol. --continue uses the normal merge protocol.
+            # Status, continue, and abort are lifecycle reports, not the
+            # legacy navigation protocol or path-only output protocol.
             for arg in "$@"; do
                 case "$arg" in
-                    --status|--abort)
+                    --status|--continue|--abort)
                         wt-core merge "$@"
                         return $?
                         ;;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,9 +150,68 @@ pub enum Command {
         /// Inspect merge topology without merging, cleaning up, or pushing
         #[arg(
             long,
-            conflicts_with_all = ["push", "no_cleanup", "print_paths", "print_paths_v2"]
+            conflicts_with_all = [
+                "push",
+                "no_cleanup",
+                "print_paths",
+                "print_paths_v2",
+                "status",
+                "continue_merge",
+                "abort"
+            ]
         )]
         inspect: bool,
+
+        /// Show the managed conflicted-merge operation
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "branch",
+                "into",
+                "inspect",
+                "push",
+                "no_cleanup",
+                "print_paths",
+                "print_paths_v2",
+                "continue_merge",
+                "abort"
+            ]
+        )]
+        status: bool,
+
+        /// Continue the managed merge after resolving all conflicts
+        #[arg(
+            long = "continue",
+            conflicts_with_all = [
+                "branch",
+                "into",
+                "inspect",
+                "push",
+                "no_cleanup",
+                "print_paths",
+                "print_paths_v2",
+                "status",
+                "abort"
+            ]
+        )]
+        continue_merge: bool,
+
+        /// Abort the managed merge and restore the destination
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "branch",
+                "into",
+                "inspect",
+                "push",
+                "no_cleanup",
+                "print_paths",
+                "print_paths_v2",
+                "status",
+                "continue_merge"
+            ]
+        )]
+        abort: bool,
 
         /// Push the target branch to origin after successful merge
         #[arg(long)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1396,7 +1396,7 @@ fn print_merge_result(
     if let Some(Err(error)) = navigation_file.map(|path| {
         write_navigation_file(
             path,
-            result.cleaned_up,
+            result.removed_path.is_some(),
             result.removed_path.as_deref(),
             &result.repo_root,
         )
@@ -1423,11 +1423,7 @@ fn print_merge_result(
             println!("{}", result.destination_path.display());
         }
         MergeFormat::Json => {
-            let event = if result.cleaned_up {
-                Some("reset".to_string())
-            } else {
-                None
-            };
+            let event = result.removed_path.as_ref().map(|_| "reset".to_string());
             print_json(&JsonMergeResponse {
                 ok: true,
                 event,
@@ -1437,7 +1433,8 @@ fn print_merge_result(
                 destination_path: result.destination_path.display().to_string(),
                 repo_root: root_str,
                 cleaned_up: result.cleaned_up,
-                removed_path: if result.cleaned_up {
+                branch_deleted: result.branch_deleted,
+                removed_path: if result.removed_path.is_some() {
                     Some(removed_str)
                 } else {
                     None
@@ -1457,8 +1454,15 @@ fn print_merge_result(
                 "Destination worktree: {}",
                 result.destination_path.display()
             );
-            if result.cleaned_up {
-                println!("Removed worktree and branch '{}'", branch_name);
+            match (&result.removed_path, result.branch_deleted) {
+                (Some(_), true) => {
+                    println!("Removed worktree and branch '{}'", branch_name);
+                }
+                (Some(path), false) => {
+                    println!("Removed worktree: {}", path.display());
+                    println!("Source branch cleanup remains pending");
+                }
+                (None, _) => {}
             }
             if result.pushed {
                 println!("Pushed {} to origin", result.mainline);
@@ -1488,6 +1492,9 @@ fn json_merge_operation(report: &worktree::MergeOperationReport) -> JsonMergeOpe
         push: report.push,
         cleanup: report.cleanup,
         keep_branch: report.keep_branch,
+        worktree_removed: report.worktree_removed,
+        branch_deleted: report.branch_deleted,
+        push_done: report.push_done,
         pending_actions: report.pending_actions.clone(),
         recovery: report.recovery.clone(),
         state_path: Some(report.state_path.display().to_string()),
@@ -1505,6 +1512,9 @@ fn empty_merge_operation(message: &str) -> JsonMergeOperation {
         push: false,
         cleanup: false,
         keep_branch: false,
+        worktree_removed: false,
+        branch_deleted: false,
+        push_done: false,
         pending_actions: Vec::new(),
         recovery: Some(message.to_string()),
         state_path: None,
@@ -1725,6 +1735,7 @@ fn print_merge_inspection(
             destination_path: preflight.destination_path.display().to_string(),
             repo_root: repo.display().to_string(),
             cleaned_up: false,
+            branch_deleted: false,
             removed_path: None,
             pushed: false,
             warnings: Vec::new(),
@@ -1778,6 +1789,7 @@ fn report_merge_failure(
             destination_path: preflight.destination_path.display().to_string(),
             repo_root: repo.display().to_string(),
             cleaned_up: false,
+            branch_deleted: false,
             removed_path: None,
             pushed: false,
             warnings: Vec::new(),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,10 +13,10 @@ use crate::git;
 use crate::output::{
     find_current_worktree, print_json, print_json_stderr, write_navigation_file,
     JsonDoctorResponse, JsonExecResponse, JsonListResponse, JsonMaterializeResponse,
-    JsonMaterializeTimings, JsonMergePreflight, JsonMergeRefusal, JsonMergeResponse,
-    JsonPruneDryRunEntry, JsonPruneDryRunResponse, JsonPruneExecuteResponse, JsonPrunedEntry,
-    JsonResponse, JsonSkippedEntry, MergeFormat, NavigationFormat, PruneFormat, RemoveFormat,
-    StatusFormat,
+    JsonMaterializeTimings, JsonMergeOperation, JsonMergeOperationResponse, JsonMergePreflight,
+    JsonMergeRefusal, JsonMergeResponse, JsonPruneDryRunEntry, JsonPruneDryRunResponse,
+    JsonPruneExecuteResponse, JsonPrunedEntry, JsonResponse, JsonSkippedEntry, MergeFormat,
+    NavigationFormat, PruneFormat, RemoveFormat, StatusFormat,
 };
 use crate::worktree;
 use unicode_width::UnicodeWidthStr;
@@ -177,6 +177,9 @@ pub fn run(cli: Cli) -> Result<RunOutcome> {
             branch,
             into,
             inspect,
+            status,
+            continue_merge,
+            abort,
             push,
             no_cleanup,
             repo,
@@ -188,6 +191,9 @@ pub fn run(cli: Cli) -> Result<RunOutcome> {
             branch: branch.as_deref().map(BranchName::new),
             into,
             inspect,
+            status,
+            continue_merge,
+            abort,
             push,
             no_cleanup,
             repo,
@@ -1288,6 +1294,9 @@ struct MergeCommandOptions {
     branch: Option<BranchName>,
     into: Option<String>,
     inspect: bool,
+    status: bool,
+    continue_merge: bool,
+    abort: bool,
     push: bool,
     no_cleanup: bool,
     repo: Option<PathBuf>,
@@ -1300,6 +1309,9 @@ fn cmd_merge(options: MergeCommandOptions) -> Result<()> {
         branch,
         into,
         inspect,
+        status,
+        continue_merge,
+        abort,
         push,
         no_cleanup,
         repo: repo_path,
@@ -1307,6 +1319,16 @@ fn cmd_merge(options: MergeCommandOptions) -> Result<()> {
         navigation_file,
     } = options;
     let repo = resolve_repo(repo_path)?;
+
+    if status {
+        return cmd_merge_status(&repo, fmt);
+    }
+    if abort {
+        return cmd_merge_abort(&repo, fmt);
+    }
+    if continue_merge {
+        return cmd_merge_continue(&repo, fmt, navigation_file.as_deref());
+    }
 
     let resolved_branch = match branch {
         Some(branch) => Some(branch),
@@ -1354,6 +1376,15 @@ fn cmd_merge(options: MergeCommandOptions) -> Result<()> {
         }
     };
 
+    print_merge_result(&repo, result, fmt, navigation_file.as_deref())
+}
+
+fn print_merge_result(
+    repo: &domain::RepoRoot,
+    result: worktree::MergeResult,
+    fmt: MergeFormat,
+    navigation_file: Option<&std::path::Path>,
+) -> Result<()> {
     let root_str = result.repo_root.display().to_string();
     let branch_name = &result.branch;
     let removed_str = result
@@ -1362,7 +1393,7 @@ fn cmd_merge(options: MergeCommandOptions) -> Result<()> {
         .map(|path| path.display().to_string())
         .unwrap_or_default();
 
-    if let Some(Err(error)) = navigation_file.as_ref().map(|path| {
+    if let Some(Err(error)) = navigation_file.map(|path| {
         write_navigation_file(
             path,
             result.cleaned_up,
@@ -1415,8 +1446,10 @@ fn cmd_merge(options: MergeCommandOptions) -> Result<()> {
                 warnings: result.warnings.clone(),
                 preflight: Some(JsonMergePreflight::from_preflight(&result.preflight)),
                 refusal: None,
+                operation: worktree::merge_operation_report_if_present(repo)
+                    .map(|report| json_merge_operation(&report)),
                 inspect: false,
-            })?;
+            })?
         }
         MergeFormat::Human => {
             println!("Merged '{}' into {}", branch_name, result.mainline);
@@ -1436,6 +1469,164 @@ fn cmd_merge(options: MergeCommandOptions) -> Result<()> {
         eprintln!("warning: {warning}");
     }
     Ok(())
+}
+
+fn json_merge_operation(report: &worktree::MergeOperationReport) -> JsonMergeOperation {
+    JsonMergeOperation {
+        state: report.state.clone(),
+        source: report.source.clone(),
+        destination: report.destination.clone(),
+        source_path: report
+            .source_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        destination_path: report
+            .destination_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        unresolved_paths: report.unresolved_paths.clone(),
+        push: report.push,
+        cleanup: report.cleanup,
+        keep_branch: report.keep_branch,
+        pending_actions: report.pending_actions.clone(),
+        recovery: report.recovery.clone(),
+        state_path: Some(report.state_path.display().to_string()),
+    }
+}
+
+fn empty_merge_operation(message: &str) -> JsonMergeOperation {
+    JsonMergeOperation {
+        state: "unknown".to_string(),
+        source: None,
+        destination: None,
+        source_path: None,
+        destination_path: None,
+        unresolved_paths: Vec::new(),
+        push: false,
+        cleanup: false,
+        keep_branch: false,
+        pending_actions: Vec::new(),
+        recovery: Some(message.to_string()),
+        state_path: None,
+    }
+}
+
+fn print_operation_error(
+    repo: &domain::RepoRoot,
+    fmt: MergeFormat,
+    error: &AppError,
+) -> Result<()> {
+    if fmt == MergeFormat::Json {
+        let operation = worktree::merge_operation_status(repo)
+            .ok()
+            .map(|report| json_merge_operation(&report))
+            .unwrap_or_else(|| empty_merge_operation(&error.message));
+        print_json(&JsonMergeOperationResponse {
+            ok: false,
+            message: error.message.clone(),
+            operation,
+        })?;
+    }
+    Err(AppError {
+        code: error.code,
+        message: error.message.clone(),
+    })
+}
+
+fn print_operation_human(report: &worktree::MergeOperationReport) {
+    println!("Managed merge operation: {}", report.state);
+    if let (Some(source), Some(destination)) = (&report.source, &report.destination) {
+        println!("  Source: {source}");
+        println!("  Destination: {destination}");
+    }
+    if let Some(path) = &report.destination_path {
+        println!("  Destination worktree: {}", path.display());
+    }
+    if report.unresolved_paths.is_empty() {
+        println!("  Unresolved paths: none");
+    } else {
+        println!("  Unresolved paths:");
+        for path in &report.unresolved_paths {
+            println!("    {path}");
+        }
+    }
+    println!("  Pending actions:");
+    if report.pending_actions.is_empty() {
+        println!("    none");
+    } else {
+        for action in &report.pending_actions {
+            println!("    {action}");
+        }
+    }
+    if let Some(recovery) = &report.recovery {
+        println!("  Recovery: {recovery}");
+    }
+}
+
+fn cmd_merge_status(repo: &domain::RepoRoot, fmt: MergeFormat) -> Result<()> {
+    if matches!(fmt, MergeFormat::PrintPaths | MergeFormat::PrintPathsV2) {
+        return Err(AppError::usage(
+            "--status cannot be used with path output formats".to_string(),
+        ));
+    }
+    let report = worktree::merge_operation_status(repo)?;
+    match fmt {
+        MergeFormat::Json => print_json(&JsonMergeOperationResponse {
+            ok: !matches!(report.state.as_str(), "stale" | "interrupted" | "corrupt"),
+            message: format!("managed merge operation is {}", report.state),
+            operation: json_merge_operation(&report),
+        })?,
+        MergeFormat::Human => print_operation_human(&report),
+        MergeFormat::PrintPaths | MergeFormat::PrintPathsV2 => unreachable!(),
+    }
+    if matches!(report.state.as_str(), "stale" | "interrupted" | "corrupt") {
+        return Err(AppError::conflict(report.recovery.unwrap_or_else(|| {
+            "managed merge state requires manual recovery".to_string()
+        })));
+    }
+    Ok(())
+}
+
+fn cmd_merge_abort(repo: &domain::RepoRoot, fmt: MergeFormat) -> Result<()> {
+    if matches!(fmt, MergeFormat::PrintPaths | MergeFormat::PrintPathsV2) {
+        return Err(AppError::usage(
+            "--abort cannot be used with path output formats".to_string(),
+        ));
+    }
+    let report = match worktree::merge_abort_operation(repo) {
+        Ok(report) => report,
+        Err(error) => return print_operation_error(repo, fmt, &error),
+    };
+    let message = format!(
+        "aborted managed merge of '{}' into {}",
+        report.source.as_deref().unwrap_or("(unknown)"),
+        report.destination.as_deref().unwrap_or("(unknown)")
+    );
+    match fmt {
+        MergeFormat::Json => print_json(&JsonMergeOperationResponse {
+            ok: true,
+            message,
+            operation: json_merge_operation(&report),
+        })?,
+        MergeFormat::Human => {
+            println!("{message}");
+            print_operation_human(&report);
+        }
+        MergeFormat::PrintPaths | MergeFormat::PrintPathsV2 => unreachable!(),
+    }
+    Ok(())
+}
+
+fn cmd_merge_continue(
+    repo: &domain::RepoRoot,
+    fmt: MergeFormat,
+    navigation_file: Option<&std::path::Path>,
+) -> Result<()> {
+    let result = match worktree::merge_continue(repo) {
+        Ok(result) => result,
+        Err(error) => return print_operation_error(repo, fmt, &error),
+    };
+    print_merge_result(repo, result, fmt, navigation_file)
 }
 
 fn print_merge_preflight(preflight: &worktree::MergePreflight) {
@@ -1543,6 +1734,7 @@ fn print_merge_inspection(
                 reason: refusal.reason.clone(),
                 message: Some(refusal.message.clone()),
             }),
+            operation: None,
             inspect: true,
         }),
         MergeFormat::Human => {
@@ -1591,6 +1783,8 @@ fn report_merge_failure(
             warnings: Vec::new(),
             preflight: Some(JsonMergePreflight::from_preflight(preflight)),
             refusal: json_refusal,
+            operation: worktree::merge_operation_report_if_present(repo)
+                .map(|report| json_merge_operation(&report)),
             inspect: false,
         })?;
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1334,12 +1334,18 @@ fn cmd_merge(options: MergeCommandOptions) -> Result<()> {
         Some(branch) => Some(branch),
         None => resolve_action_branch(&repo, fmt == MergeFormat::Json, "merge", inspect)?,
     };
-    let preflight =
-        worktree::merge_preflight(&repo, resolved_branch.as_ref(), into.as_deref(), inspect)?;
-
     if inspect {
+        let preflight =
+            worktree::merge_preflight(&repo, resolved_branch.as_ref(), into.as_deref(), true)?;
         return print_merge_inspection(&repo, &preflight, fmt);
     }
+
+    // Hold ownership before preflight and keep it through Git finalization and
+    // every durable journal/cleanup update. A paused hook therefore blocks all
+    // competing mutators while read-only status remains available.
+    let lifecycle_lock = worktree::acquire_merge_lifecycle_lock(&repo)?;
+    let preflight =
+        worktree::merge_preflight(&repo, resolved_branch.as_ref(), into.as_deref(), false)?;
 
     if fmt == MergeFormat::Human {
         print_merge_preflight(&preflight);
@@ -1351,30 +1357,31 @@ fn cmd_merge(options: MergeCommandOptions) -> Result<()> {
     }
 
     let preflight_for_error = preflight.clone();
-    let result = match worktree::merge_with_preflight(&repo, preflight, push, no_cleanup) {
-        Ok(result) => result,
-        Err(failure) => {
-            let refusal = match failure.kind {
-                worktree::MergeFailureKind::ContentConflict => JsonMergeRefusal {
-                    kind: "content".to_string(),
-                    reason: "content_conflict".to_string(),
-                    message: Some("destination content conflicts with the source".to_string()),
-                },
-                worktree::MergeFailureKind::GitFailure => JsonMergeRefusal {
-                    kind: "git".to_string(),
-                    reason: "git_error".to_string(),
-                    message: Some(failure.error.message.clone()),
-                },
-            };
-            return report_merge_failure(
-                &repo,
-                &preflight_for_error,
-                fmt,
-                failure.error,
-                Some(refusal),
-            );
-        }
-    };
+    let result =
+        match worktree::merge_with_preflight(&repo, preflight, push, no_cleanup, &lifecycle_lock) {
+            Ok(result) => result,
+            Err(failure) => {
+                let refusal = match failure.kind {
+                    worktree::MergeFailureKind::ContentConflict => JsonMergeRefusal {
+                        kind: "content".to_string(),
+                        reason: "content_conflict".to_string(),
+                        message: Some("destination content conflicts with the source".to_string()),
+                    },
+                    worktree::MergeFailureKind::GitFailure => JsonMergeRefusal {
+                        kind: "git".to_string(),
+                        reason: "git_error".to_string(),
+                        message: Some(failure.error.message.clone()),
+                    },
+                };
+                return report_merge_failure(
+                    &repo,
+                    &preflight_for_error,
+                    fmt,
+                    failure.error,
+                    Some(refusal),
+                );
+            }
+        };
 
     print_merge_result(&repo, result, fmt, navigation_file.as_deref())
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -885,7 +885,7 @@ fn registered_worktree_admin(common_dir: &Path, worktree: &Path) -> Result<PathB
 /// `<common-dir>/worktrees`. The path is captured before a merge and compared
 /// later; path, branch, and common-directory checks alone cannot distinguish a
 /// replacement worktree registered during a hook.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum WorktreeIdentity {
     Main { admin_dir: PathBuf },
     Linked { admin_dir: PathBuf },
@@ -1130,6 +1130,33 @@ pub fn has_unmerged_entries(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Return each path that still has unmerged index stages, once.
+pub fn unmerged_paths(path: &Path) -> Result<Vec<String>> {
+    let mut cmd = Cmd::new("git");
+    cmd.args(["ls-files", "--unmerged", "-z"]).current_dir(path);
+    sanitize_git_environment(&mut cmd);
+    let output = cmd
+        .output()
+        .map_err(|error| AppError::git(format!("failed to run git ls-files: {error}")))?;
+    if !output.status.success() {
+        return Err(classify_git_error(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    let mut paths = Vec::new();
+    for record in output.stdout.split(|byte| *byte == 0) {
+        let record = String::from_utf8_lossy(record);
+        let Some((_, path)) = record.split_once('\t') else {
+            continue;
+        };
+        if !paths.iter().any(|existing| existing == path) {
+            paths.push(path.to_string());
+        }
+    }
+    Ok(paths)
+}
+
 /// Check if a remote-tracking branch exists for `origin/<branch>`.
 pub fn remote_branch_exists(repo: &RepoRoot, branch: &BranchName) -> bool {
     let refspec = format!("refs/remotes/origin/{}", branch.as_str());
@@ -1146,6 +1173,34 @@ pub fn set_upstream(repo: &RepoRoot, branch: &BranchName) -> Result<()> {
         repo.as_ref(),
     )?;
     Ok(())
+}
+
+/// Return the full commit currently checked out in a worktree.
+pub fn head_commit(path: &Path) -> Result<String> {
+    git(&["rev-parse", "--verify", "HEAD^{commit}"], path)
+}
+
+/// Return the full commit currently referenced by a local branch.
+pub fn branch_head(repo: &RepoRoot, branch: &str) -> Result<String> {
+    let reference = format!("refs/heads/{branch}");
+    git(&["rev-parse", "--verify", &reference], repo.as_ref())
+}
+
+/// Return the source commit recorded by Git for an in-progress merge.
+pub fn merge_head(path: &Path) -> Result<Option<String>> {
+    let marker = git_path(path, "MERGE_HEAD")?;
+    match fs::read_to_string(marker) {
+        Ok(value) => Ok(value
+            .lines()
+            .next()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(AppError::conflict(format!(
+            "cannot read merge state: {error}"
+        ))),
+    }
 }
 
 /// Merge a branch into the current branch using `--no-ff`.
@@ -1167,12 +1222,45 @@ pub fn merge_no_ff(path: &Path, branch: &str) -> Result<()> {
     Ok(())
 }
 
+/// Continue an in-progress merge through Git's normal commit and hook path.
+pub fn merge_continue(path: &Path) -> Result<()> {
+    let mut cmd = Cmd::new("git");
+    cmd.args(["merge", "--continue"]).current_dir(path);
+    if std::env::var_os("GIT_EDITOR").is_none() {
+        // The merge message was created by the initial merge. Avoid opening
+        // an editor in non-interactive callers without changing Git's commit
+        // or hook behavior.
+        cmd.env("GIT_EDITOR", "true");
+    }
+    sanitize_git_environment(&mut cmd);
+    let output = cmd
+        .output()
+        .map_err(|error| AppError::git(format!("failed to run git merge --continue: {error}")))?;
+    if !output.status.success() {
+        return Err(classify_git_error(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Abort an in-progress merge and report failures to managed callers.
+pub fn merge_abort_checked(path: &Path) -> Result<()> {
+    git(&["merge", "--abort"], path)?;
+    Ok(())
+}
+
 /// Abort an in-progress merge in the destination worktree.
 ///
 /// Best-effort: if there is no merge to abort, git returns an error that
 /// we silently ignore.
 pub fn merge_abort(path: &Path) {
-    let _ = git(&["merge", "--abort"], path);
+    let _ = merge_abort_checked(path);
+}
+
+/// Location of wt-core's repository-local managed merge state.
+pub fn merge_operation_path(repo: &RepoRoot) -> Result<PathBuf> {
+    git_path(repo.as_ref(), "wt-core/merge-operation.json")
 }
 
 /// Verify Git has a usable difftool before launching an interactive diff.

--- a/src/git.rs
+++ b/src/git.rs
@@ -1180,10 +1180,48 @@ pub fn head_commit(path: &Path) -> Result<String> {
     git(&["rev-parse", "--verify", "HEAD^{commit}"], path)
 }
 
-/// Return the full commit currently referenced by a local branch.
-pub fn branch_head(repo: &RepoRoot, branch: &str) -> Result<String> {
+/// Return the parent commits of a commit, in Git's recorded order.
+pub fn commit_parents(path: &Path, revision: &str) -> Result<Vec<String>> {
+    let output = git(&["rev-list", "--parents", "-n", "1", revision], path)?;
+    Ok(output
+        .split_whitespace()
+        .skip(1)
+        .map(str::to_string)
+        .collect())
+}
+
+/// Identify the merge commit created from the captured destination/source
+/// heads. If a hook or concurrent writer advanced the destination once more,
+/// return the merge commit as the expected result so callers can refuse the
+/// newer HEAD rather than silently treating it as the merge result.
+pub fn merge_result_head(
+    path: &Path,
+    destination_head: &str,
+    source_head: &str,
+) -> Result<Option<String>> {
+    let current = head_commit(path)?;
+    let parents = commit_parents(path, &current)?;
+    if parents.len() == 2 && parents[0] == destination_head && parents[1] == source_head {
+        return Ok(Some(current));
+    }
+    let Some(first_parent) = parents.first() else {
+        return Ok(None);
+    };
+    let first_parents = commit_parents(path, first_parent)?;
+    if first_parents.len() == 2
+        && first_parents[0] == destination_head
+        && first_parents[1] == source_head
+    {
+        return Ok(Some(first_parent.clone()));
+    }
+    Ok(None)
+}
+
+/// Read the authoritative remote branch head without changing local refs.
+pub fn remote_branch_head(repo: &RepoRoot, branch: &str) -> Result<Option<String>> {
     let reference = format!("refs/heads/{branch}");
-    git(&["rev-parse", "--verify", &reference], repo.as_ref())
+    let output = git(&["ls-remote", "origin", &reference], repo.as_ref())?;
+    Ok(output.split_whitespace().next().map(str::to_string))
 }
 
 /// Return the source commit recorded by Git for an in-progress merge.

--- a/src/git.rs
+++ b/src/git.rs
@@ -1301,6 +1301,11 @@ pub fn merge_operation_path(repo: &RepoRoot) -> Result<PathBuf> {
     git_path(repo.as_ref(), "wt-core/merge-operation.json")
 }
 
+/// Location of the OS-backed owner lock for mutating merge lifecycles.
+pub fn merge_operation_lock_path(repo: &RepoRoot) -> Result<PathBuf> {
+    git_path(repo.as_ref(), "wt-core/merge-operation.lock")
+}
+
 /// Verify Git has a usable difftool before launching an interactive diff.
 pub fn ensure_difftool_available(path: &Path, tool: Option<&str>) -> Result<()> {
     match tool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod domain;
 mod error;
 mod git;
 mod materialize;
+mod operation_state;
 mod output;
 mod symlinks;
 mod worktree;

--- a/src/operation_state.rs
+++ b/src/operation_state.rs
@@ -5,8 +5,9 @@
 //! that make the journal safe to replace and recover.
 
 use std::fs;
-use std::io;
+use std::io::{self, Seek, SeekFrom, Write};
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{AppError, Result};
 
@@ -36,6 +37,212 @@ pub(crate) struct MergeProgress {
     pub(crate) worktree_removed: bool,
     pub(crate) branch_deleted: bool,
     pub(crate) push_done: bool,
+}
+
+/// An OS-backed owner for the repository's mutating merge lifecycle.
+///
+/// The file remains after the process exits, but the OS lock does not. This is
+/// intentional: process death therefore recovers without a PID-based timeout,
+/// while a paused Git hook keeps the lock until Git and its hook descendants
+/// finish. The handle is made inheritable so an orphaned Git subprocess cannot
+/// finalize a merge after its `wt-core` parent has died and the lock has been
+/// reclaimed.
+#[derive(Debug)]
+pub(crate) struct MergeLifecycleLock {
+    // The handle is intentionally retained for the entire lifecycle. Its OS
+    // lock is released automatically on normal drop or process death.
+    _file: fs::File,
+    operation_id: String,
+}
+
+impl MergeLifecycleLock {
+    pub(crate) fn operation_id(&self) -> &str {
+        &self.operation_id
+    }
+}
+
+/// Acquire the repository-wide mutating merge lifecycle lock.
+///
+/// Status deliberately does not call this function. Every command that can
+/// run Git or change the journal must hold the returned handle until its last
+/// durable action has completed.
+pub(crate) fn acquire_merge_lifecycle_lock(path: &Path) -> Result<MergeLifecycleLock> {
+    let parent = path.parent().ok_or_else(|| {
+        AppError::invariant(format!(
+            "managed merge lock path '{}' has no parent",
+            path.display()
+        ))
+    })?;
+    ensure_private_directory(parent)?;
+
+    let mut options = fs::OpenOptions::new();
+    options.create(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path).map_err(|error| {
+        AppError::git(format!(
+            "cannot open managed merge lifecycle lock '{}': {error}",
+            path.display()
+        ))
+    })?;
+    ensure_private_file(path)?;
+
+    if !try_lock_exclusive(&file).map_err(|error| {
+        AppError::git(format!(
+            "cannot acquire managed merge lifecycle lock '{}': {error}",
+            path.display()
+        ))
+    })? {
+        let owner = fs::read_to_string(path)
+            .ok()
+            .map(|contents| contents.trim().replace('\n', "; "))
+            .filter(|contents| !contents.is_empty())
+            .unwrap_or_else(|| "owner details are not yet available".to_string());
+        return Err(AppError::conflict(format!(
+            "managed merge lifecycle is busy ({owner}); wait for the live owner to finish, inspect with `wt merge --status`, then retry `wt merge`, `wt merge --continue`, or `wt merge --abort` as appropriate"
+        )));
+    }
+
+    let operation_id = new_operation_id();
+    let owner = format!(
+        "pid={}\noperation_id={}\n",
+        std::process::id(),
+        operation_id
+    );
+    file.set_len(0)
+        .and_then(|_| file.seek(SeekFrom::Start(0)))
+        .and_then(|_| file.write_all(owner.as_bytes()))
+        .and_then(|_| file.sync_all())
+        .map_err(|error| {
+            AppError::git(format!(
+                "cannot record managed merge lifecycle owner '{}': {error}",
+                path.display()
+            ))
+        })?;
+    make_inheritable(&file).map_err(|error| {
+        AppError::git(format!(
+            "cannot make managed merge lifecycle lock inheritable: {error}"
+        ))
+    })?;
+
+    Ok(MergeLifecycleLock {
+        _file: file,
+        operation_id,
+    })
+}
+
+fn new_operation_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("{}-{nanos}", std::process::id())
+}
+
+#[cfg(unix)]
+fn try_lock_exclusive(file: &fs::File) -> io::Result<bool> {
+    use std::os::fd::AsRawFd;
+
+    // SAFETY: the descriptor belongs to `file` and remains open for the call.
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if result == 0 {
+        return Ok(true);
+    }
+    let error = io::Error::last_os_error();
+    if error
+        .raw_os_error()
+        .is_some_and(|code| code == libc::EWOULDBLOCK || code == libc::EAGAIN)
+    {
+        Ok(false)
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(windows)]
+fn try_lock_exclusive(file: &fs::File) -> io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{GetLastError, ERROR_LOCK_VIOLATION};
+    use windows_sys::Win32::Storage::FileSystem::{
+        LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+    };
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let mut overlapped = OVERLAPPED::default();
+    // SAFETY: the file handle is owned by `file`; the overlapped structure is
+    // initialized and remains alive for the duration of the nonblocking call.
+    let result = unsafe {
+        LockFileEx(
+            file.as_raw_handle(),
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            u32::MAX,
+            u32::MAX,
+            &mut overlapped,
+        )
+    };
+    if result != 0 {
+        return Ok(true);
+    }
+    let error = unsafe { GetLastError() };
+    if error == ERROR_LOCK_VIOLATION {
+        Ok(false)
+    } else {
+        Err(io::Error::from_raw_os_error(error as i32))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn try_lock_exclusive(_file: &fs::File) -> io::Result<bool> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "managed merge lifecycle locking is unsupported on this platform",
+    ))
+}
+
+#[cfg(unix)]
+fn make_inheritable(file: &fs::File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let descriptor = file.as_raw_fd();
+    // SAFETY: the descriptor belongs to `file` and remains open for both calls.
+    let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: as above; clearing close-on-exec lets Git and its hooks retain
+    // the lifecycle lock until the mutating subprocess has fully exited.
+    if unsafe { libc::fcntl(descriptor, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn make_inheritable(file: &fs::File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{SetHandleInformation, HANDLE_FLAG_INHERIT};
+
+    // SAFETY: the handle belongs to `file` and remains valid for the call.
+    if unsafe {
+        SetHandleInformation(
+            file.as_raw_handle(),
+            HANDLE_FLAG_INHERIT,
+            HANDLE_FLAG_INHERIT,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn make_inheritable(_file: &fs::File) -> io::Result<()> {
+    Ok(())
 }
 
 /// Ensure the journal directory is private before creating or trusting a
@@ -204,5 +411,24 @@ mod tests {
         replace_existing(&temporary, &destination).expect("atomic replacement");
         assert_eq!(fs::read(&destination).expect("replacement"), b"new");
         assert!(!temporary.exists());
+    }
+
+    #[test]
+    fn lifecycle_locks_are_repository_local_and_released_by_drop() {
+        let first_repo = tempfile::tempdir().expect("first repository");
+        let second_repo = tempfile::tempdir().expect("second repository");
+        let first_path = first_repo.path().join("wt-core/merge-operation.lock");
+        let second_path = second_repo.path().join("wt-core/merge-operation.lock");
+
+        let first = acquire_merge_lifecycle_lock(&first_path).expect("first lock");
+        let busy = acquire_merge_lifecycle_lock(&first_path).expect_err("same repo is busy");
+        assert!(busy.message.contains("managed merge lifecycle is busy"));
+        let second = acquire_merge_lifecycle_lock(&second_path)
+            .expect("a distinct repository has an independent lifecycle");
+
+        drop(first);
+        let _recovered =
+            acquire_merge_lifecycle_lock(&first_path).expect("released lock is recoverable");
+        drop(second);
     }
 }

--- a/src/operation_state.rs
+++ b/src/operation_state.rs
@@ -1,0 +1,208 @@
+//! Durable merge-operation state primitives.
+//!
+//! The merge workflow owns the repository-specific state shape, while this
+//! module owns its typed lifecycle/progress values and the filesystem rules
+//! that make the journal safe to replace and recover.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use crate::error::{AppError, Result};
+
+/// Lifecycle phase persisted in the managed merge journal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MergePhase {
+    Starting,
+    Conflicted,
+    Committed,
+}
+
+impl MergePhase {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Conflicted => "conflicted",
+            Self::Committed => "committed",
+        }
+    }
+}
+
+/// Completed post-commit actions. These are deliberately grouped so a journal
+/// update cannot accidentally confuse the cleanup policy with action progress.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct MergeProgress {
+    pub(crate) worktree_removed: bool,
+    pub(crate) branch_deleted: bool,
+    pub(crate) push_done: bool,
+}
+
+/// Ensure the journal directory is private before creating or trusting a
+/// managed operation record. Refusing an existing insecure directory is safer
+/// than silently changing permissions on a directory another local user may
+/// intentionally share.
+pub(crate) fn ensure_private_directory(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(AppError::conflict(format!(
+                    "managed merge state directory '{}' is not a private directory",
+                    path.display()
+                )));
+            }
+            ensure_directory_mode(path)?;
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            fs::create_dir_all(path).map_err(|error| {
+                AppError::git(format!(
+                    "cannot create managed merge state directory '{}': {error}",
+                    path.display()
+                ))
+            })?;
+            // create_dir_all obeys umask, so enforce the mode after creation
+            // and check again for a concurrent replacement.
+            set_private_directory_mode(path)?;
+            ensure_directory_mode(path)?;
+        }
+        Err(error) => {
+            return Err(AppError::git(format!(
+                "cannot inspect managed merge state directory '{}': {error}",
+                path.display()
+            )))
+        }
+    }
+    Ok(())
+}
+
+/// Verify an existing journal is a regular private file. Missing files are
+/// handled by the caller because a status query may legitimately have none.
+pub(crate) fn ensure_private_file(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        AppError::git(format!(
+            "cannot inspect managed merge state '{}': {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(AppError::conflict(format!(
+            "managed merge state '{}' is not a private regular file",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o777 != 0o600 {
+            return Err(AppError::conflict(format!(
+                "managed merge state '{}' has insecure permissions (expected 0600)",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_directory_mode(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = fs::symlink_metadata(path)
+        .map_err(|error| AppError::git(format!("cannot inspect state directory: {error}")))?
+        .permissions()
+        .mode();
+    if mode & 0o077 != 0 {
+        return Err(AppError::conflict(format!(
+            "managed merge state directory '{}' has insecure permissions (expected 0700)",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_directory_mode(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_directory_mode(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700)).map_err(|error| {
+        AppError::git(format!(
+            "cannot make managed merge state directory '{}' private: {error}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn set_private_directory_mode(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Install a fully-written temporary file over the journal path.
+///
+/// `rename` replaces atomically on POSIX but fails when the destination exists
+/// on Windows. MoveFileEx(REPLACE_EXISTING | WRITE_THROUGH) provides the same
+/// replacement semantics on Windows without a delete-then-rename gap.
+pub(crate) fn replace_existing(temp: &Path, destination: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        fs::rename(temp, destination).map_err(|error| {
+            AppError::git(format!(
+                "cannot install managed merge state '{}': {error}",
+                destination.display()
+            ))
+        })
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
+
+        let source: Vec<u16> = temp.as_os_str().encode_wide().chain(Some(0)).collect();
+        let target: Vec<u16> = destination
+            .as_os_str()
+            .encode_wide()
+            .chain(Some(0))
+            .collect();
+        // SAFETY: both vectors are NUL-terminated and remain alive for the
+        // duration of the OS call; MoveFileExW does not retain the pointers.
+        let result = unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                target.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result == 0 {
+            return Err(AppError::git(format!(
+                "cannot install managed merge state '{}': {}",
+                destination.display(),
+                io::Error::last_os_error()
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replacement_replaces_an_existing_record() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let destination = directory.path().join("merge-operation.json");
+        let temporary = directory.path().join("merge-operation.json.tmp");
+        fs::write(&destination, b"old").expect("old record");
+        fs::write(&temporary, b"new").expect("new record");
+
+        replace_existing(&temporary, &destination).expect("atomic replacement");
+        assert_eq!(fs::read(&destination).expect("replacement"), b"new");
+        assert!(!temporary.exists());
+    }
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -480,6 +480,9 @@ pub struct JsonMergeOperation {
     pub push: bool,
     pub cleanup: bool,
     pub keep_branch: bool,
+    pub worktree_removed: bool,
+    pub branch_deleted: bool,
+    pub push_done: bool,
     pub pending_actions: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery: Option<String>,
@@ -509,6 +512,7 @@ pub struct JsonMergeResponse {
     pub destination_path: String,
     pub repo_root: String,
     pub cleaned_up: bool,
+    pub branch_deleted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub removed_path: Option<String>,
     pub pushed: bool,

--- a/src/output.rs
+++ b/src/output.rs
@@ -464,6 +464,38 @@ fn is_false(value: &bool) -> bool {
     !value
 }
 
+/// Durable state and pending actions for a managed merge operation.
+#[derive(Debug, Serialize)]
+pub struct JsonMergeOperation {
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination_path: Option<String>,
+    pub unresolved_paths: Vec<String>,
+    pub push: bool,
+    pub cleanup: bool,
+    pub keep_branch: bool,
+    pub pending_actions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_path: Option<String>,
+}
+
+/// JSON response for `merge --status`, `--continue`, and `--abort` errors.
+#[derive(Debug, Serialize)]
+pub struct JsonMergeOperationResponse {
+    pub ok: bool,
+    pub message: String,
+    #[serde(flatten)]
+    pub operation: JsonMergeOperation,
+}
+
 /// JSON response for the merge command.
 #[derive(Debug, Serialize)]
 pub struct JsonMergeResponse {
@@ -487,6 +519,8 @@ pub struct JsonMergeResponse {
     pub preflight: Option<JsonMergePreflight>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refusal: Option<JsonMergeRefusal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation: Option<JsonMergeOperation>,
     /// True when this response came from `merge --inspect`.
     #[serde(skip_serializing_if = "is_false")]
     pub inspect: bool,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -909,6 +909,13 @@ pub enum SourceHistory {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct MergeOperationState {
     schema: u32,
+    /// Stable identity for one merge lifecycle. Journal mutations must never
+    /// cross this boundary, even if a stale process wakes after recovery.
+    #[serde(default)]
+    operation_id: String,
+    /// Monotonic journal generation used as the compare-and-swap version.
+    #[serde(default)]
+    generation: u64,
     phase: MergePhase,
     source: String,
     destination: String,
@@ -1003,9 +1010,13 @@ fn merge_operation_file(repo: &RepoRoot) -> Result<MergeOperationFile> {
     };
 
     match serde_json::from_str::<MergeOperationState>(&contents) {
-        Ok(state) if state.schema == MERGE_OPERATION_SCHEMA => {
+        Ok(state) if state.schema == MERGE_OPERATION_SCHEMA && !state.operation_id.is_empty() => {
             Ok(MergeOperationFile::Valid(Box::new(state)))
         }
+        Ok(state) if state.schema == MERGE_OPERATION_SCHEMA => Ok(MergeOperationFile::Corrupt {
+            path,
+            reason: "managed merge state has no operation identity".to_string(),
+        }),
         Ok(state) => Ok(MergeOperationFile::Corrupt {
             path,
             reason: format!("unsupported state schema {}", state.schema),
@@ -1180,10 +1191,37 @@ fn sync_operation_parent(_parent: &Path) -> Result<()> {
     Ok(())
 }
 
+fn verify_operation_generation(repo: &RepoRoot, expected: &MergeOperationState) -> Result<()> {
+    match merge_operation_file(repo)? {
+        MergeOperationFile::Valid(current)
+            if current.operation_id == expected.operation_id
+                && current.generation == expected.generation =>
+        {
+            Ok(())
+        }
+        MergeOperationFile::Valid(current) => Err(AppError::conflict(format!(
+            "managed merge state belongs to operation '{}' generation {}; refusing to overwrite operation '{}' generation {}",
+            current.operation_id,
+            current.generation,
+            expected.operation_id,
+            expected.generation
+        ))),
+        MergeOperationFile::Missing => Err(AppError::conflict(
+            "managed merge state disappeared before its compare-and-swap update; preserving the Git operation"
+                .to_string(),
+        )),
+        MergeOperationFile::Corrupt { path, reason } => Err(AppError::conflict(format!(
+            "managed merge state at '{}' changed before its compare-and-swap update ({reason}); preserving it",
+            path.display()
+        ))),
+    }
+}
+
 fn write_operation_state_inner(
     repo: &RepoRoot,
     state: &MergeOperationState,
     create_only: bool,
+    expected: Option<&MergeOperationState>,
 ) -> Result<()> {
     let path = git::merge_operation_path(repo)?;
     let parent = path.parent().ok_or_else(|| {
@@ -1193,6 +1231,9 @@ fn write_operation_state_inner(
         ))
     })?;
     operation_state::ensure_private_directory(parent)?;
+    if let Some(expected) = expected {
+        verify_operation_generation(repo, expected)?;
+    }
     let bytes = serde_json::to_vec_pretty(state).map_err(|error| {
         AppError::invariant(format!("cannot encode managed merge state: {error}"))
     })?;
@@ -1236,30 +1277,42 @@ fn write_operation_state_inner(
             }
         },
         false => {
-            match fs::symlink_metadata(&path) {
-                Ok(_) => operation_state::ensure_private_file(&path)?,
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => {
+            // Recheck immediately before replacement. The lifecycle lock is
+            // the synchronization boundary, while this generation check makes
+            // stale callers fail closed even if they bypass that boundary.
+            if let Some(expected) = expected {
+                verify_operation_generation(repo, expected).map_err(|error| {
                     let _ = fs::remove_file(&temp);
-                    return Err(AppError::git(format!(
-                        "cannot inspect managed merge state '{}': {error}",
-                        path.display()
-                    )));
-                }
+                    error
+                })?;
             }
-            operation_state::replace_existing(&temp, &path)?;
+            if let Err(error) = operation_state::ensure_private_file(&path) {
+                let _ = fs::remove_file(&temp);
+                return Err(error);
+            }
+            if let Err(error) = operation_state::replace_existing(&temp, &path) {
+                let _ = fs::remove_file(&temp);
+                return Err(error);
+            }
         }
     }
     sync_operation_parent(parent)?;
     Ok(())
 }
 
-fn write_operation_state(repo: &RepoRoot, state: &MergeOperationState) -> Result<()> {
-    write_operation_state_inner(repo, state, false)
+fn write_operation_state(repo: &RepoRoot, state: &mut MergeOperationState) -> Result<()> {
+    let next_generation = state.generation.checked_add(1).ok_or_else(|| {
+        AppError::invariant("managed merge state generation exhausted".to_string())
+    })?;
+    let mut next = state.clone();
+    next.generation = next_generation;
+    write_operation_state_inner(repo, &next, false, Some(state))?;
+    state.generation = next_generation;
+    Ok(())
 }
 
 fn create_operation_state(repo: &RepoRoot, state: &MergeOperationState) -> Result<()> {
-    write_operation_state_inner(repo, state, true)
+    write_operation_state_inner(repo, state, true, None)
 }
 
 /// Remove the operation record only after atomically detaching and verifying
@@ -1304,8 +1357,20 @@ fn clear_operation_state(repo: &RepoRoot, expected: &MergeOperationState) -> Res
         .as_deref()
         .ok()
         .and_then(|value| serde_json::from_str::<MergeOperationState>(value).ok());
-    if current.as_ref() != Some(expected) {
-        let _ = (!path.exists()).then(|| fs::rename(&tombstone, &path));
+    let matches_generation = current.as_ref().is_some_and(|current| {
+        current.operation_id == expected.operation_id && current.generation == expected.generation
+    });
+    if !matches_generation {
+        match path.exists() {
+            false => {
+                let _ = fs::rename(&tombstone, &path);
+            }
+            true => {
+                // The canonical path is another operation. Remove only the
+                // detached record that we already proved was not its journal.
+                let _ = fs::remove_file(&tombstone);
+            }
+        }
         return Err(AppError::conflict(
             "managed merge state changed while the operation was running; refusing to clear the replacement".to_string(),
         ));
@@ -2054,9 +2119,12 @@ fn merge_state_from_preflight(
     destination_head: String,
     push: bool,
     no_cleanup: bool,
+    operation_id: &str,
 ) -> MergeOperationState {
     MergeOperationState {
         schema: MERGE_OPERATION_SCHEMA,
+        operation_id: operation_id.to_string(),
+        generation: 0,
         phase: MergePhase::Starting,
         source: preflight.source.clone(),
         destination: preflight.destination.clone(),
@@ -2087,6 +2155,16 @@ fn merge_state_from_preflight(
             ..MergeProgress::default()
         },
     }
+}
+
+/// Acquire the one owner allowed to mutate a repository's merge lifecycle.
+///
+/// Read-only status intentionally does not acquire this lock.
+pub(crate) fn acquire_merge_lifecycle_lock(
+    repo: &RepoRoot,
+) -> Result<operation_state::MergeLifecycleLock> {
+    let path = git::merge_operation_lock_path(repo)?;
+    operation_state::acquire_merge_lifecycle_lock(&path)
 }
 
 fn load_valid_merge_state(repo: &RepoRoot) -> Result<(PathBuf, MergeOperationState)> {
@@ -2407,11 +2485,12 @@ fn continue_merge_commit(
 
 /// Continue a managed merge after its conflicts have been resolved.
 pub fn merge_continue(repo: &RepoRoot) -> Result<MergeResult> {
+    let _lifecycle_lock = acquire_merge_lifecycle_lock(repo)?;
     let (_, mut state) = load_valid_merge_state(repo)?;
     if reconcile_operation_progress(repo, &mut state)? {
         // A prior action or the commit itself may have completed before its
         // progress write. Persist reconciliation before taking another action.
-        write_operation_state(repo, &state)?;
+        write_operation_state(repo, &mut state)?;
     }
     let report = merge_operation_status(repo)?;
     if matches!(report.state.as_str(), "stale" | "interrupted" | "corrupt") {
@@ -2442,6 +2521,7 @@ pub fn merge_continue(repo: &RepoRoot) -> Result<MergeResult> {
 
 /// Abort a managed merge and clear only the matching operation record.
 pub fn merge_abort_operation(repo: &RepoRoot) -> Result<MergeOperationReport> {
+    let _lifecycle_lock = acquire_merge_lifecycle_lock(repo)?;
     let (_, state) = load_valid_merge_state(repo)?;
     let report = merge_operation_status(repo)?;
     if matches!(report.state.as_str(), "stale" | "interrupted" | "corrupt") {
@@ -2533,11 +2613,12 @@ fn handle_merge_failure(
 }
 
 /// Run a merge using an already collected preflight.
-pub fn merge_with_preflight(
+pub(crate) fn merge_with_preflight(
     repo: &RepoRoot,
     preflight: MergePreflight,
     push: bool,
     no_cleanup: bool,
+    lifecycle_lock: &operation_state::MergeLifecycleLock,
 ) -> std::result::Result<MergeResult, MergeFailure> {
     if let Some(refusal) = &preflight.refusal {
         return Err(MergeFailure {
@@ -2575,8 +2656,14 @@ pub fn merge_with_preflight(
             });
         }
     };
-    let mut operation =
-        merge_state_from_preflight(&preflight, source_head, destination_head, push, no_cleanup);
+    let mut operation = merge_state_from_preflight(
+        &preflight,
+        source_head,
+        destination_head,
+        push,
+        no_cleanup,
+        lifecycle_lock.operation_id(),
+    );
 
     // Never overwrite an operation that may require recovery. This also
     // keeps a stale or corrupt record from being silently detached from the
@@ -2634,7 +2721,7 @@ pub fn merge_with_preflight(
         })?;
     operation.phase = MergePhase::Committed;
     operation.completed_destination_head = Some(expected);
-    if let Err(error) = write_operation_state(repo, &operation) {
+    if let Err(error) = write_operation_state(repo, &mut operation) {
         return Err(MergeFailure {
             kind: MergeFailureKind::GitFailure,
             error: AppError::git(format!(

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -972,18 +972,11 @@ enum MergeOperationFile {
 
 fn merge_operation_file(repo: &RepoRoot) -> Result<MergeOperationFile> {
     let path = git::merge_operation_path(repo)?;
-    if let Some(error) = path
-        .parent()
-        .and_then(|parent| operation_state::ensure_private_directory(parent).err())
-    {
-        return Ok(MergeOperationFile::Corrupt {
-            path,
-            reason: error.message,
-        });
-    }
     match fs::symlink_metadata(&path) {
         Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // A status query must not initialize the journal namespace just to
+            // discover that there is no operation to report.
             return Ok(MergeOperationFile::Missing);
         }
         Err(error) => {
@@ -992,6 +985,15 @@ fn merge_operation_file(repo: &RepoRoot) -> Result<MergeOperationFile> {
                 reason: format!("cannot inspect state file: {error}"),
             });
         }
+    }
+    if let Some(error) = path
+        .parent()
+        .and_then(|parent| operation_state::ensure_private_directory(parent).err())
+    {
+        return Ok(MergeOperationFile::Corrupt {
+            path,
+            reason: error.message,
+        });
     }
     if let Err(error) = operation_state::ensure_private_file(&path) {
         return Ok(MergeOperationFile::Corrupt {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,5 +1,8 @@
 use std::collections::HashSet;
+use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::domain::{BranchName, RepoRoot, Worktree};
 use crate::error::{AppError, Result};
@@ -928,7 +931,7 @@ pub fn doctor(repo: &RepoRoot) -> Result<Vec<Diagnostic>> {
 }
 
 /// How the destination branch relates to its configured upstream.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MergeTopology {
     NoUpstream,
@@ -940,12 +943,570 @@ pub enum MergeTopology {
 }
 
 /// History relationship between the source branch and destination history.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceHistory {
     NotMerged,
     AlreadyMerged,
     MergedThenReverted,
+}
+
+/// The repository-local record that binds a conflicted Git merge to its
+/// original source and destination worktree registrations.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct MergeOperationState {
+    schema: u32,
+    phase: String,
+    source: String,
+    destination: String,
+    source_path: PathBuf,
+    destination_path: PathBuf,
+    source_identity: git::WorktreeIdentity,
+    destination_identity: git::WorktreeIdentity,
+    source_head: String,
+    destination_head: String,
+    merge_head: Option<String>,
+    completed_destination_head: Option<String>,
+    upstream: Option<String>,
+    ahead: Option<u32>,
+    behind: Option<u32>,
+    topology: MergeTopology,
+    source_history: SourceHistory,
+    source_was_merged: bool,
+    source_was_reverted: bool,
+    reverted_commit: Option<String>,
+    push: bool,
+    cleanup: bool,
+    keep_branch: bool,
+    worktree_removed: bool,
+    branch_deleted: bool,
+    push_done: bool,
+}
+
+const MERGE_OPERATION_SCHEMA: u32 = 1;
+
+/// Read-only status of the managed merge operation.
+#[derive(Debug, Clone)]
+pub struct MergeOperationReport {
+    pub state: String,
+    pub source: Option<String>,
+    pub destination: Option<String>,
+    pub source_path: Option<PathBuf>,
+    pub destination_path: Option<PathBuf>,
+    pub unresolved_paths: Vec<String>,
+    pub push: bool,
+    pub cleanup: bool,
+    pub keep_branch: bool,
+    pub pending_actions: Vec<String>,
+    pub recovery: Option<String>,
+    pub state_path: PathBuf,
+}
+
+enum MergeOperationFile {
+    Missing,
+    Valid(Box<MergeOperationState>),
+    Corrupt { path: PathBuf, reason: String },
+}
+
+fn merge_operation_file(repo: &RepoRoot) -> Result<MergeOperationFile> {
+    let path = git::merge_operation_path(repo)?;
+    let contents = match fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(MergeOperationFile::Missing);
+        }
+        Err(error) => {
+            return Ok(MergeOperationFile::Corrupt {
+                path,
+                reason: format!("cannot read state file: {error}"),
+            });
+        }
+    };
+
+    match serde_json::from_str::<MergeOperationState>(&contents) {
+        Ok(state) if state.schema == MERGE_OPERATION_SCHEMA => {
+            if valid_operation_phase(&state.phase) {
+                Ok(MergeOperationFile::Valid(Box::new(state)))
+            } else {
+                Ok(MergeOperationFile::Corrupt {
+                    path,
+                    reason: format!("unsupported operation phase '{}'", state.phase),
+                })
+            }
+        }
+        Ok(state) => Ok(MergeOperationFile::Corrupt {
+            path,
+            reason: format!("unsupported state schema {}", state.schema),
+        }),
+        Err(error) => Ok(MergeOperationFile::Corrupt {
+            path,
+            reason: format!("invalid JSON: {error}"),
+        }),
+    }
+}
+
+fn valid_operation_phase(phase: &str) -> bool {
+    matches!(phase, "starting" | "conflicted" | "committed")
+}
+
+fn operation_report_base(state: &MergeOperationState, state_path: PathBuf) -> MergeOperationReport {
+    MergeOperationReport {
+        state: state.phase.clone(),
+        source: Some(state.source.clone()),
+        destination: Some(state.destination.clone()),
+        source_path: Some(state.source_path.clone()),
+        destination_path: Some(state.destination_path.clone()),
+        unresolved_paths: Vec::new(),
+        push: state.push,
+        cleanup: state.cleanup,
+        keep_branch: state.keep_branch,
+        pending_actions: Vec::new(),
+        recovery: None,
+        state_path,
+    }
+}
+
+fn no_operation_report(state_path: PathBuf) -> MergeOperationReport {
+    MergeOperationReport {
+        state: "none".to_string(),
+        source: None,
+        destination: None,
+        source_path: None,
+        destination_path: None,
+        unresolved_paths: Vec::new(),
+        push: false,
+        cleanup: false,
+        keep_branch: false,
+        pending_actions: Vec::new(),
+        recovery: None,
+        state_path,
+    }
+}
+
+fn corrupt_operation_report(path: PathBuf, reason: String) -> MergeOperationReport {
+    MergeOperationReport {
+        state: "corrupt".to_string(),
+        source: None,
+        destination: None,
+        source_path: None,
+        destination_path: None,
+        unresolved_paths: Vec::new(),
+        push: false,
+        cleanup: false,
+        keep_branch: false,
+        pending_actions: Vec::new(),
+        recovery: Some(format!(
+            "managed merge state is corrupt ({reason}); preserve '{}', inspect the destination, and repair or remove the state only after recovery",
+            path.display()
+        )),
+        state_path: path,
+    }
+}
+
+fn pending_operation_actions(
+    state: &MergeOperationState,
+    phase: &str,
+    unresolved: &[String],
+) -> Vec<String> {
+    let mut actions = Vec::new();
+    let merge_action = match (
+        matches!(phase, "starting" | "conflicted"),
+        unresolved.is_empty(),
+    ) {
+        (true, true) => Some("run `wt merge --continue` to create the merge commit"),
+        (true, false) => Some("resolve the listed paths, then run `wt merge --continue`"),
+        _ => None,
+    };
+    if let Some(action) = merge_action {
+        actions.push(action.to_string());
+    }
+    let cleanup_action = match (state.cleanup, state.worktree_removed, state.branch_deleted) {
+        (true, true, false) => Some("remove the source branch"),
+        (true, false, _) => Some("remove the source worktree and branch"),
+        _ => None,
+    };
+    if let Some(action) = cleanup_action {
+        actions.push(action.to_string());
+    }
+    if state.push && !state.push_done {
+        actions.push(format!("push {} to origin", state.destination));
+    }
+    actions
+}
+
+fn stale_operation_report(
+    state: &MergeOperationState,
+    state_path: PathBuf,
+    reason: impl Into<String>,
+) -> MergeOperationReport {
+    let mut report = operation_report_base(state, state_path.clone());
+    report.state = "stale".to_string();
+    report.recovery = Some(format!(
+        "managed merge state is stale ({}) and was not changed; inspect '{}' and the destination, then finish or abort the Git operation manually before removing the state",
+        reason.into(),
+        state_path.display()
+    ));
+    report
+}
+
+fn interrupted_operation_report(
+    state: &MergeOperationState,
+    state_path: PathBuf,
+) -> MergeOperationReport {
+    let mut report = operation_report_base(state, state_path.clone());
+    report.state = "interrupted".to_string();
+    report.recovery = Some(format!(
+        "Git no longer has the merge recorded for this state; inspect '{}' and the destination before manually completing or restoring it, then clear the state",
+        state_path.display()
+    ));
+    report
+}
+
+fn operation_preflight(state: &MergeOperationState) -> MergePreflight {
+    MergePreflight {
+        source: state.source.clone(),
+        source_path: state.source_path.clone(),
+        source_identity: state.source_identity.clone(),
+        destination: state.destination.clone(),
+        destination_path: state.destination_path.clone(),
+        destination_identity: state.destination_identity.clone(),
+        upstream: state.upstream.clone(),
+        ahead: state.ahead,
+        behind: state.behind,
+        topology: state.topology,
+        source_history: state.source_history,
+        source_was_merged: state.source_was_merged,
+        source_was_reverted: state.source_was_reverted,
+        reverted_commit: state.reverted_commit.clone(),
+        allowed: true,
+        refusal: None,
+    }
+}
+
+#[cfg(unix)]
+fn sync_operation_parent(parent: &Path) -> Result<()> {
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| {
+            AppError::git(format!(
+                "cannot flush managed merge state directory: {error}"
+            ))
+        })
+}
+
+#[cfg(not(unix))]
+fn sync_operation_parent(_parent: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn write_operation_state_inner(
+    repo: &RepoRoot,
+    state: &MergeOperationState,
+    create_only: bool,
+) -> Result<()> {
+    let path = git::merge_operation_path(repo)?;
+    let parent = path.parent().ok_or_else(|| {
+        AppError::invariant(format!(
+            "managed merge state path '{}' has no parent",
+            path.display()
+        ))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        AppError::git(format!(
+            "cannot create managed merge state directory: {error}"
+        ))
+    })?;
+    let bytes = serde_json::to_vec_pretty(state).map_err(|error| {
+        AppError::invariant(format!("cannot encode managed merge state: {error}"))
+    })?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let temp = path.with_file_name(format!(
+        ".merge-operation.json.tmp.{}.{}",
+        std::process::id(),
+        nonce
+    ));
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temp)
+        .map_err(|error| AppError::git(format!("cannot write managed merge state: {error}")))?;
+    file.write_all(&bytes)
+        .and_then(|_| file.sync_all())
+        .map_err(|error| AppError::git(format!("cannot flush managed merge state: {error}")))?;
+    match create_only {
+        true => match fs::hard_link(&temp, &path) {
+            Ok(()) => {
+                fs::remove_file(&temp).map_err(|error| {
+                    AppError::git(format!(
+                        "cannot remove temporary managed merge state: {error}"
+                    ))
+                })?;
+            }
+            Err(error) => {
+                let _ = fs::remove_file(&temp);
+                return Err(AppError::conflict(format!(
+                    "cannot claim managed merge state: {error}"
+                )));
+            }
+        },
+        false => {
+            fs::rename(&temp, &path).map_err(|error| {
+                AppError::git(format!("cannot install managed merge state: {error}"))
+            })?;
+        }
+    }
+    sync_operation_parent(parent)?;
+    Ok(())
+}
+
+fn write_operation_state(repo: &RepoRoot, state: &MergeOperationState) -> Result<()> {
+    write_operation_state_inner(repo, state, false)
+}
+
+fn create_operation_state(repo: &RepoRoot, state: &MergeOperationState) -> Result<()> {
+    write_operation_state_inner(repo, state, true)
+}
+
+/// Remove the operation record only after atomically detaching and verifying
+/// the exact bytes that were expected. If another writer installs a
+/// replacement between the read and rename, that replacement stays at the
+/// canonical path and the expected record is retained as recovery evidence.
+fn clear_operation_state(repo: &RepoRoot, expected: &MergeOperationState) -> Result<()> {
+    let path = git::merge_operation_path(repo)?;
+    let parent = path.parent().ok_or_else(|| {
+        AppError::invariant(format!(
+            "managed merge state path '{}' has no parent",
+            path.display()
+        ))
+    })?;
+    let tombstone = path.with_file_name(format!(
+        ".merge-operation.json.removing.{}.{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default()
+    ));
+
+    if !path.exists() {
+        return Ok(());
+    }
+    fs::rename(&path, &tombstone).map_err(|error| {
+        AppError::conflict(format!(
+            "cannot detach managed merge state before clearing it: {error}"
+        ))
+    })?;
+
+    let contents = fs::read_to_string(&tombstone);
+    let current = contents
+        .as_deref()
+        .ok()
+        .and_then(|value| serde_json::from_str::<MergeOperationState>(value).ok());
+    if current.as_ref() != Some(expected) {
+        let _ = (!path.exists()).then(|| fs::rename(&tombstone, &path));
+        return Err(AppError::conflict(
+            "managed merge state changed while the operation was running; refusing to clear the replacement".to_string(),
+        ));
+    }
+
+    fs::remove_file(&tombstone)
+        .map_err(|error| AppError::git(format!("cannot clear managed merge state: {error}")))?;
+    sync_operation_parent(parent)?;
+    Ok(())
+}
+
+fn state_worktree<'a>(
+    worktrees: &'a [Worktree],
+    path: &Path,
+    branch: &str,
+) -> Option<&'a Worktree> {
+    worktrees
+        .iter()
+        .find(|wt| wt.path == path && wt.branch.as_deref() == Some(branch))
+}
+
+fn validate_operation_worktree(
+    repo: &RepoRoot,
+    worktree: &Worktree,
+    role: &str,
+    expected: &git::WorktreeIdentity,
+) -> Result<()> {
+    let actual = validate_merge_worktree(repo, worktree, role)?;
+    if actual != *expected {
+        return Err(identity_changed(
+            role,
+            worktree.branch.as_deref().unwrap_or("(detached)"),
+            &worktree.path,
+            expected,
+            &actual,
+        ));
+    }
+    Ok(())
+}
+
+fn finish_committed_report(
+    mut report: MergeOperationReport,
+    state: &MergeOperationState,
+) -> MergeOperationReport {
+    report.pending_actions = pending_operation_actions(state, "committed", &[]);
+    report.state = if report.pending_actions.is_empty() {
+        "complete".to_string()
+    } else {
+        "committed".to_string()
+    };
+    report
+}
+
+fn inspect_committed_operation(
+    repo: &RepoRoot,
+    state: &MergeOperationState,
+    state_path: PathBuf,
+    worktrees: &[Worktree],
+    report: MergeOperationReport,
+) -> Result<MergeOperationReport> {
+    let Some(expected_head) = &state.completed_destination_head else {
+        return Ok(stale_operation_report(
+            state,
+            state_path,
+            "completed destination HEAD is missing",
+        ));
+    };
+    let actual_head = git::head_commit(&state.destination_path)?;
+    if &actual_head != expected_head {
+        return Ok(stale_operation_report(
+            state,
+            state_path,
+            "destination HEAD changed after the merge commit",
+        ));
+    }
+    if state.worktree_removed {
+        return Ok(finish_committed_report(report, state));
+    }
+
+    let Some(source) = state_worktree(worktrees, &state.source_path, &state.source) else {
+        return Ok(stale_operation_report(
+            state,
+            state_path,
+            "source worktree disappeared before cleanup completed",
+        ));
+    };
+    if let Err(error) = validate_operation_worktree(repo, source, "source", &state.source_identity)
+    {
+        return Ok(stale_operation_report(state, state_path, error.message));
+    }
+    if git::head_commit(&state.source_path)? != state.source_head {
+        return Ok(stale_operation_report(
+            state,
+            state_path,
+            "source branch HEAD changed after the merge began",
+        ));
+    }
+    Ok(finish_committed_report(report, state))
+}
+
+fn inspect_operation_state(
+    repo: &RepoRoot,
+    state: &MergeOperationState,
+    state_path: PathBuf,
+) -> Result<MergeOperationReport> {
+    let mut report = operation_report_base(state, state_path.clone());
+    let worktrees = git::list_worktrees_readonly(repo)?;
+    let destination = match state_worktree(&worktrees, &state.destination_path, &state.destination)
+    {
+        Some(destination) => destination,
+        None => {
+            return Ok(stale_operation_report(
+                state,
+                state_path,
+                "destination path or branch no longer matches",
+            ))
+        }
+    };
+    if let Err(error) = validate_operation_worktree(
+        repo,
+        destination,
+        "destination",
+        &state.destination_identity,
+    ) {
+        return Ok(stale_operation_report(state, state_path, error.message));
+    }
+
+    if state.phase == "committed" {
+        return inspect_committed_operation(repo, state, state_path, &worktrees, report);
+    }
+
+    let Some(source) = state_worktree(&worktrees, &state.source_path, &state.source) else {
+        return Ok(stale_operation_report(
+            state,
+            state_path,
+            "source path or branch no longer matches",
+        ));
+    };
+    if let Err(error) = validate_operation_worktree(repo, source, "source", &state.source_identity)
+    {
+        return Ok(stale_operation_report(state, state_path, error.message));
+    }
+    if git::head_commit(&state.source_path)? != state.source_head {
+        return Ok(stale_operation_report(
+            state,
+            state_path,
+            "source branch HEAD changed while the merge was paused",
+        ));
+    }
+    if git::head_commit(&state.destination_path)? != state.destination_head {
+        return Ok(stale_operation_report(
+            state,
+            state_path,
+            "destination HEAD changed while the merge was paused",
+        ));
+    }
+
+    match git::operation_state(&state.destination_path)? {
+        Some("merge") => {
+            if git::merge_head(&state.destination_path)? != state.merge_head {
+                return Ok(stale_operation_report(
+                    state,
+                    state_path,
+                    "MERGE_HEAD does not match the recorded source",
+                ));
+            }
+            report.unresolved_paths = git::unmerged_paths(&state.destination_path)?;
+            report.state = if report.unresolved_paths.is_empty() {
+                "ready".to_string()
+            } else {
+                "conflicted".to_string()
+            };
+            report.pending_actions =
+                pending_operation_actions(state, &report.state, &report.unresolved_paths);
+            Ok(report)
+        }
+        Some(other) => Ok(stale_operation_report(
+            state,
+            state_path,
+            format!("destination has a different {other} operation in progress"),
+        )),
+        None => Ok(interrupted_operation_report(state, state_path)),
+    }
+}
+
+/// Return the current managed merge status without pruning worktree metadata.
+pub fn merge_operation_status(repo: &RepoRoot) -> Result<MergeOperationReport> {
+    let path = git::merge_operation_path(repo)?;
+    match merge_operation_file(repo)? {
+        MergeOperationFile::Missing => Ok(no_operation_report(path)),
+        MergeOperationFile::Corrupt { path, reason } => Ok(corrupt_operation_report(path, reason)),
+        MergeOperationFile::Valid(state) => inspect_operation_state(repo, &state, path),
+    }
+}
+
+/// Return a report for an operation file after a merge failure, if one exists.
+pub fn merge_operation_report_if_present(repo: &RepoRoot) -> Option<MergeOperationReport> {
+    merge_operation_status(repo)
+        .ok()
+        .filter(|report| report.state != "none")
 }
 
 /// A refusal identified before Git's content merge starts.
@@ -1407,7 +1968,7 @@ fn classify_merge_failure(
     };
     let error = match kind {
         MergeFailureKind::ContentConflict => AppError::conflict(format!(
-            "content merge conflicts with '{}' — merge aborted; use `git merge` directly to handle conflicts\n{error}",
+            "content merge conflicts with '{}' — resolve the listed paths, then run `wt merge --continue`; use `wt merge --abort` to restore the destination\n{error}",
             target_branch
         )),
         MergeFailureKind::GitFailure => AppError {
@@ -1425,6 +1986,345 @@ fn partial_success_warning(action: &str, replacement_action: &str, error: &AppEr
         )
     } else {
         format!("merge succeeded but {action} failed: {error}")
+    }
+}
+
+fn merge_state_from_preflight(
+    preflight: &MergePreflight,
+    source_head: String,
+    destination_head: String,
+    push: bool,
+    no_cleanup: bool,
+) -> MergeOperationState {
+    MergeOperationState {
+        schema: MERGE_OPERATION_SCHEMA,
+        phase: "starting".to_string(),
+        source: preflight.source.clone(),
+        destination: preflight.destination.clone(),
+        source_path: preflight.source_path.clone(),
+        destination_path: preflight.destination_path.clone(),
+        source_identity: preflight.source_identity.clone(),
+        destination_identity: preflight.destination_identity.clone(),
+        source_head,
+        destination_head,
+        merge_head: None,
+        completed_destination_head: None,
+        upstream: preflight.upstream.clone(),
+        ahead: preflight.ahead,
+        behind: preflight.behind,
+        topology: preflight.topology,
+        source_history: preflight.source_history,
+        source_was_merged: preflight.source_was_merged,
+        source_was_reverted: preflight.source_was_reverted,
+        reverted_commit: preflight.reverted_commit.clone(),
+        push,
+        cleanup: !no_cleanup,
+        keep_branch: no_cleanup,
+        // These flags describe completed cleanup actions, not the policy. A
+        // no-cleanup operation still needs its source identity revalidated
+        // while it is paused.
+        worktree_removed: false,
+        branch_deleted: false,
+        push_done: !push,
+    }
+}
+
+fn load_valid_merge_state(repo: &RepoRoot) -> Result<(PathBuf, MergeOperationState)> {
+    let path = git::merge_operation_path(repo)?;
+    match merge_operation_file(repo)? {
+        MergeOperationFile::Valid(state) => Ok((path, *state)),
+        MergeOperationFile::Missing => Err(AppError::conflict(
+            "no managed merge operation is recorded; start or inspect the merge manually, then use `wt merge --status`"
+                .to_string(),
+        )),
+        MergeOperationFile::Corrupt { path, reason } => Err(AppError::conflict(format!(
+            "managed merge state is corrupt ({reason}); preserve '{}', recover the destination manually, and do not retry until it is repaired",
+            path.display()
+        ))),
+    }
+}
+
+fn operation_recovery_error(report: &MergeOperationReport) -> AppError {
+    AppError::conflict(
+        report
+            .recovery
+            .clone()
+            .unwrap_or_else(|| format!("managed merge operation is in '{}' state", report.state)),
+    )
+}
+
+fn cleanup_merge_operation(
+    repo: &RepoRoot,
+    state: &mut MergeOperationState,
+    preflight: &MergePreflight,
+    warnings: &mut Vec<String>,
+) -> Result<Option<PathBuf>> {
+    if !state.cleanup {
+        return Ok(None);
+    }
+
+    let removed_path = if state.worktree_removed {
+        Some(state.source_path.clone())
+    } else {
+        let (source, _) = validate_preflight_worktrees(repo, preflight, "source", "destination")?;
+        if git::head_commit(&source.path)? != state.source_head {
+            return Err(AppError::conflict(
+                "source branch HEAD changed before cleanup; refusing to remove the newer worktree"
+                    .to_string(),
+            ));
+        }
+        let path = source.path.clone();
+        git::remove_worktree(repo, &path, false)?;
+        state.worktree_removed = true;
+        write_operation_state(repo, state)?;
+        Some(path)
+    };
+
+    if state.branch_deleted {
+        return Ok(removed_path);
+    }
+
+    let destination = validate_preflight_destination(repo, preflight, "destination")?;
+    let branch = BranchName::new(&state.source);
+    match git::delete_branch_at(&destination.path, &branch, false) {
+        Ok(()) => {
+            state.branch_deleted = true;
+            let marker_warning = git::clear_preserved_branch(repo, &branch)
+                .err()
+                .map(|error| {
+                    format!(
+                        "branch '{}' deleted but lifecycle marker cleanup failed: {error}",
+                        state.source
+                    )
+                });
+            if let Some(warning) = marker_warning {
+                warnings.push(warning);
+            }
+            write_operation_state(repo, state)?;
+        }
+        Err(error) => {
+            warnings.push(format!(
+                "worktree removed but branch deletion failed: {error}"
+            ));
+        }
+    }
+
+    Ok(removed_path)
+}
+
+fn merge_result_from_operation(
+    repo: &RepoRoot,
+    state: &MergeOperationState,
+    preflight: MergePreflight,
+    removed_path: Option<PathBuf>,
+    warnings: Vec<String>,
+) -> MergeResult {
+    MergeResult {
+        branch: BranchName::new(&state.source),
+        mainline: state.destination.clone(),
+        destination_path: state.destination_path.clone(),
+        repo_root: repo.to_path_buf(),
+        cleaned_up: state.worktree_removed,
+        removed_path,
+        pushed: state.push && state.push_done,
+        preflight,
+        warnings,
+    }
+}
+
+fn continue_merge_commit(
+    repo: &RepoRoot,
+    state: &mut MergeOperationState,
+    preflight: &MergePreflight,
+    report: &MergeOperationReport,
+) -> Result<()> {
+    if !matches!(report.state.as_str(), "ready") {
+        return Err(AppError::conflict(format!(
+            "cannot continue while unresolved paths remain: {}; resolve them and run `wt merge --continue`",
+            report.unresolved_paths.join(", ")
+        )));
+    }
+    validate_preflight_worktrees(repo, preflight, "source", "destination")?;
+    if git::merge_head(&state.destination_path)? != state.merge_head {
+        return Err(AppError::conflict(
+            "destination MERGE_HEAD changed before continuation; managed state was preserved for recovery".to_string(),
+        ));
+    }
+    git::merge_continue(&state.destination_path).map_err(|error| AppError {
+        code: error.code,
+        message: format!(
+            "managed merge continuation failed; state was preserved — resolve hook or Git errors and retry `wt merge --continue`\n{error}"
+        ),
+    })?;
+    state.phase = "committed".to_string();
+    // Read the branch ref rather than trusting a path after hooks have
+    // run. A hook may replace a linked worktree; cleanup and push will
+    // still revalidate the captured registration identity below.
+    state.completed_destination_head = Some(git::branch_head(repo, &state.destination)?);
+    write_operation_state(repo, state)
+}
+
+fn clear_completed_operation(
+    repo: &RepoRoot,
+    state: &MergeOperationState,
+    warnings: &mut Vec<String>,
+) {
+    let complete = !state.cleanup || (state.worktree_removed && state.branch_deleted);
+    let complete = complete && (!state.push || state.push_done);
+    if !complete {
+        return;
+    }
+    if let Err(error) = clear_operation_state(repo, state) {
+        warnings.push(format!(
+            "merge completed but managed state could not be cleared: {error}"
+        ));
+    }
+}
+
+/// Continue a managed merge after its conflicts have been resolved.
+pub fn merge_continue(repo: &RepoRoot) -> Result<MergeResult> {
+    let (_, mut state) = load_valid_merge_state(repo)?;
+    let report = merge_operation_status(repo)?;
+    if matches!(report.state.as_str(), "stale" | "interrupted" | "corrupt") {
+        return Err(operation_recovery_error(&report));
+    }
+    if report.state == "none" {
+        return Err(AppError::conflict(
+            "no managed merge operation is recorded; nothing to continue".to_string(),
+        ));
+    }
+
+    let preflight = operation_preflight(&state);
+    if state.phase != "committed" {
+        continue_merge_commit(repo, &mut state, &preflight, &report)?;
+    }
+
+    let mut warnings = Vec::new();
+    let removed_path = match cleanup_merge_operation(repo, &mut state, &preflight, &mut warnings) {
+        Ok(path) => path,
+        Err(error) => {
+            warnings.push(partial_success_warning("cleanup", "removed", &error));
+            None
+        }
+    };
+
+    if state.push && !state.push_done {
+        match validate_preflight_destination(repo, &preflight, "destination") {
+            Ok(_) => match git::push(&state.destination_path, &state.destination) {
+                Ok(()) => {
+                    state.push_done = true;
+                    write_operation_state(repo, &state)?;
+                }
+                Err(error) => warnings.push(format!("merge succeeded but push failed: {error}")),
+            },
+            Err(error) => warnings.push(partial_success_warning(
+                "destination push",
+                "pushed",
+                &error,
+            )),
+        }
+    }
+
+    clear_completed_operation(repo, &state, &mut warnings);
+
+    Ok(merge_result_from_operation(
+        repo,
+        &state,
+        preflight,
+        removed_path.or_else(|| state.worktree_removed.then(|| state.source_path.clone())),
+        warnings,
+    ))
+}
+
+/// Abort a managed merge and clear only the matching operation record.
+pub fn merge_abort_operation(repo: &RepoRoot) -> Result<MergeOperationReport> {
+    let (_, state) = load_valid_merge_state(repo)?;
+    let report = merge_operation_status(repo)?;
+    if matches!(report.state.as_str(), "stale" | "interrupted" | "corrupt") {
+        return Err(operation_recovery_error(&report));
+    }
+    if state.phase == "committed" {
+        return Err(AppError::conflict(
+            "the managed merge is already committed; it cannot be aborted — finish pending push or cleanup actions instead".to_string(),
+        ));
+    }
+    if report.state == "none" {
+        return Err(AppError::conflict(
+            "no managed merge operation is recorded; nothing to abort".to_string(),
+        ));
+    }
+    validate_preflight_worktrees(repo, &operation_preflight(&state), "source", "destination")?;
+    if git::merge_head(&state.destination_path)? != state.merge_head {
+        return Err(AppError::conflict(
+            "destination MERGE_HEAD no longer matches the managed operation; state was preserved for manual recovery".to_string(),
+        ));
+    }
+
+    git::merge_abort_checked(&state.destination_path).map_err(|error| AppError {
+        code: error.code,
+        message: format!("managed merge abort failed; state was preserved\n{error}"),
+    })?;
+    if git::merge_in_progress(&state.destination_path)
+        || git::head_commit(&state.destination_path)? != state.destination_head
+    {
+        return Err(AppError::conflict(
+            "Git did not restore the original destination; managed state was preserved for recovery".to_string(),
+        ));
+    }
+    validate_preflight_worktrees(repo, &operation_preflight(&state), "source", "destination")?;
+    clear_operation_state(repo, &state)?;
+    let mut aborted = report;
+    aborted.state = "aborted".to_string();
+    aborted.unresolved_paths.clear();
+    aborted.pending_actions.clear();
+    aborted.recovery = None;
+    Ok(aborted)
+}
+
+fn record_conflicted_merge_state(
+    repo: &RepoRoot,
+    destination_path: &Path,
+    operation: &mut MergeOperationState,
+) -> Result<bool> {
+    operation.phase = "conflicted".to_string();
+    operation.merge_head = git::merge_head(destination_path)?;
+    let Some(_) = operation.merge_head else {
+        return Ok(false);
+    };
+    write_operation_state(repo, operation)?;
+    Ok(true)
+}
+
+fn handle_merge_failure(
+    repo: &RepoRoot,
+    destination_path: &Path,
+    target_branch: &BranchName,
+    operation: &mut MergeOperationState,
+    error: AppError,
+) -> MergeFailure {
+    let failure = classify_merge_failure(destination_path, target_branch, error);
+    if failure.kind != MergeFailureKind::ContentConflict {
+        abort_created_merge(destination_path);
+        let _ = clear_operation_state(repo, operation);
+        return failure;
+    }
+
+    match record_conflicted_merge_state(repo, destination_path, operation) {
+        Ok(true) => failure,
+        Ok(false) => {
+            abort_created_merge(destination_path);
+            let _ = clear_operation_state(repo, operation);
+            failure
+        }
+        Err(state_error) => {
+            abort_created_merge(destination_path);
+            MergeFailure {
+                kind: MergeFailureKind::GitFailure,
+                error: AppError::conflict(format!(
+                    "content merge conflict could not be recorded safely; merge was aborted: {state_error}"
+                )),
+            }
+        }
     }
 }
 
@@ -1454,18 +2354,73 @@ pub fn merge_with_preflight(
     let destination_path = preflight.destination_path.clone();
     let target_branch = BranchName::new(&preflight.source);
     let destination_branch = preflight.destination.clone();
+    let source_head = match git::head_commit(&preflight.source_path) {
+        Ok(head) => head,
+        Err(error) => {
+            return Err(MergeFailure {
+                kind: MergeFailureKind::GitFailure,
+                error,
+            });
+        }
+    };
+    let destination_head = match git::head_commit(&destination_path) {
+        Ok(head) => head,
+        Err(error) => {
+            return Err(MergeFailure {
+                kind: MergeFailureKind::GitFailure,
+                error,
+            });
+        }
+    };
+    let mut operation =
+        merge_state_from_preflight(&preflight, source_head, destination_head, push, no_cleanup);
+
+    // Never overwrite an operation that may require recovery. This also
+    // keeps a stale or corrupt record from being silently detached from the
+    // Git merge it describes.
+    match merge_operation_file(repo) {
+        Ok(MergeOperationFile::Missing) => {}
+        Ok(MergeOperationFile::Valid(_)) | Ok(MergeOperationFile::Corrupt { .. }) => {
+            return Err(MergeFailure {
+                kind: MergeFailureKind::GitFailure,
+                error: AppError::conflict(
+                    "a managed merge operation already exists; inspect it with `wt merge --status` and recover it before starting another merge".to_string(),
+                ),
+            });
+        }
+        Err(error) => {
+            return Err(MergeFailure {
+                kind: MergeFailureKind::GitFailure,
+                error,
+            });
+        }
+    }
+    if let Err(error) = create_operation_state(repo, &operation) {
+        return Err(MergeFailure {
+            kind: MergeFailureKind::GitFailure,
+            error,
+        });
+    }
 
     // Attempt the merge from the selected destination worktree's context.
     if let Err(error) = git::merge_no_ff(&destination_path, target_branch.as_str()) {
-        // The preflight established that any merge state now belongs to this
-        // invocation. Abort it after classifying the failure so a hook or
-        // other Git failure is not mislabeled as a content conflict.
-        let failure = classify_merge_failure(&destination_path, &target_branch, error);
-        abort_created_merge(&destination_path);
-        return Err(failure);
+        return Err(handle_merge_failure(
+            repo,
+            &destination_path,
+            &target_branch,
+            &mut operation,
+            error,
+        ));
     }
 
+    // A clean merge has no resumable operation. Clearing this record before
+    // cleanup preserves the established non-conflict lifecycle and output.
     let mut warnings = Vec::new();
+    if let Err(error) = clear_operation_state(repo, &operation) {
+        warnings.push(format!(
+            "merge succeeded but managed state could not be cleared: {error}"
+        ));
+    }
 
     // Cleanup: remove the source worktree and branch (default behaviour).
     // Downgraded to a warning because the merge has already been committed;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::domain::{BranchName, RepoRoot, Worktree};
 use crate::error::{AppError, Result};
 use crate::git;
+use crate::operation_state::{self, MergePhase, MergeProgress};
 use crate::symlinks;
 
 /// Find the worktree that most specifically contains `cwd`.
@@ -404,54 +405,6 @@ fn remove_with_branch_context(
                 Some(format!("worktree removed but branch deletion failed: {e}")),
             ),
         }
-    };
-
-    Ok(RemoveResult {
-        removed_path,
-        branch: target_branch,
-        repo_root: repo.to_path_buf(),
-        branch_deleted,
-        warning,
-    })
-}
-
-/// Remove the exact source worktree captured by merge preflight.
-///
-/// Unlike the user-facing remove path, merge cleanup must not prune and then
-/// rediscover a worktree by branch name. Requiring both paths and identities
-/// prevents cleanup from deleting a replacement repository or branch.
-fn remove_exact_merge_source(repo: &RepoRoot, preflight: &MergePreflight) -> Result<RemoveResult> {
-    let (source, _) = validate_preflight_worktrees(repo, preflight, "source", "destination")?;
-    let removed_path = source.path.clone();
-    let target_branch = BranchName::new(&preflight.source);
-
-    git::remove_worktree(repo, &removed_path, false)?;
-
-    // The source was removed above, so validate the destination separately
-    // immediately before deleting the merged source branch in its context.
-    let destination = validate_preflight_destination(repo, preflight, "destination")?;
-
-    let (branch_deleted, warning) = match git::delete_branch_at(
-        &destination.path,
-        &target_branch,
-        false,
-    ) {
-        Ok(()) => {
-            let warning = git::clear_preserved_branch(repo, &target_branch)
-                .err()
-                .map(|error| {
-                    format!(
-                        "branch '{target_branch}' deleted but lifecycle marker cleanup failed: {error}"
-                    )
-                });
-            (true, warning)
-        }
-        Err(error) => (
-            false,
-            Some(format!(
-                "worktree removed but branch deletion failed: {error}"
-            )),
-        ),
     };
 
     Ok(RemoveResult {
@@ -956,7 +909,7 @@ pub enum SourceHistory {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct MergeOperationState {
     schema: u32,
-    phase: String,
+    phase: MergePhase,
     source: String,
     destination: String,
     source_path: PathBuf,
@@ -978,9 +931,8 @@ struct MergeOperationState {
     push: bool,
     cleanup: bool,
     keep_branch: bool,
-    worktree_removed: bool,
-    branch_deleted: bool,
-    push_done: bool,
+    #[serde(flatten)]
+    progress: MergeProgress,
 }
 
 const MERGE_OPERATION_SCHEMA: u32 = 1;
@@ -997,6 +949,9 @@ pub struct MergeOperationReport {
     pub push: bool,
     pub cleanup: bool,
     pub keep_branch: bool,
+    pub worktree_removed: bool,
+    pub branch_deleted: bool,
+    pub push_done: bool,
     pub pending_actions: Vec<String>,
     pub recovery: Option<String>,
     pub state_path: PathBuf,
@@ -1010,11 +965,35 @@ enum MergeOperationFile {
 
 fn merge_operation_file(repo: &RepoRoot) -> Result<MergeOperationFile> {
     let path = git::merge_operation_path(repo)?;
-    let contents = match fs::read_to_string(&path) {
-        Ok(contents) => contents,
+    if let Some(error) = path
+        .parent()
+        .and_then(|parent| operation_state::ensure_private_directory(parent).err())
+    {
+        return Ok(MergeOperationFile::Corrupt {
+            path,
+            reason: error.message,
+        });
+    }
+    match fs::symlink_metadata(&path) {
+        Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return Ok(MergeOperationFile::Missing);
         }
+        Err(error) => {
+            return Ok(MergeOperationFile::Corrupt {
+                path,
+                reason: format!("cannot inspect state file: {error}"),
+            });
+        }
+    }
+    if let Err(error) = operation_state::ensure_private_file(&path) {
+        return Ok(MergeOperationFile::Corrupt {
+            path,
+            reason: error.message,
+        });
+    }
+    let contents = match fs::read_to_string(&path) {
+        Ok(contents) => contents,
         Err(error) => {
             return Ok(MergeOperationFile::Corrupt {
                 path,
@@ -1025,14 +1004,7 @@ fn merge_operation_file(repo: &RepoRoot) -> Result<MergeOperationFile> {
 
     match serde_json::from_str::<MergeOperationState>(&contents) {
         Ok(state) if state.schema == MERGE_OPERATION_SCHEMA => {
-            if valid_operation_phase(&state.phase) {
-                Ok(MergeOperationFile::Valid(Box::new(state)))
-            } else {
-                Ok(MergeOperationFile::Corrupt {
-                    path,
-                    reason: format!("unsupported operation phase '{}'", state.phase),
-                })
-            }
+            Ok(MergeOperationFile::Valid(Box::new(state)))
         }
         Ok(state) => Ok(MergeOperationFile::Corrupt {
             path,
@@ -1045,13 +1017,9 @@ fn merge_operation_file(repo: &RepoRoot) -> Result<MergeOperationFile> {
     }
 }
 
-fn valid_operation_phase(phase: &str) -> bool {
-    matches!(phase, "starting" | "conflicted" | "committed")
-}
-
 fn operation_report_base(state: &MergeOperationState, state_path: PathBuf) -> MergeOperationReport {
     MergeOperationReport {
-        state: state.phase.clone(),
+        state: state.phase.as_str().to_string(),
         source: Some(state.source.clone()),
         destination: Some(state.destination.clone()),
         source_path: Some(state.source_path.clone()),
@@ -1060,6 +1028,9 @@ fn operation_report_base(state: &MergeOperationState, state_path: PathBuf) -> Me
         push: state.push,
         cleanup: state.cleanup,
         keep_branch: state.keep_branch,
+        worktree_removed: state.progress.worktree_removed,
+        branch_deleted: state.progress.branch_deleted,
+        push_done: state.progress.push_done,
         pending_actions: Vec::new(),
         recovery: None,
         state_path,
@@ -1077,6 +1048,9 @@ fn no_operation_report(state_path: PathBuf) -> MergeOperationReport {
         push: false,
         cleanup: false,
         keep_branch: false,
+        worktree_removed: false,
+        branch_deleted: false,
+        push_done: false,
         pending_actions: Vec::new(),
         recovery: None,
         state_path,
@@ -1094,6 +1068,9 @@ fn corrupt_operation_report(path: PathBuf, reason: String) -> MergeOperationRepo
         push: false,
         cleanup: false,
         keep_branch: false,
+        worktree_removed: false,
+        branch_deleted: false,
+        push_done: false,
         pending_actions: Vec::new(),
         recovery: Some(format!(
             "managed merge state is corrupt ({reason}); preserve '{}', inspect the destination, and repair or remove the state only after recovery",
@@ -1105,12 +1082,12 @@ fn corrupt_operation_report(path: PathBuf, reason: String) -> MergeOperationRepo
 
 fn pending_operation_actions(
     state: &MergeOperationState,
-    phase: &str,
+    phase: MergePhase,
     unresolved: &[String],
 ) -> Vec<String> {
     let mut actions = Vec::new();
     let merge_action = match (
-        matches!(phase, "starting" | "conflicted"),
+        matches!(phase, MergePhase::Starting | MergePhase::Conflicted),
         unresolved.is_empty(),
     ) {
         (true, true) => Some("run `wt merge --continue` to create the merge commit"),
@@ -1120,7 +1097,11 @@ fn pending_operation_actions(
     if let Some(action) = merge_action {
         actions.push(action.to_string());
     }
-    let cleanup_action = match (state.cleanup, state.worktree_removed, state.branch_deleted) {
+    let cleanup_action = match (
+        state.cleanup,
+        state.progress.worktree_removed,
+        state.progress.branch_deleted,
+    ) {
         (true, true, false) => Some("remove the source branch"),
         (true, false, _) => Some("remove the source worktree and branch"),
         _ => None,
@@ -1128,7 +1109,7 @@ fn pending_operation_actions(
     if let Some(action) = cleanup_action {
         actions.push(action.to_string());
     }
-    if state.push && !state.push_done {
+    if state.push && !state.progress.push_done {
         actions.push(format!("push {} to origin", state.destination));
     }
     actions
@@ -1211,11 +1192,7 @@ fn write_operation_state_inner(
             path.display()
         ))
     })?;
-    fs::create_dir_all(parent).map_err(|error| {
-        AppError::git(format!(
-            "cannot create managed merge state directory: {error}"
-        ))
-    })?;
+    operation_state::ensure_private_directory(parent)?;
     let bytes = serde_json::to_vec_pretty(state).map_err(|error| {
         AppError::invariant(format!("cannot encode managed merge state: {error}"))
     })?;
@@ -1228,14 +1205,20 @@ fn write_operation_state_inner(
         std::process::id(),
         nonce
     ));
-    let mut file = fs::OpenOptions::new()
-        .create_new(true)
-        .write(true)
+    let mut options = fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
         .open(&temp)
         .map_err(|error| AppError::git(format!("cannot write managed merge state: {error}")))?;
     file.write_all(&bytes)
         .and_then(|_| file.sync_all())
         .map_err(|error| AppError::git(format!("cannot flush managed merge state: {error}")))?;
+    drop(file);
     match create_only {
         true => match fs::hard_link(&temp, &path) {
             Ok(()) => {
@@ -1253,9 +1236,18 @@ fn write_operation_state_inner(
             }
         },
         false => {
-            fs::rename(&temp, &path).map_err(|error| {
-                AppError::git(format!("cannot install managed merge state: {error}"))
-            })?;
+            match fs::symlink_metadata(&path) {
+                Ok(_) => operation_state::ensure_private_file(&path)?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    let _ = fs::remove_file(&temp);
+                    return Err(AppError::git(format!(
+                        "cannot inspect managed merge state '{}': {error}",
+                        path.display()
+                    )));
+                }
+            }
+            operation_state::replace_existing(&temp, &path)?;
         }
     }
     sync_operation_parent(parent)?;
@@ -1291,8 +1283,15 @@ fn clear_operation_state(repo: &RepoRoot, expected: &MergeOperationState) -> Res
             .unwrap_or_default()
     ));
 
-    if !path.exists() {
-        return Ok(());
+    match fs::symlink_metadata(&path) {
+        Ok(_) => operation_state::ensure_private_file(&path)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(AppError::git(format!(
+                "cannot inspect managed merge state '{}': {error}",
+                path.display()
+            )))
+        }
     }
     fs::rename(&path, &tombstone).map_err(|error| {
         AppError::conflict(format!(
@@ -1347,11 +1346,100 @@ fn validate_operation_worktree(
     Ok(())
 }
 
+/// Reconcile effects that may have completed after the process lost the
+/// opportunity to persist its progress record. This only recognizes effects
+/// whose observable result is exactly the recorded intent; it never deletes a
+/// replacement worktree/branch and never treats a diverged remote as pushed.
+fn reconcile_operation_progress(repo: &RepoRoot, state: &mut MergeOperationState) -> Result<bool> {
+    let mut changed = false;
+
+    if state.phase != MergePhase::Committed {
+        let source_head = state
+            .merge_head
+            .as_deref()
+            .unwrap_or(state.source_head.as_str());
+        let Some(expected) = git::merge_result_head(
+            &state.destination_path,
+            &state.destination_head,
+            source_head,
+        )?
+        else {
+            return Ok(false);
+        };
+        state.phase = MergePhase::Committed;
+        state.completed_destination_head = Some(expected);
+        changed = true;
+    }
+
+    let Some(expected) = state.completed_destination_head.clone() else {
+        return Ok(changed);
+    };
+    if git::head_commit(&state.destination_path)? != expected {
+        // The merge result exists, but the destination has advanced. Keep the
+        // journal available for truthful stale-state reporting and refuse all
+        // destructive follow-up actions.
+        return Ok(changed);
+    }
+
+    if state.cleanup {
+        changed |= reconcile_cleanup_progress(repo, state)?;
+    }
+    if state.push && !state.progress.push_done {
+        changed |= reconcile_push_progress(repo, state, &expected);
+    }
+
+    Ok(changed)
+}
+
+fn reconcile_cleanup_progress(repo: &RepoRoot, state: &mut MergeOperationState) -> Result<bool> {
+    let worktrees = git::list_worktrees_readonly(repo)?;
+    let source_present = state_worktree(&worktrees, &state.source_path, &state.source).is_some();
+    let branch = BranchName::new(&state.source);
+    match (
+        state.progress.worktree_removed,
+        state.progress.branch_deleted,
+    ) {
+        (false, _) if !source_present => match git::branch_oid(repo, &branch) {
+            Some(head) if head == state.source_head => {
+                state.progress.worktree_removed = true;
+                Ok(true)
+            }
+            None => {
+                // Both cleanup effects are already visible. The requested
+                // outcome is idempotently complete.
+                state.progress.worktree_removed = true;
+                state.progress.branch_deleted = true;
+                Ok(true)
+            }
+            Some(_) => Ok(false),
+        },
+        (true, false) if git::branch_oid(repo, &branch).is_none() => {
+            state.progress.branch_deleted = true;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn reconcile_push_progress(
+    repo: &RepoRoot,
+    state: &mut MergeOperationState,
+    expected: &str,
+) -> bool {
+    match git::remote_branch_head(repo, &state.destination) {
+        Ok(Some(remote_head)) if remote_head == expected => {
+            state.progress.push_done = true;
+            true
+        }
+        _ => false,
+    }
+}
+
 fn finish_committed_report(
     mut report: MergeOperationReport,
     state: &MergeOperationState,
 ) -> MergeOperationReport {
-    report.pending_actions = pending_operation_actions(state, "committed", &[]);
+    report.pending_actions = pending_operation_actions(state, MergePhase::Committed, &[]);
     report.state = if report.pending_actions.is_empty() {
         "complete".to_string()
     } else {
@@ -1382,7 +1470,7 @@ fn inspect_committed_operation(
             "destination HEAD changed after the merge commit",
         ));
     }
-    if state.worktree_removed {
+    if state.progress.worktree_removed {
         return Ok(finish_committed_report(report, state));
     }
 
@@ -1412,6 +1500,9 @@ fn inspect_operation_state(
     state: &MergeOperationState,
     state_path: PathBuf,
 ) -> Result<MergeOperationReport> {
+    let mut reconciled = state.clone();
+    let _ = reconcile_operation_progress(repo, &mut reconciled)?;
+    let state = &reconciled;
     let mut report = operation_report_base(state, state_path.clone());
     let worktrees = git::list_worktrees_readonly(repo)?;
     let destination = match state_worktree(&worktrees, &state.destination_path, &state.destination)
@@ -1434,7 +1525,7 @@ fn inspect_operation_state(
         return Ok(stale_operation_report(state, state_path, error.message));
     }
 
-    if state.phase == "committed" {
+    if state.phase == MergePhase::Committed {
         return inspect_committed_operation(repo, state, state_path, &worktrees, report);
     }
 
@@ -1480,7 +1571,7 @@ fn inspect_operation_state(
                 "conflicted".to_string()
             };
             report.pending_actions =
-                pending_operation_actions(state, &report.state, &report.unresolved_paths);
+                pending_operation_actions(state, state.phase, &report.unresolved_paths);
             Ok(report)
         }
         Some(other) => Ok(stale_operation_report(
@@ -1556,6 +1647,7 @@ pub struct MergeResult {
     pub cleaned_up: bool,
     /// Path of the removed worktree (only set when `cleaned_up` is true).
     pub removed_path: Option<PathBuf>,
+    pub branch_deleted: bool,
     pub pushed: bool,
     /// Facts gathered before the merge mutation.
     pub preflight: MergePreflight,
@@ -1797,39 +1889,6 @@ fn validate_preflight_worktrees(
     Ok((source.clone(), destination.clone()))
 }
 
-/// Re-read and validate the exact destination record after source cleanup.
-fn validate_preflight_destination(
-    repo: &RepoRoot,
-    preflight: &MergePreflight,
-    role: &str,
-) -> Result<Worktree> {
-    let worktrees = git::list_worktrees_readonly(repo)?;
-    let destination = worktrees
-        .iter()
-        .find(|wt| {
-            wt.path == preflight.destination_path
-                && wt.branch.as_deref() == Some(preflight.destination.as_str())
-        })
-        .ok_or_else(|| {
-            AppError::conflict(format!(
-                "stale {role} worktree metadata for branch '{}' at {}: path or branch no longer matches the preflight record",
-                preflight.destination,
-                preflight.destination_path.display()
-            ))
-        })?;
-    let identity = validate_merge_worktree(repo, destination, role)?;
-    if identity != preflight.destination_identity {
-        return Err(identity_changed(
-            role,
-            &preflight.destination,
-            &preflight.destination_path,
-            &preflight.destination_identity,
-            &identity,
-        ));
-    }
-    Ok(destination.clone())
-}
-
 /// Inspect the merge topology without changing repository state.
 ///
 /// `readonly` is true for `--inspect`. Normal merges deliberately prune
@@ -1998,7 +2057,7 @@ fn merge_state_from_preflight(
 ) -> MergeOperationState {
     MergeOperationState {
         schema: MERGE_OPERATION_SCHEMA,
-        phase: "starting".to_string(),
+        phase: MergePhase::Starting,
         source: preflight.source.clone(),
         destination: preflight.destination.clone(),
         source_path: preflight.source_path.clone(),
@@ -2023,9 +2082,10 @@ fn merge_state_from_preflight(
         // These flags describe completed cleanup actions, not the policy. A
         // no-cleanup operation still needs its source identity revalidated
         // while it is paused.
-        worktree_removed: false,
-        branch_deleted: false,
-        push_done: !push,
+        progress: MergeProgress {
+            push_done: !push,
+            ..MergeProgress::default()
+        },
     }
 }
 
@@ -2053,42 +2113,105 @@ fn operation_recovery_error(report: &MergeOperationReport) -> AppError {
     )
 }
 
+fn validate_committed_destination(
+    repo: &RepoRoot,
+    state: &MergeOperationState,
+) -> Result<Worktree> {
+    let expected = state.completed_destination_head.as_deref().ok_or_else(|| {
+        AppError::conflict(
+            "managed merge has no recorded destination merge-result HEAD; state was preserved"
+                .to_string(),
+        )
+    })?;
+    let worktrees = git::list_worktrees_readonly(repo)?;
+    let destination = state_worktree(&worktrees, &state.destination_path, &state.destination)
+        .ok_or_else(|| {
+            AppError::conflict(
+                "destination worktree changed before cleanup or push; managed state was preserved"
+                    .to_string(),
+            )
+        })?;
+    validate_operation_worktree(
+        repo,
+        destination,
+        "destination",
+        &state.destination_identity,
+    )?;
+    let actual = git::head_commit(&state.destination_path)?;
+    if actual != expected {
+        return Err(AppError::conflict(
+            "destination HEAD changed after the merge result; refusing cleanup or push and preserving managed state"
+                .to_string(),
+        ));
+    }
+    Ok(destination.clone())
+}
+
+fn validate_committed_source(repo: &RepoRoot, state: &MergeOperationState) -> Result<Worktree> {
+    let worktrees = git::list_worktrees_readonly(repo)?;
+    let source = state_worktree(&worktrees, &state.source_path, &state.source).ok_or_else(|| {
+        AppError::conflict(
+            "source worktree changed before cleanup; refusing to remove a replacement and preserving managed state"
+                .to_string(),
+        )
+    })?;
+    validate_operation_worktree(repo, source, "source", &state.source_identity)?;
+    if git::head_commit(&source.path)? != state.source_head
+        || git::branch_oid(repo, &BranchName::new(&state.source)).as_deref()
+            != Some(state.source_head.as_str())
+    {
+        return Err(AppError::conflict(
+            "source HEAD changed after the merge; refusing cleanup and preserving managed state"
+                .to_string(),
+        ));
+    }
+    Ok(source.clone())
+}
+
 fn cleanup_merge_operation(
     repo: &RepoRoot,
     state: &mut MergeOperationState,
-    preflight: &MergePreflight,
     warnings: &mut Vec<String>,
 ) -> Result<Option<PathBuf>> {
     if !state.cleanup {
         return Ok(None);
     }
 
-    let removed_path = if state.worktree_removed {
+    let removed_path = if state.progress.worktree_removed {
         Some(state.source_path.clone())
     } else {
-        let (source, _) = validate_preflight_worktrees(repo, preflight, "source", "destination")?;
-        if git::head_commit(&source.path)? != state.source_head {
-            return Err(AppError::conflict(
-                "source branch HEAD changed before cleanup; refusing to remove the newer worktree"
-                    .to_string(),
-            ));
-        }
+        // Validate both captured heads immediately before the destructive
+        // action. The branch check closes the race between worktree removal
+        // and branch deletion.
+        let _ = validate_committed_destination(repo, state)?;
+        let source = validate_committed_source(repo, state)?;
         let path = source.path.clone();
         git::remove_worktree(repo, &path, false)?;
-        state.worktree_removed = true;
+        state.progress.worktree_removed = true;
+        // Do not continue to branch deletion until the journal records the
+        // completed worktree removal durably.
         write_operation_state(repo, state)?;
         Some(path)
     };
 
-    if state.branch_deleted {
+    if state.progress.branch_deleted {
         return Ok(removed_path);
     }
 
-    let destination = validate_preflight_destination(repo, preflight, "destination")?;
+    let destination = validate_committed_destination(repo, state)?;
     let branch = BranchName::new(&state.source);
+    match git::branch_oid(repo, &branch) {
+        Some(head) if head != state.source_head => {
+            return Err(AppError::conflict(
+                "source branch HEAD changed before branch cleanup; refusing to delete the newer branch"
+                    .to_string(),
+            ));
+        }
+        _ => {}
+    }
     match git::delete_branch_at(&destination.path, &branch, false) {
         Ok(()) => {
-            state.branch_deleted = true;
+            state.progress.branch_deleted = true;
             let marker_warning = git::clear_preserved_branch(repo, &branch)
                 .err()
                 .map(|error| {
@@ -2102,6 +2225,12 @@ fn cleanup_merge_operation(
             }
             write_operation_state(repo, state)?;
         }
+        Err(_error) if git::branch_oid(repo, &branch).is_none() => {
+            // A concurrent non-force deletion has already completed the same
+            // requested action. Record it and reconcile on the next retry.
+            state.progress.branch_deleted = true;
+            write_operation_state(repo, state)?;
+        }
         Err(error) => {
             warnings.push(format!(
                 "worktree removed but branch deletion failed: {error}"
@@ -2110,6 +2239,104 @@ fn cleanup_merge_operation(
     }
 
     Ok(removed_path)
+}
+
+fn finish_push(
+    repo: &RepoRoot,
+    state: &mut MergeOperationState,
+    destination: &Worktree,
+    warnings: &mut Vec<String>,
+) -> bool {
+    match git::push(&destination.path, &state.destination) {
+        Ok(()) => {
+            state.progress.push_done = true;
+            match write_operation_state(repo, state) {
+                Ok(()) => true,
+                Err(error) => {
+                    warnings.push(format!(
+                        "push completed but managed progress could not be recorded; retry `wt merge --continue`: {error}"
+                    ));
+                    false
+                }
+            }
+        }
+        Err(error) => {
+            warnings.push(format!("merge succeeded but push failed: {error}"));
+            true
+        }
+    }
+}
+
+fn clear_completed_operation(
+    repo: &RepoRoot,
+    state: &MergeOperationState,
+    warnings: &mut Vec<String>,
+) {
+    let cleanup_complete =
+        !state.cleanup || (state.progress.worktree_removed && state.progress.branch_deleted);
+    let complete = cleanup_complete && (!state.push || state.progress.push_done);
+    if !complete {
+        return;
+    }
+    match clear_operation_state(repo, state) {
+        Ok(()) => {}
+        Err(error) => warnings.push(format!(
+            "merge completed but managed state could not be cleared: {error}"
+        )),
+    }
+}
+
+fn finish_committed_operation(
+    repo: &RepoRoot,
+    state: &mut MergeOperationState,
+    warnings: &mut Vec<String>,
+) -> Option<PathBuf> {
+    let _destination = match validate_committed_destination(repo, state) {
+        Ok(destination) => destination,
+        Err(error) => {
+            warnings.push(partial_success_warning(
+                "cleanup and push",
+                "completed",
+                &error,
+            ));
+            return state
+                .progress
+                .worktree_removed
+                .then(|| state.source_path.clone());
+        }
+    };
+
+    let removed_path = match cleanup_merge_operation(repo, state, warnings) {
+        Ok(path) => path,
+        Err(error) => {
+            warnings.push(partial_success_warning("cleanup", "completed", &error));
+            return state
+                .progress
+                .worktree_removed
+                .then(|| state.source_path.clone());
+        }
+    };
+
+    let push_recorded = match (state.push, state.progress.push_done) {
+        (true, false) => match validate_committed_destination(repo, state) {
+            Ok(destination) => finish_push(repo, state, &destination, warnings),
+            Err(error) => {
+                warnings.push(partial_success_warning(
+                    "destination push",
+                    "pushed",
+                    &error,
+                ));
+                true
+            }
+        },
+        _ => true,
+    };
+    if !push_recorded {
+        return removed_path;
+    }
+
+    clear_completed_operation(repo, state, warnings);
+    removed_path
 }
 
 fn merge_result_from_operation(
@@ -2124,9 +2351,12 @@ fn merge_result_from_operation(
         mainline: state.destination.clone(),
         destination_path: state.destination_path.clone(),
         repo_root: repo.to_path_buf(),
-        cleaned_up: state.worktree_removed,
+        cleaned_up: state.cleanup
+            && state.progress.worktree_removed
+            && state.progress.branch_deleted,
         removed_path,
-        pushed: state.push && state.push_done,
+        branch_deleted: state.progress.branch_deleted,
+        pushed: state.push && state.progress.push_done,
         preflight,
         warnings,
     }
@@ -2156,34 +2386,33 @@ fn continue_merge_commit(
             "managed merge continuation failed; state was preserved — resolve hook or Git errors and retry `wt merge --continue`\n{error}"
         ),
     })?;
-    state.phase = "committed".to_string();
-    // Read the branch ref rather than trusting a path after hooks have
-    // run. A hook may replace a linked worktree; cleanup and push will
-    // still revalidate the captured registration identity below.
-    state.completed_destination_head = Some(git::branch_head(repo, &state.destination)?);
+    let source_head = state.merge_head.clone().ok_or_else(|| {
+        AppError::invariant("managed merge has no recorded MERGE_HEAD".to_string())
+    })?;
+    let expected = git::merge_result_head(
+        &state.destination_path,
+        &state.destination_head,
+        &source_head,
+    )?
+    .ok_or_else(|| {
+        AppError::conflict(
+            "managed merge committed, but its expected merge-result HEAD could not be identified; state was preserved"
+                .to_string(),
+        )
+    })?;
+    state.phase = MergePhase::Committed;
+    state.completed_destination_head = Some(expected);
     write_operation_state(repo, state)
-}
-
-fn clear_completed_operation(
-    repo: &RepoRoot,
-    state: &MergeOperationState,
-    warnings: &mut Vec<String>,
-) {
-    let complete = !state.cleanup || (state.worktree_removed && state.branch_deleted);
-    let complete = complete && (!state.push || state.push_done);
-    if !complete {
-        return;
-    }
-    if let Err(error) = clear_operation_state(repo, state) {
-        warnings.push(format!(
-            "merge completed but managed state could not be cleared: {error}"
-        ));
-    }
 }
 
 /// Continue a managed merge after its conflicts have been resolved.
 pub fn merge_continue(repo: &RepoRoot) -> Result<MergeResult> {
     let (_, mut state) = load_valid_merge_state(repo)?;
+    if reconcile_operation_progress(repo, &mut state)? {
+        // A prior action or the commit itself may have completed before its
+        // progress write. Persist reconciliation before taking another action.
+        write_operation_state(repo, &state)?;
+    }
     let report = merge_operation_status(repo)?;
     if matches!(report.state.as_str(), "stale" | "interrupted" | "corrupt") {
         return Err(operation_recovery_error(&report));
@@ -2195,43 +2424,18 @@ pub fn merge_continue(repo: &RepoRoot) -> Result<MergeResult> {
     }
 
     let preflight = operation_preflight(&state);
-    if state.phase != "committed" {
+    if state.phase != MergePhase::Committed {
         continue_merge_commit(repo, &mut state, &preflight, &report)?;
     }
 
     let mut warnings = Vec::new();
-    let removed_path = match cleanup_merge_operation(repo, &mut state, &preflight, &mut warnings) {
-        Ok(path) => path,
-        Err(error) => {
-            warnings.push(partial_success_warning("cleanup", "removed", &error));
-            None
-        }
-    };
-
-    if state.push && !state.push_done {
-        match validate_preflight_destination(repo, &preflight, "destination") {
-            Ok(_) => match git::push(&state.destination_path, &state.destination) {
-                Ok(()) => {
-                    state.push_done = true;
-                    write_operation_state(repo, &state)?;
-                }
-                Err(error) => warnings.push(format!("merge succeeded but push failed: {error}")),
-            },
-            Err(error) => warnings.push(partial_success_warning(
-                "destination push",
-                "pushed",
-                &error,
-            )),
-        }
-    }
-
-    clear_completed_operation(repo, &state, &mut warnings);
+    let removed_path = finish_committed_operation(repo, &mut state, &mut warnings);
 
     Ok(merge_result_from_operation(
         repo,
         &state,
         preflight,
-        removed_path.or_else(|| state.worktree_removed.then(|| state.source_path.clone())),
+        removed_path,
         warnings,
     ))
 }
@@ -2243,7 +2447,7 @@ pub fn merge_abort_operation(repo: &RepoRoot) -> Result<MergeOperationReport> {
     if matches!(report.state.as_str(), "stale" | "interrupted" | "corrupt") {
         return Err(operation_recovery_error(&report));
     }
-    if state.phase == "committed" {
+    if state.phase == MergePhase::Committed {
         return Err(AppError::conflict(
             "the managed merge is already committed; it cannot be aborted — finish pending push or cleanup actions instead".to_string(),
         ));
@@ -2286,7 +2490,7 @@ fn record_conflicted_merge_state(
     destination_path: &Path,
     operation: &mut MergeOperationState,
 ) -> Result<bool> {
-    operation.phase = "conflicted".to_string();
+    operation.phase = MergePhase::Conflicted;
     operation.merge_head = git::merge_head(destination_path)?;
     let Some(_) = operation.merge_head else {
         return Ok(false);
@@ -2353,7 +2557,6 @@ pub fn merge_with_preflight(
 
     let destination_path = preflight.destination_path.clone();
     let target_branch = BranchName::new(&preflight.source);
-    let destination_branch = preflight.destination.clone();
     let source_head = match git::head_commit(&preflight.source_path) {
         Ok(head) => head,
         Err(error) => {
@@ -2413,71 +2616,42 @@ pub fn merge_with_preflight(
         ));
     }
 
-    // A clean merge has no resumable operation. Clearing this record before
-    // cleanup preserves the established non-conflict lifecycle and output.
-    let mut warnings = Vec::new();
-    if let Err(error) = clear_operation_state(repo, &operation) {
-        warnings.push(format!(
-            "merge succeeded but managed state could not be cleared: {error}"
-        ));
+    // The merge commit is the durable point of no return. Record its exact
+    // two-parent result before attempting cleanup or push; if this write
+    // fails, leave the starting journal in place so the next status/continue
+    // can identify and reconcile the completed commit.
+    let expected = git::merge_result_head(&destination_path, &operation.destination_head, &operation.source_head)
+        .map_err(|error| MergeFailure {
+            kind: MergeFailureKind::GitFailure,
+            error,
+        })?
+        .ok_or_else(|| MergeFailure {
+            kind: MergeFailureKind::GitFailure,
+            error: AppError::conflict(
+                "merge committed, but the expected merge-result HEAD could not be identified; managed state was preserved"
+                    .to_string(),
+            ),
+        })?;
+    operation.phase = MergePhase::Committed;
+    operation.completed_destination_head = Some(expected);
+    if let Err(error) = write_operation_state(repo, &operation) {
+        return Err(MergeFailure {
+            kind: MergeFailureKind::GitFailure,
+            error: AppError::git(format!(
+                "merge committed but durable managed state could not be recorded; retry `wt merge --continue` without changing the source or destination: {error}"
+            )),
+        });
     }
 
-    // Cleanup: remove the source worktree and branch (default behaviour).
-    // Downgraded to a warning because the merge has already been committed;
-    // a hard error would hide the successful merge from the caller.
-    let (cleaned_up, removed_path) = if no_cleanup {
-        (false, None)
-    } else {
-        match remove_exact_merge_source(repo, &preflight) {
-            Ok(result) => {
-                if let Some(warning) = result.warning {
-                    warnings.push(warning);
-                }
-                (true, Some(result.removed_path))
-            }
-            Err(error) => {
-                warnings.push(partial_success_warning("cleanup", "removed", &error));
-                (false, None)
-            }
-        }
-    };
-
-    // Push the selected destination branch to origin if requested. The
-    // destination may have changed while cleanup ran, so verify it again
-    // before allowing a remote mutation.
-    let pushed = if push {
-        match validate_preflight_destination(repo, &preflight, "destination") {
-            Ok(_) => match git::push(&destination_path, &destination_branch) {
-                Ok(()) => true,
-                Err(error) => {
-                    warnings.push(format!("merge succeeded but push failed: {error}"));
-                    false
-                }
-            },
-            Err(error) => {
-                warnings.push(partial_success_warning(
-                    "destination push",
-                    "pushed",
-                    &error,
-                ));
-                false
-            }
-        }
-    } else {
-        false
-    };
-
-    Ok(MergeResult {
-        branch: target_branch,
-        mainline: destination_branch,
-        destination_path,
-        repo_root: repo.to_path_buf(),
-        cleaned_up,
-        removed_path,
-        pushed,
+    let mut warnings = Vec::new();
+    let removed_path = finish_committed_operation(repo, &mut operation, &mut warnings);
+    Ok(merge_result_from_operation(
+        repo,
+        &operation,
         preflight,
+        removed_path,
         warnings,
-    })
+    ))
 }
 
 #[cfg(test)]

--- a/tests/bindings/bash_test.bash
+++ b/tests/bindings/bash_test.bash
@@ -224,10 +224,10 @@ echo "$status_json" | grep -q '"state":"conflicted"' \
     || fail "wt merge --status: missing conflicted state"
 printf 'resolved\n' > binding-conflict.txt
 git add binding-conflict.txt
-continue_json=$(wt merge --continue --json)
-echo "$continue_json" | grep -q '"cleaned_up":true' \
-    && pass "wt merge --continue: completes and cleans up" \
-    || fail "wt merge --continue: missing cleanup result"
+continue_human=$(wt merge --continue)
+echo "$continue_human" | grep -q "Merged 'matrix-conflict' into " \
+    && pass "wt merge --continue: human lifecycle path completes" \
+    || fail "wt merge --continue: human lifecycle path failed"
 [[ ! -e "$conflict_source" ]] \
     && pass "wt merge --continue: source worktree removed" \
     || fail "wt merge --continue: source worktree remains"

--- a/tests/bindings/bash_test.bash
+++ b/tests/bindings/bash_test.bash
@@ -200,6 +200,38 @@ echo "$json_merge" | grep -q '"cleaned_up":true' \
     && pass "matrix merge --json: cwd reset to repository root" \
     || fail "matrix merge --json: cwd was not reset"
 
+# ── resumable merge lifecycle ───────────────────────────────────────
+cd "$MATRIX_ROOT"
+wt add matrix-conflict >/dev/null 2>&1
+conflict_source="$PWD"
+printf 'source\n' > binding-conflict.txt
+git add binding-conflict.txt
+git commit -m "source conflict" >/dev/null 2>&1
+cd "$MATRIX_ROOT"
+printf 'destination\n' > binding-conflict.txt
+git add binding-conflict.txt
+git commit -m "destination conflict" >/dev/null 2>&1
+set +e
+wt merge matrix-conflict >"$WORK/bash-conflict.out" 2>&1
+conflict_rc=$?
+set -e
+[[ $conflict_rc -ne 0 ]] \
+    && pass "wt merge: conflict remains resumable" \
+    || fail "wt merge: conflict unexpectedly succeeded"
+status_json=$(wt merge --status --json)
+echo "$status_json" | grep -q '"state":"conflicted"' \
+    && pass "wt merge --status: reports conflicted operation" \
+    || fail "wt merge --status: missing conflicted state"
+printf 'resolved\n' > binding-conflict.txt
+git add binding-conflict.txt
+continue_json=$(wt merge --continue --json)
+echo "$continue_json" | grep -q '"cleaned_up":true' \
+    && pass "wt merge --continue: completes and cleans up" \
+    || fail "wt merge --continue: missing cleanup result"
+[[ ! -e "$conflict_source" ]] \
+    && pass "wt merge --continue: source worktree removed" \
+    || fail "wt merge --continue: source worktree remains"
+
 cd /tmp
 
 echo "All bash binding tests passed."

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -1,6 +1,8 @@
 mod fixtures;
 
 use std::process::Command as StdCommand;
+#[cfg(unix)]
+use std::process::Stdio;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -518,6 +520,182 @@ fn merge_state_and_directory_are_private() {
         .assert()
         .failure()
         .stdout(predicate::str::contains("insecure permissions"));
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_lifecycle_lock_blocks_hook_race_but_allows_read_only_status() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    wt_core()
+        .args(["add", "feature/paused", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-paused");
+    commit_file(&source, "paused.txt", "paused", "paused source");
+    wt_core()
+        .args(["add", "feature/new", "--repo", &repo_str])
+        .assert()
+        .success();
+    let new_source = find_worktree_dir(&repo.path(), "feature-new");
+    commit_file(&new_source, "new.txt", "new", "new source");
+
+    let entered = repo.path().join("post-merge-entered");
+    let release = repo.path().join("post-merge-release");
+    install_hook(
+        &repo,
+        "post-merge",
+        &format!(
+            "#!/bin/sh\nset -eu\nprintf entered > {}\nwhile [ ! -f {} ]; do sleep 0.05; done\n",
+            shell_quote(&entered.display().to_string()),
+            shell_quote(&release.display().to_string()),
+        ),
+    );
+
+    let mut original = StdCommand::new(assert_cmd::cargo_bin!("wt-core"));
+    original
+        .args(["merge", "feature/paused", "--repo", &repo_str])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let original = original.spawn().expect("paused merge should start");
+    wait_for_file(&entered);
+
+    let status = wt_core()
+        .args(["merge", "--status", "--json", "--repo", &repo_str])
+        .output()
+        .expect("status should run while the hook owns the lifecycle");
+    assert!(
+        status.status.success(),
+        "status should remain read-only: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    let continue_output = wt_core()
+        .args(["merge", "--continue", "--repo", &repo_str])
+        .output()
+        .expect("continue should run");
+    assert!(!continue_output.status.success());
+    assert!(String::from_utf8_lossy(&continue_output.stderr).contains("busy"));
+    assert!(String::from_utf8_lossy(&continue_output.stderr).contains("--status"));
+
+    let abort_output = wt_core()
+        .args(["merge", "--abort", "--repo", &repo_str])
+        .output()
+        .expect("abort should run");
+    assert!(!abort_output.status.success());
+    assert!(String::from_utf8_lossy(&abort_output.stderr).contains("busy"));
+
+    let new_merge_output = wt_core()
+        .args(["merge", "feature/new", "--repo", &repo_str])
+        .output()
+        .expect("new merge should run");
+    assert!(!new_merge_output.status.success());
+    assert!(String::from_utf8_lossy(&new_merge_output.stderr).contains("busy"));
+
+    std::fs::write(&release, "release\n").expect("release paused hook");
+    let output = original
+        .wait_with_output()
+        .expect("original merge should finish after hook release");
+    assert!(
+        output.status.success(),
+        "original merge failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .exists());
+    assert!(!git_path(&repo.path(), "MERGE_HEAD").exists());
+    assert!(!source.exists());
+    assert!(new_source.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_lifecycle_lock_recovers_after_owner_death_without_stale_finalization() {
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    wt_core()
+        .args(["add", "feature/death", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-death");
+    commit_file(&source, "death.txt", "death", "death source");
+
+    let entered = repo.path().join("post-merge-death-entered");
+    let release = repo.path().join("post-merge-death-release");
+    install_hook(
+        &repo,
+        "post-merge",
+        &format!(
+            "#!/bin/sh\nset -eu\nprintf entered > {}\nwhile [ ! -f {} ]; do sleep 0.05; done\n",
+            shell_quote(&entered.display().to_string()),
+            shell_quote(&release.display().to_string()),
+        ),
+    );
+
+    let mut original = StdCommand::new(assert_cmd::cargo_bin!("wt-core"));
+    original
+        .args(["merge", "feature/death", "--repo", &repo_str])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut original = original.spawn().expect("merge should start");
+    wait_for_file(&entered);
+    original.kill().expect("owner should be terminable");
+
+    // Git and its hook retain the inherited lifecycle lock after the owner
+    // dies. Releasing the hook first must not let continuation race Git's
+    // finalization; it may only recover after the child has exited.
+    let busy = wt_core()
+        .args(["merge", "--continue", "--repo", &repo_str])
+        .output()
+        .expect("continuation should run");
+    assert!(!busy.status.success());
+    assert!(String::from_utf8_lossy(&busy.stderr).contains("busy"));
+
+    std::fs::write(&release, "release\n").expect("release orphaned hook");
+    let _ = original.wait_with_output();
+
+    let mut recovered = None;
+    for _ in 0..100 {
+        let output = wt_core()
+            .args(["merge", "--continue", "--repo", &repo_str])
+            .output()
+            .expect("recovery continuation should run");
+        if output.status.success() {
+            recovered = Some(output);
+            break;
+        }
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("busy"),
+            "unexpected recovery failure: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        sleep(Duration::from_millis(20));
+    }
+    assert!(recovered.is_some(), "lifecycle lock did not recover");
+    assert!(!repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .exists());
+    assert!(!source.exists());
+}
+
+#[cfg(unix)]
+fn wait_for_file(path: &std::path::Path) {
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    for _ in 0..200 {
+        if path.is_file() {
+            return;
+        }
+        sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for {}", path.display());
 }
 
 #[cfg(unix)]

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -301,6 +301,227 @@ fn merge_continue_keeps_source_when_original_merge_skipped_cleanup() {
 
 #[cfg(unix)]
 #[test]
+fn merge_continue_reconciles_commit_after_state_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    create_conflicted_merge(&repo, "feature/state-write-commit");
+    std::fs::write(repo.path().join("shared.txt"), "resolved\n").expect("resolve conflict");
+    run_git(&["add", "shared.txt"], &repo.path());
+
+    let state_dir = repo.path().join(".git/wt-core");
+    std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o500))
+        .expect("make journal unwritable");
+    wt_core()
+        .args(["merge", "--continue", "--json", "--repo", &repo_str])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("\"state\":\"committed\""));
+    std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700))
+        .expect("restore journal permissions");
+
+    let status = wt_core()
+        .args(["merge", "--status", "--json", "--repo", &repo_str])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let status_json: serde_json::Value = serde_json::from_slice(&status).expect("status JSON");
+    assert_eq!(status_json["state"], "committed");
+    assert_eq!(status_json["worktree_removed"], false);
+
+    wt_core()
+        .args(["merge", "--continue", "--repo", &repo_str])
+        .assert()
+        .success();
+    assert_branch_deleted(&repo.path(), "feature/state-write-commit");
+    assert!(!repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_continue_reconciles_push_after_progress_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (repo, upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+    create_conflicted_merge_at(&repo.path(), "feature/push-state-write", false, true);
+    std::fs::write(repo.path().join("shared.txt"), "resolved\n").expect("resolve conflict");
+    run_git(&["add", "shared.txt"], &repo.path());
+
+    let state_dir = repo.path().join(".git/wt-core");
+    install_hook(
+        &repo,
+        "pre-push",
+        &format!(
+            "#!/bin/sh\nchmod 0500 {}\n",
+            shell_quote(&state_dir.display().to_string())
+        ),
+    );
+    let output = wt_core()
+        .args(["merge", "--continue", "--json", "--repo", &repo_str])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("merge JSON");
+    assert_eq!(json["pushed"], true);
+    assert_eq!(json["operation"]["push_done"], true);
+    assert!(git_log_oneline(upstream.path(), "main")
+        .contains("Merge branch 'feature/push-state-write'"));
+
+    std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700))
+        .expect("restore journal permissions");
+    std::fs::remove_file(repo.path().join(".git/hooks/pre-push")).expect("remove hook");
+    wt_core()
+        .args(["merge", "--continue", "--repo", &repo_str])
+        .assert()
+        .success();
+    assert!(!repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_source_head_race_preserves_source_and_followup_intent() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    wt_core()
+        .args(["add", "feature/source-head-race", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-source-head-race");
+    commit_file(&source, "source.txt", "source", "source");
+    let source_str = source.display().to_string();
+    install_hook(
+        &repo,
+        "post-merge",
+        &format!(
+            "#!/bin/sh\nunset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX\nprintf race > {}/race.txt\ngit -C {} add race.txt\ngit -C {} commit -m race\n",
+            shell_quote(&source_str),
+            shell_quote(&source_str),
+            shell_quote(&source_str)
+        ),
+    );
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/source-head-race",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("merge JSON");
+    assert_eq!(json["cleaned_up"], false);
+    assert!(json["operation"]["state"] == "stale");
+    assert!(
+        source.exists(),
+        "source HEAD race must preserve the source worktree"
+    );
+    assert_branch_exists(&repo.path(), "feature/source-head-race");
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_destination_head_race_refuses_cleanup_and_push() {
+    let (repo, _upstream) = setup_repo_with_upstream();
+    let repo_str = repo.path().display().to_string();
+    wt_core()
+        .args(["add", "feature/destination-head-race", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-destination-head-race");
+    commit_file(&source, "destination-race.txt", "race", "race");
+    install_hook(
+        &repo,
+        "post-merge",
+        "#!/bin/sh\nunset GIT_EDITOR\ngit commit --allow-empty -m destination-race\n",
+    );
+
+    let output = wt_core()
+        .args([
+            "merge",
+            "feature/destination-head-race",
+            "--push",
+            "--json",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("merge JSON");
+    assert_eq!(json["cleaned_up"], false);
+    assert_eq!(json["pushed"], false);
+    assert!(
+        source.exists(),
+        "destination HEAD race must preserve cleanup intent"
+    );
+    assert_branch_exists(&repo.path(), "feature/destination-head-race");
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_state_and_directory_are_private() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let repo = fixtures::TestRepo::new();
+    create_conflicted_merge(&repo, "feature/private-state");
+    let state_dir = repo.path().join(".git/wt-core");
+    let state = state_dir.join("merge-operation.json");
+    assert_eq!(
+        std::fs::metadata(&state_dir)
+            .expect("state dir")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+    assert_eq!(
+        std::fs::metadata(&state)
+            .expect("state")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+
+    let mut insecure = std::fs::metadata(&state)
+        .expect("state metadata")
+        .permissions();
+    insecure.set_mode(0o644);
+    std::fs::set_permissions(&state, insecure).expect("make state insecure");
+    wt_core()
+        .args([
+            "merge",
+            "--status",
+            "--json",
+            "--repo",
+            &repo.path().display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("insecure permissions"));
+}
+
+#[cfg(unix)]
+#[test]
 fn merge_continue_hook_failure_preserves_merge_for_retry() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -97,7 +97,7 @@ fn merge_no_cleanup_keeps_worktree_and_branch() {
 // ── Conflict tests ──────────────────────────────────────────────────
 
 #[test]
-fn merge_conflict_aborts_and_leaves_everything_untouched() {
+fn merge_conflict_preserves_destination_and_managed_state() {
     let repo = fixtures::TestRepo::new();
     let repo_str = repo.path().display().to_string();
 
@@ -111,30 +111,340 @@ fn merge_conflict_aborts_and_leaves_everything_untouched() {
     commit_file(&wt_dir, "shared.txt", "feature version", "feature change");
     commit_file(&repo.path(), "shared.txt", "main version", "main change");
 
-    // Merge should fail with conflict details from git.
+    // Merge should fail with conflict details but preserve Git's merge state.
     wt_core()
         .args(["merge", "feature/conflict", "--repo", &repo_str])
         .assert()
         .failure()
         .stderr(predicate::str::contains("merge conflicts"))
-        .stderr(predicate::str::contains("merge aborted"));
+        .stderr(predicate::str::contains("wt merge --continue"))
+        .stderr(predicate::str::contains("merge aborted").not());
 
-    // Worktree should still exist
+    // Worktree and branch remain available for the eventual continuation.
     let wt_dir = find_worktree_dir(&repo.path(), "feature-conflict");
     assert!(
         wt_dir.exists(),
         "worktree should still exist after conflict"
     );
-
-    // Branch should still exist
     assert_branch_exists(&repo.path(), "feature/conflict");
 
-    // Main worktree should be clean (merge was aborted)
     let status = git_status(&repo.path());
     assert!(
-        status.is_empty(),
-        "main worktree should be clean after abort: {status}"
+        status.contains("AA shared.txt"),
+        "main worktree should preserve the conflict: {status}"
     );
+    assert!(
+        repo.path()
+            .join(".git/wt-core/merge-operation.json")
+            .is_file(),
+        "managed merge state should be durable"
+    );
+}
+
+#[test]
+fn merge_status_and_continue_report_and_finish_conflict() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let source = create_conflicted_merge(&repo, "feature/continue");
+
+    let status = wt_core()
+        .args(["merge", "--status", "--json", "--repo", &repo_str])
+        .output()
+        .expect("status should run");
+    assert!(status.status.success());
+    let status_json: serde_json::Value =
+        serde_json::from_slice(&status.stdout).expect("status JSON");
+    assert_eq!(status_json["ok"], true);
+    assert_eq!(status_json["state"], "conflicted");
+    assert_eq!(
+        status_json["unresolved_paths"],
+        serde_json::json!(["shared.txt"])
+    );
+    assert!(status_json["pending_actions"]
+        .as_array()
+        .is_some_and(|actions| actions.iter().any(|action| action
+            .as_str()
+            .is_some_and(|action| action.contains("resolve")))));
+
+    wt_core()
+        .args(["merge", "--continue", "--repo", &repo_str])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unresolved paths remain"));
+
+    std::fs::write(repo.path().join("shared.txt"), "resolved\n").expect("resolve conflict");
+    run_git(&["add", "shared.txt"], &repo.path());
+    wt_core()
+        .args(["merge", "--continue", "--json", "--repo", &repo_str])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"cleaned_up\":true"))
+        .stdout(predicate::str::contains("Merge branch 'feature/continue'").not());
+
+    assert!(
+        !source.exists(),
+        "continue should apply the original cleanup policy"
+    );
+    assert_branch_deleted(&repo.path(), "feature/continue");
+    assert!(!repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .exists());
+}
+
+#[test]
+fn merge_linked_destination_conflict_continue_preserves_common_state_and_cleanup() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let destination = add_linked_destination(&repo, "release/conflict");
+
+    wt_core()
+        .args(["add", "feature/linked-conflict", "--repo", &repo_str])
+        .assert()
+        .success();
+    let source = find_worktree_dir(&repo.path(), "feature-linked-conflict");
+    commit_file(&source, "shared.txt", "source", "source conflict");
+    commit_file(
+        &destination,
+        "shared.txt",
+        "destination",
+        "destination conflict",
+    );
+
+    wt_core()
+        .args([
+            "merge",
+            "feature/linked-conflict",
+            "--into",
+            "release/conflict",
+            "--repo",
+            &repo_str,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("wt merge --continue"));
+    let status_path = repo.path().join(".git/wt-core/merge-operation.json");
+    assert!(
+        status_path.is_file(),
+        "linked merge state should use common Git dir"
+    );
+
+    std::fs::write(destination.join("shared.txt"), "resolved\n").expect("resolve linked conflict");
+    run_git(&["add", "shared.txt"], &destination);
+    wt_core()
+        .args(["merge", "--continue", "--json", "--repo", &repo_str])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "\"mainline\":\"release/conflict\"",
+        ))
+        .stdout(predicate::str::contains("\"cleaned_up\":true"));
+
+    assert!(
+        !source.exists(),
+        "linked destination continuation cleans source"
+    );
+    assert_branch_deleted(&repo.path(), "feature/linked-conflict");
+    assert!(!status_path.exists());
+}
+
+#[test]
+fn merge_abort_restores_destination_and_clears_matching_state() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let source = create_conflicted_merge(&repo, "feature/abort");
+    let original_head = git_rev_parse(&repo.path(), "HEAD");
+
+    wt_core()
+        .args(["merge", "--abort", "--json", "--repo", &repo_str])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"state\":\"aborted\""));
+
+    assert_eq!(git_rev_parse(&repo.path(), "HEAD"), original_head);
+    assert!(
+        git_status(&repo.path()).is_empty(),
+        "abort should restore a clean destination"
+    );
+    assert!(
+        source.exists(),
+        "abort must not clean up the source worktree"
+    );
+    assert_branch_exists(&repo.path(), "feature/abort");
+    assert!(!repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .exists());
+}
+
+#[test]
+fn merge_continue_keeps_source_when_original_merge_skipped_cleanup() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let source = create_conflicted_merge_with_options(&repo, "feature/keep-conflict", true);
+    std::fs::write(repo.path().join("shared.txt"), "resolved\n").expect("resolve conflict");
+    run_git(&["add", "shared.txt"], &repo.path());
+
+    wt_core()
+        .args(["merge", "--continue", "--json", "--repo", &repo_str])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"cleaned_up\":false"));
+
+    assert!(source.exists(), "--no-cleanup must survive continuation");
+    assert_branch_exists(&repo.path(), "feature/keep-conflict");
+    assert!(!repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn merge_continue_hook_failure_preserves_merge_for_retry() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    create_conflicted_merge(&repo, "feature/continue-hook");
+    std::fs::write(repo.path().join("shared.txt"), "resolved\n").expect("resolve conflict");
+    run_git(&["add", "shared.txt"], &repo.path());
+    install_hook(
+        &repo,
+        "pre-commit",
+        "#!/bin/sh\necho continue hook failed >&2\nexit 42\n",
+    );
+
+    wt_core()
+        .args(["merge", "--continue", "--repo", &repo_str])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("continuation failed"));
+    assert!(repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .is_file());
+    assert!(git_path(&repo.path(), "MERGE_HEAD").exists());
+
+    std::fs::remove_file(repo.path().join(".git/hooks/pre-commit")).expect("remove hook");
+    wt_core()
+        .args(["merge", "--continue", "--repo", &repo_str])
+        .assert()
+        .success();
+    assert!(!repo
+        .path()
+        .join(".git/wt-core/merge-operation.json")
+        .exists());
+}
+
+#[test]
+fn merge_continue_failed_push_preserves_committed_operation_for_retry() {
+    let remote = fixtures::ClonedTestRepo::new();
+    let repo = remote.path();
+    let repo_str = repo.display().to_string();
+    create_conflicted_merge_at(&repo, "feature/push-retry", false, true);
+    // The helper above needs only the repository fixture API; remove origin to
+    // force the original push intent to fail after the merge commit.
+    run_git(&["remote", "remove", "origin"], &repo);
+
+    std::fs::write(repo.join("shared.txt"), "resolved\n").expect("resolve conflict");
+    run_git(&["add", "shared.txt"], &repo);
+    wt_core()
+        .args(["merge", "--continue", "--json", "--repo", &repo_str])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("push failed"));
+    assert!(repo.join(".git/wt-core/merge-operation.json").is_file());
+
+    let origin = remote.origin_path();
+    let origin_str = origin.display().to_string();
+    run_git(&["remote", "add", "origin", &origin_str], &repo);
+    run_git(&["push", "origin", "main"], &repo);
+    wt_core()
+        .args(["merge", "--continue", "--repo", &repo_str])
+        .assert()
+        .success();
+    assert!(!repo.join(".git/wt-core/merge-operation.json").exists());
+}
+
+#[test]
+fn merge_status_guides_recovery_for_stale_interrupted_and_corrupt_state() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let source = create_conflicted_merge(&repo, "feature/recovery");
+    commit_file(
+        &source,
+        "after-conflict.txt",
+        "changed",
+        "change while paused",
+    );
+
+    let stale = wt_core()
+        .args(["merge", "--status", "--json", "--repo", &repo_str])
+        .output()
+        .expect("status should run");
+    assert!(!stale.status.success());
+    let stale_json: serde_json::Value = serde_json::from_slice(&stale.stdout).expect("stale JSON");
+    assert_eq!(stale_json["state"], "stale");
+    assert!(stale_json["recovery"]
+        .as_str()
+        .is_some_and(|message| message.contains("source branch HEAD changed")));
+    run_git(&["reset", "--hard", "HEAD^"], &source);
+
+    run_git(&["merge", "--abort"], &repo.path());
+
+    let interrupted = wt_core()
+        .args(["merge", "--status", "--json", "--repo", &repo_str])
+        .output()
+        .expect("status should run");
+    assert!(!interrupted.status.success());
+    let interrupted_json: serde_json::Value =
+        serde_json::from_slice(&interrupted.stdout).expect("interrupted JSON");
+    assert_eq!(interrupted_json["state"], "interrupted");
+    assert!(interrupted_json["recovery"]
+        .as_str()
+        .is_some_and(|message| message.contains("Git no longer has the merge")));
+
+    let state_path = repo.path().join(".git/wt-core/merge-operation.json");
+    std::fs::write(&state_path, "{not-json").expect("corrupt state");
+    let corrupt = wt_core()
+        .args(["merge", "--status", "--json", "--repo", &repo_str])
+        .output()
+        .expect("status should run");
+    assert!(!corrupt.status.success());
+    let corrupt_json: serde_json::Value =
+        serde_json::from_slice(&corrupt.stdout).expect("corrupt JSON");
+    assert_eq!(corrupt_json["state"], "corrupt");
+    assert!(corrupt_json["recovery"]
+        .as_str()
+        .is_some_and(|message| message.contains("preserve")));
+}
+
+#[test]
+fn merge_status_rejects_a_changed_recorded_admin_identity() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    create_conflicted_merge(&repo, "feature/identity-status");
+    let state_path = repo.path().join(".git/wt-core/merge-operation.json");
+    let mut state: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&state_path).expect("read state"))
+            .expect("state JSON");
+    state["source_identity"]["Linked"]["admin_dir"] = serde_json::json!("/replacement/admin");
+    std::fs::write(
+        &state_path,
+        serde_json::to_vec_pretty(&state).expect("encode state"),
+    )
+    .expect("write state");
+
+    let output = wt_core()
+        .args(["merge", "--status", "--json", "--repo", &repo_str])
+        .output()
+        .expect("status should run");
+    assert!(!output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("status JSON");
+    assert_eq!(json["state"], "stale");
+    assert!(json["recovery"]
+        .as_str()
+        .is_some_and(|message| message.contains("identity changed")));
+    assert!(git_path(&repo.path(), "MERGE_HEAD").exists());
 }
 
 // ── Dirty worktree tests ────────────────────────────────────────────
@@ -1291,6 +1601,14 @@ fn merge_json_distinguishes_content_conflict_from_topology_refusal() {
     assert_eq!(json["preflight"]["topology"], "no_upstream");
     assert_eq!(json["refusal"]["kind"], "content");
     assert_eq!(json["refusal"]["reason"], "content_conflict");
+    assert_eq!(json["operation"]["state"], "conflicted");
+    assert_eq!(
+        json["operation"]["unresolved_paths"],
+        serde_json::json!(["shared.txt"])
+    );
+    assert!(json["operation"]["state_path"]
+        .as_str()
+        .is_some_and(|path| path.ends_with(".git/wt-core/merge-operation.json")));
     assert_eq!(git_rev_parse(&repo.path(), "HEAD"), destination_before);
     assert!(source.exists(), "content conflict must preserve the source");
 }
@@ -2191,6 +2509,46 @@ fn merge_linked_destination_identity_control_keeps_push_with_non_replacing_hook(
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
+
+fn create_conflicted_merge(repo: &fixtures::TestRepo, branch: &str) -> std::path::PathBuf {
+    create_conflicted_merge_at(&repo.path(), branch, false, false)
+}
+
+fn create_conflicted_merge_with_options(
+    repo: &fixtures::TestRepo,
+    branch: &str,
+    no_cleanup: bool,
+) -> std::path::PathBuf {
+    create_conflicted_merge_at(&repo.path(), branch, no_cleanup, false)
+}
+
+fn create_conflicted_merge_at(
+    repo: &std::path::Path,
+    branch: &str,
+    no_cleanup: bool,
+    push: bool,
+) -> std::path::PathBuf {
+    let repo_str = repo.display().to_string();
+    wt_core()
+        .args(["add", branch, "--repo", &repo_str])
+        .assert()
+        .success();
+    let prefix = branch.replace('/', "-");
+    let source = find_worktree_dir(repo, &prefix);
+    commit_file(&source, "shared.txt", "feature version", "feature change");
+    commit_file(repo, "shared.txt", "main version", "main change");
+
+    let mut merge = wt_core();
+    merge.args(["merge", branch, "--repo", &repo_str]);
+    if no_cleanup {
+        merge.arg("--no-cleanup");
+    }
+    if push {
+        merge.arg("--push");
+    }
+    merge.assert().failure();
+    source
+}
 
 #[cfg(unix)]
 fn install_hook(repo: &fixtures::TestRepo, name: &str, script: &str) {

--- a/tests/cli_merge.rs
+++ b/tests/cli_merge.rs
@@ -13,6 +13,35 @@ fn wt_core() -> Command {
     Command::new(assert_cmd::cargo_bin!("wt-core"))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct FilesystemMetadata {
+    file_type: (bool, bool, bool),
+    len: u64,
+    readonly: bool,
+    modified: Option<std::time::SystemTime>,
+    #[cfg(unix)]
+    mode: u32,
+}
+
+fn filesystem_metadata(path: &std::path::Path) -> Option<FilesystemMetadata> {
+    let metadata = std::fs::symlink_metadata(path).ok()?;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    Some(FilesystemMetadata {
+        file_type: (
+            metadata.file_type().is_file(),
+            metadata.file_type().is_dir(),
+            metadata.file_type().is_symlink(),
+        ),
+        len: metadata.len(),
+        readonly: metadata.permissions().readonly(),
+        modified: metadata.modified().ok(),
+        #[cfg(unix)]
+        mode: metadata.permissions().mode() & 0o7777,
+    })
+}
+
 /// Environment variables cleared for raw git commands in tests.
 const GIT_ENV_OVERRIDES: &[&str] = &[
     "GIT_DIR",
@@ -97,6 +126,38 @@ fn merge_no_cleanup_keeps_worktree_and_branch() {
 }
 
 // ── Conflict tests ──────────────────────────────────────────────────
+
+#[test]
+fn merge_status_does_not_initialize_missing_state_namespace() {
+    let repo = fixtures::TestRepo::new();
+    let repo_str = repo.path().display().to_string();
+    let git_dir = repo.path().join(".git");
+    let state_dir = git_dir.join("wt-core");
+    let state_path = state_dir.join("merge-operation.json");
+    let lock_path = state_dir.join("merge-operation.lock");
+    let paths = [git_dir, state_dir, state_path, lock_path];
+    let before: Vec<_> = paths.iter().map(|path| filesystem_metadata(path)).collect();
+    assert!(
+        before[1].is_none(),
+        "fixture must start without managed state"
+    );
+
+    let output = wt_core()
+        .args(["merge", "--status", "--json", "--repo", &repo_str])
+        .output()
+        .expect("status should run without managed state");
+    assert!(
+        output.status.success(),
+        "status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status: serde_json::Value = serde_json::from_slice(&output.stdout).expect("status JSON");
+    assert_eq!(status["state"], "none");
+    assert_eq!(status["ok"], true);
+
+    let after: Vec<_> = paths.iter().map(|path| filesystem_metadata(path)).collect();
+    assert_eq!(before, after, "status changed managed filesystem metadata");
+}
 
 #[test]
 fn merge_conflict_preserves_destination_and_managed_state() {


### PR DESCRIPTION
## Summary

- implement the durable resumable merge lifecycle for issue #70
- add locking and CAS safeguards for concurrent/resumed operations
- add lifecycle validation and preserve the Windows residual handling path

## Stack

This PR is stacked on dependency PRs #75, #76, #77, #78, and #79. It will be retargeted after those dependency PRs land.

Closes #70
